### PR TITLE
Prevent lexer from reading beyond the end of the buffer

### DIFF
--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -392,6 +392,15 @@ scanagain:
 		hash = 0;
 		s = pLexBuffer;
 		while (yyleng < nLexMaxLeng) {
+			/* XXX: Kludge warning! The dereference of s below
+			 * may go beyond the end of the buffer. We use the
+			 * following test to stop that from happening,
+			 * without really understanding what the rest of
+			 * the code is doing. This may not be the correct
+			 * fix! */
+			if (!*s)
+				break;
+
 			yyleng += 1;
 			hash = ((hash << 1) + (toupper(*s))) % LEXHASHSIZE;
 			s += 1;


### PR DESCRIPTION
Please consider merging this fix for the lexer segfault on OpenBSD. I fully admit that I don't completely understand the code in question, and there is probably a better way to do this, however I think the patch is functionally correct. Please review.

On Linux, valgrind complains about the overflow like this:

  Pass 1...
  ==20054== Invalid read of size 1
  ==20054==    at 0x406CDA: yylex (lexer.c:396)
  ==20054==    by 0x40207C: yyparse (asmy.c:2921)
  ==20054==    by 0x4086AF: main (main.c:351)
  ==20054==  Address 0x503a102 is 0 bytes after a block of size 23,538 alloc'd
  ==20054==    at 0x402994D: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
  ==20054==    by 0x406411: yy_create_buffer (lexer.c:147)
  ==20054==    by 0x404FE3: fstk_RunInclude (fstack.c:243)
  ==20054==    by 0x4025F5: yyparse (asmy.y:744)
  ==20054==    by 0x4086AF: main (main.c:351)
  ==20054==

This is a bit of a crude fix which simply exits the hashing loop when
we reach the end of the string. We should probably do some kind of
length calculation on the buffer instead.

Signed-off-by: Vegard Nossum vegard.nossum@gmail.com
