### PR TITLE
Include getopt.h (fix compilation on GNU/Linux)

### DIFF
--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -6,6 +6,7 @@
  */
 
 #include <math.h>
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/fix/main.c
+++ b/src/fix/main.c
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <getopt.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/link/main.c
+++ b/src/link/main.c
@@ -1,3 +1,4 @@
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Please also consider merging this. You should probably see if it even compiles on OpenBSD; for GNU/Linux at least, we need getopt.h to compile.
