### PR TITLE
Try to import undefined symbols from other objects

### DIFF
--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -364,12 +364,12 @@ sym_GetValue(char *s)
 			}
 			return (getvaluefield(psym));
 		} else {
-			if ((nPass == 1) || (psym->nType & SYMF_IMPORT)) {
-				/* 0x80 seems like a good default value... */
-				return (0x80);
-			} else {
-				yyerror("'%s' not defined", s);
+			if (nPass == 2) {
+				/* Assume undefined symbols are imported from somewhere else */
+				psym->nType |= SYMF_IMPORT;
 			}
+			/* 0x80 seems like a good default value... */
+			return (0x80);
 		}
 	} else {
 		if (nPass == 1) {


### PR DESCRIPTION
For large projects (500k+ lines) that share labels across dozens of objects, it's convenient to include a list of global labels in each one. This list quickly becomes so long that it loses meaning (and noticeably increases compile time).

Instead, any symbol that's not defined is expected to be imported at the linking stage. If the symbol is never defined, an error is thrown as normal. This lets labels remain local to a file by default, and choosing to export a label doesn't require recompiling the entire project.

I can't come up with any reason to require manual imports in the first place.
