### PR TITLE
Compiles on arch linux (PATH_MAX)

### DIFF
--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -19,6 +19,11 @@
 #include "extern/err.h"
 #include "extern/strl.h"
 
+/* to get PATH_MAX */
+#ifdef __linux__
+#include <linux/limits.h>
+#endif
+
 /*
  * RGBAsm - FSTACK.C (FileStack routines)
  *


### PR DESCRIPTION
PATH_MAX is defined in linux/limits.h, at least on arch linux.
