### PR TITLE
link: Suppress cascading errors.

### DIFF
--- a/test/link/cascading-errors-fatal-assert.asm
+++ b/test/link/cascading-errors-fatal-assert.asm
@@ -1,0 +1,2 @@
+	assert FATAL, UnknownSymbol == 42
+	assert WeDontReachHere

--- a/test/link/cascading-errors-fatal-assert.out
+++ b/test/link/cascading-errors-fatal-assert.out
@@ -1,0 +1,3 @@
+error: cascading-errors-fatal-assert.asm(1): Unknown symbol "UnknownSymbol"
+fatal: cascading-errors-fatal-assert.asm(1): couldn't evaluate assertion
+Linking aborted after 2 errors

--- a/test/link/cascading-errors.asm
+++ b/test/link/cascading-errors.asm
@@ -1,0 +1,19 @@
+SECTION "zero", ROM0[$0]
+Zero:
+
+; Pin the section such that a jr to 0 is out of range
+SECTION "test", ROM0[$1000]
+	;; XXX: the fallback value used is the index of the symbol (in the object file?)
+	;; Is this intended?
+	dw Bar
+	dw Foo / Bar
+	dw Foo / Zero
+
+	rst Foo
+
+	jr NonExist
+
+	ldh a, [hNonExist + $200]
+
+	assert Foo == 42
+	assert WARN, Bar == 42

--- a/test/link/cascading-errors.out
+++ b/test/link/cascading-errors.out
@@ -1,0 +1,11 @@
+error: cascading-errors.asm(18): Unknown symbol "Foo"
+error: cascading-errors.asm(19): Unknown symbol "Bar"
+error: cascading-errors.asm(16): Unknown symbol "hNonExist"
+error: cascading-errors.asm(14): Unknown symbol "NonExist"
+error: cascading-errors.asm(12): Unknown symbol "Foo"
+error: cascading-errors.asm(10): Unknown symbol "Foo"
+error: cascading-errors.asm(10): Division by 0
+error: cascading-errors.asm(9): Unknown symbol "Foo"
+error: cascading-errors.asm(9): Unknown symbol "Bar"
+error: cascading-errors.asm(8): Unknown symbol "Bar"
+Linking failed with 10 errors


### PR DESCRIPTION
As discussed on Discord, this PR makes rgblink track whether an error occurred during an evaluation of a value, and suppress any further errors it causes.

Each value on the RPN stack has its own error flag. This allows, for instance, reporting a divide-by-zero error if the left operand is an error, but suppressing it if the right operand is an error - maximizing the usefulness of the set of errors emitted during a single linker run.