### PR TITLE
Enable CMake in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,10 +9,12 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, macos-10.15]
         cc: [gcc, clang]
+        buildsys: [make, cmake]
         include:
           - os: ubuntu-18.04
             cc: gcc
             target: develop
+            cmakevars: -DDEVELOP=ON
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -21,12 +23,18 @@ jobs:
         shell: bash
         run: |
           ./.github/actions/install_deps.sh ${{ matrix.os }}
-      - name: Build
+      - name: Build & install using Make
         run: |
           make ${{ matrix.target }} -j Q= CC=${{ matrix.cc }}
-      - name: Install
-        run: |
           sudo make install -j Q=
+        if: matrix.buildsys == 'make'
+      - name: Build & install using CMake
+        run: |
+          cmake -S . -B build -DCMAKE_VERBOSE_MAKEFILE=ON ${{ matrix.cmakevars }}
+          cmake --build build
+          cp build/src/rgb{asm,link,fix,gfx} .
+          sudo cmake --install build
+        if: matrix.buildsys == 'cmake'
       - name: Package binaries
         run: |
           mkdir bins
@@ -34,7 +42,7 @@ jobs:
       - name: Upload binaries
         uses: actions/upload-artifact@v1
         with:
-          name: rgbds-canary-${{ matrix.os }}-${{ matrix.cc }}
+          name: rgbds-canary-${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.buildsys }}
           path: bins
       - name: Test
         shell: bash


### PR DESCRIPTION
Since #578 has been merged, we can check that we're not breaking the CMake build!

Fixes #574.