### PR TITLE
Fix #588: lexer_CaptureMacroBody can read nested MACRO/ENDM

### DIFF
--- a/include/hashmap.h
+++ b/include/hashmap.h
@@ -34,6 +34,16 @@ typedef struct HashMapEntry *HashMap[HASHMAP_NB_BUCKETS];
 bool hash_AddElement(HashMap map, char const *key, void *element);
 
 /**
+ * Replaces an element with an already-present key in a hashmap.
+ * @warning Inserting a NULL will make `hash_GetElement`'s return ambiguous!
+ * @param map The HashMap to replace the element in
+ * @param key The key with which the element will be stored and retrieved
+ * @param element The element to replace
+ * @return True if the element was found and replaced
+ */
+bool hash_ReplaceElement(HashMap const map, char const *key, void *element);
+
+/**
  * Removes an element from a hashmap.
  * @param map The HashMap to remove the element from
  * @param key The key to search the element with

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -173,6 +173,7 @@ void charmap_Add(char *mapping, uint8_t value)
 			if (currentCharmap->usedNodes == currentCharmap->capacity) {
 				currentCharmap->capacity *= 2;
 				currentCharmap = resizeCharmap(currentCharmap, currentCharmap->capacity);
+				hash_ReplaceElement(charmaps, currentCharmap->name, currentCharmap);
 			}
 
 			/* Switch to and init new node */

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -64,6 +64,22 @@ bool hash_AddElement(HashMap map, char const *key, void *element)
 	return newEntry->next != NULL;
 }
 
+bool hash_ReplaceElement(HashMap const map, char const *key, void *element)
+{
+	HashType hashedKey = hash(key);
+	struct HashMapEntry *ptr = map[(HalfHashType)hashedKey];
+
+	while (ptr) {
+		if (hashedKey >> HALF_HASH_NB_BITS == ptr->hash
+		 && !strcmp(ptr->key, key)) {
+			ptr->content = element;
+			return true;
+		}
+		ptr = ptr->next;
+	}
+	return false;
+}
+
 bool hash_RemoveElement(HashMap map, char const *key)
 {
 	HashType hashedKey = hash(key);


### PR DESCRIPTION
This is probably not 100% ready to be merged; it needs test cases at the very least (edit: and it's commingled with the fix for #586). However, I think the basic approach is ready for review.

It now handles this asm the same way as 0.4.1 and outputs the ROM `11 ff 99 99 ee`:

```
SECTION "test", ROM0[0]
foo: \ ; fooo
 MACRO
 ; blah1: MACRO
 db $11
 ; ENDM
\1: \
 macro
  ; blah2: MACRO
  dw $9999
  ; ENDM
 endm
spam_\1_eggs \
 \ ; comment
 : macro
  ; blah3: macro
  db $ee
  ; endm
 endm
 db $ff
ENDM
 foo bar       ; outputs $11, defines bar and spam_bar_eggs
 bar           ; outputs $99 $99
 spam_bar_eggs ; outputs $ee
```