### PR TITLE
Create specialized symbol finder functions

### DIFF
--- a/include/asm/rpn.h
+++ b/include/asm/rpn.h
@@ -46,7 +46,7 @@ static inline bool rpn_isSymbol(const struct Expression *expr)
 	return expr->isSymbol;
 }
 
-void rpn_Symbol(struct Expression *expr, char *tzSym);
+void rpn_Symbol(struct Expression *expr, char const *tzSym);
 void rpn_Number(struct Expression *expr, uint32_t i);
 void rpn_LOGNOT(struct Expression *expr, const struct Expression *src);
 struct Symbol const *rpn_SymbolOf(struct Expression const *expr);

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -121,7 +121,19 @@ struct Symbol *sym_AddSet(char const *symName, int32_t value);
 uint32_t sym_GetPCValue(void);
 uint32_t sym_GetConstantSymValue(struct Symbol const *sym);
 uint32_t sym_GetConstantValue(char const *s);
-struct Symbol *sym_FindSymbol(char const *symName);
+/*
+ * Find a symbol by exact name, bypassing expansion checks
+ */
+struct Symbol *sym_FindExactSymbol(char const *name);
+/*
+ * Find a symbol by exact name; may not be scoped, produces an error if it is
+ */
+struct Symbol *sym_FindUnscopedSymbol(char const *name);
+/*
+ * Find a symbol, possibly scoped, by name
+ */
+struct Symbol *sym_FindScopedSymbol(char const *name);
+struct Symbol const *sym_GetPC(void);
 struct Symbol *sym_AddMacro(char const *symName, int32_t defLineNo, char *body, size_t size);
 struct Symbol *sym_Ref(char const *symName);
 struct Symbol *sym_AddString(char const *symName, char const *value);

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -317,7 +317,7 @@ void fstk_RunMacro(char const *macroName, struct MacroArgs *args)
 {
 	dbgPrint("Running macro \"%s\"\n", macroName);
 
-	struct Symbol *macro = sym_FindSymbol(macroName);
+	struct Symbol *macro = sym_FindExactSymbol(macroName);
 
 	if (!macro) {
 		error("Macro \"%s\" not defined\n", macroName);

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -1311,7 +1311,7 @@ static char const *readInterpolation(void)
 	}
 	symName[i] = '\0';
 
-	struct Symbol const *sym = sym_FindSymbol(symName);
+	struct Symbol const *sym = sym_FindScopedSymbol(symName);
 
 	if (!sym) {
 		error("Interpolated symbol \"%s\" does not exist\n", symName);
@@ -1691,9 +1691,10 @@ static int yylex_NORMAL(void)
 				if (tokenType != T_ID && tokenType != T_LOCAL_ID)
 					return tokenType;
 
-				if (lexerState->expandStrings) {
+				/* Local symbols cannot be string expansions */
+				if (tokenType == T_ID && lexerState->expandStrings) {
 					/* Attempt string expansion */
-					struct Symbol const *sym = sym_FindSymbol(yylval.tzSym);
+					struct Symbol const *sym = sym_FindExactSymbol(yylval.tzSym);
 
 					if (sym && sym->type == SYM_EQUS) {
 						char const *s = sym_GetStringValue(sym);

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -932,7 +932,7 @@ relocexpr_no_str : scoped_id	{ rpn_Symbol(&$$, $1); }
 		| T_OP_DEF {
 			lexer_ToggleStringExpansion(false);
 		} '(' scoped_id ')' {
-			struct Symbol const *sym = sym_FindSymbol($4);
+			struct Symbol const *sym = sym_FindScopedSymbol($4);
 
 			rpn_Number(&$$, !!sym);
 

--- a/src/asm/section.c
+++ b/src/asm/section.c
@@ -620,7 +620,7 @@ void out_PCRelByte(struct Expression *expr)
 {
 	checkcodesection();
 	reserveSpace(1);
-	struct Symbol const *pc = sym_FindSymbol("@");
+	struct Symbol const *pc = sym_GetPC();
 
 	if (!rpn_IsDiffConstant(expr, pc)) {
 		createPatch(PATCHTYPE_JR, expr);


### PR DESCRIPTION
The old "find symbol with auto scope" function is now three:
- One finds the exact name passed to it, skipping any checks. This is useful e.g. if such checks were already performed.
- One checks that the name is not scoped, and calls the first. This is useful for names that cannot be scoped, such as checking for EQUS. Doing this instead of the third should improve performance somehwat, since this specific case is hit by the lexer each time an identifier is read.
- The last one checks if the name should be expanded (`.loc` → `Glob.loc`), and that the local part is not scoped. This is essentially the old function.