### PR TITLE
PRINTV, PRINTI, and PRINTF emit a trailing newline

### DIFF
--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -795,13 +795,13 @@ popc		: T_POP_POPC	{ charmap_Pop(); }
 printt		: T_POP_PRINTT string	{ printf("%s", $2); }
 ;
 
-printv		: T_POP_PRINTV const	{ printf("$%" PRIX32, $2); }
+printv		: T_POP_PRINTV const	{ printf("$%" PRIX32 "\n", $2); }
 ;
 
-printi		: T_POP_PRINTI const	{ printf("%" PRId32, $2); }
+printi		: T_POP_PRINTI const	{ printf("%" PRId32 "\n", $2); }
 ;
 
-printf		: T_POP_PRINTF const	{ math_Print($2); }
+printf		: T_POP_PRINTF const	{ math_Print($2); putchar('\n'); }
 ;
 
 const_3bit	: const {

--- a/test/asm/bank.asm
+++ b/test/asm/bank.asm
@@ -6,7 +6,6 @@ def_sect: macro
 	ENDC
 
 	PRINTV BANK("\1")
-	PRINTT "\n"
 endm
 
  def_sect ROM0_ok,  ROM0

--- a/test/asm/bank.err
+++ b/test/asm/bank.err
@@ -1,9 +1,9 @@
-ERROR: bank.asm(14) -> bank.asm::def_sect(8):
+ERROR: bank.asm(13) -> bank.asm::def_sect(8):
     Expected constant expression: Section "ROMX_bad"'s bank is not known
-ERROR: bank.asm(16) -> bank.asm::def_sect(8):
+ERROR: bank.asm(15) -> bank.asm::def_sect(8):
     Expected constant expression: Section "VRAM_bad"'s bank is not known
-ERROR: bank.asm(18) -> bank.asm::def_sect(8):
+ERROR: bank.asm(17) -> bank.asm::def_sect(8):
     Expected constant expression: Section "SRAM_bad"'s bank is not known
-ERROR: bank.asm(21) -> bank.asm::def_sect(8):
+ERROR: bank.asm(20) -> bank.asm::def_sect(8):
     Expected constant expression: Section "WRAMX_bad"'s bank is not known
 error: Assembly aborted (4 errors)!

--- a/test/asm/label-diff.asm
+++ b/test/asm/label-diff.asm
@@ -18,9 +18,7 @@ Constant2: ; Same as above
 
 print_diff: MACRO
 	PRINTV (\1) - (\2)
-	PRINTT "\n"
 	PRINTV (\2) - (\1)
-	PRINTT "\n"
 ENDM
 
 POPS ; Ensure we are in neither section

--- a/test/asm/label-macro-arg.asm
+++ b/test/asm/label-macro-arg.asm
@@ -1,9 +1,3 @@
-print: MACRO
-	printv \1
-	printt "\n"
-ENDM
-
-
 m1: MACRO
 x\1
 ENDM
@@ -20,10 +14,10 @@ ENDM
 	m1 x = 7
 	m2 2 = 8
 
-	print x
-	print y
-	print xx
-	print yy
+	printv x
+	printv y
+	printv xx
+	printv yy
 
 
 test_char: MACRO

--- a/test/asm/label-macro-arg.err
+++ b/test/asm/label-macro-arg.err
@@ -1,7 +1,7 @@
-ERROR: label-macro-arg.asm(44) -> label-macro-arg.asm::test_char(31):
+ERROR: label-macro-arg.asm(38) -> label-macro-arg.asm::test_char(25):
     Local label 'sizeof_.something' in main scope
 while expanding symbol "VAR_DEF"
-ERROR: label-macro-arg.asm(44) -> label-macro-arg.asm::test_char(31):
+ERROR: label-macro-arg.asm(38) -> label-macro-arg.asm::test_char(25):
     syntax error
 while expanding symbol "VAR_DEF"
 error: Assembly aborted (2 errors)!

--- a/test/asm/operator-precedence.asm
+++ b/test/asm/operator-precedence.asm
@@ -1,7 +1,2 @@
-print: MACRO
-	printv \1
-	printt "\n"
-ENDM
-
-	print 1 == 1 || 1 == 2
-	print (1 == 1) || (1 == 2)
+	printv 1 == 1 || 1 == 2
+	printv (1 == 1) || (1 == 2)

--- a/test/asm/opt-b.asm
+++ b/test/asm/opt-b.asm
@@ -1,3 +1,2 @@
 OPT b.X
 PRINTV %..X.X.X.
-PRINTT "\n"

--- a/test/asm/opt-g.asm
+++ b/test/asm/opt-g.asm
@@ -1,3 +1,2 @@
 OPT g.x0X
 PRINTV `.x.x0X0X
-PRINTT "\n"

--- a/test/asm/overflow.asm
+++ b/test/asm/overflow.asm
@@ -1,39 +1,34 @@
 SECTION "sec", ROM0
 
-print_x: MACRO
-	printv x
-	printt "\n"
-ENDM
-
 x = 2147483647
 x = x + 1
 	dl 2147483647+1
-	print_x
+	printv x
 
 x = -2147483648
 x = x - 1
 	dl -2147483648-1
-	print_x
+	printv x
 
 x = -2147483648
 x = x * -1
 	dl -2147483648 * -1
-	print_x
+	printv x
 
 x = -2147483648
 x = x / -1
 	dl -2147483648 / -1
-	print_x
+	printv x
 
 x = -2147483648
 x = x % -1
 	dl -2147483648 % -1
-	print_x
+	printv x
 
 x = -1
 x = x << 1
 	dl -1 << 1
-	print_x
+	printv x
 
 x = 4294967295
 x = 4294967296

--- a/test/asm/overflow.err
+++ b/test/asm/overflow.err
@@ -1,8 +1,8 @@
-warning: overflow.asm(24): [-Wdiv]
+warning: overflow.asm(19): [-Wdiv]
     Division of -2147483648 by -1 yields -2147483648
-warning: overflow.asm(25): [-Wdiv]
+warning: overflow.asm(20): [-Wdiv]
     Division of -2147483648 by -1 yields -2147483648
-warning: overflow.asm(39): [-Wlarge-constant]
+warning: overflow.asm(34): [-Wlarge-constant]
     Integer constant is too large
-warning: overflow.asm(42): [-Wlarge-constant]
+warning: overflow.asm(37): [-Wlarge-constant]
     Graphics constant is too long, only 8 first pixels considered

--- a/test/asm/strlen.asm
+++ b/test/asm/strlen.asm
@@ -1,9 +1,4 @@
 SECTION "sec", ROM0
 
-xstrlen: MACRO
-	PRINTV STRLEN(\1)
-	PRINTT "\n"
-ENDM
-
-	xstrlen "ABC"
-	xstrlen "カタカナ"
+	PRINTV STRLEN("ABC")
+	PRINTV STRLEN("カタカナ")

--- a/test/asm/use-label-outside-section.asm
+++ b/test/asm/use-label-outside-section.asm
@@ -1,3 +1,2 @@
 lab:
 	PRINTV lab-lab
-	PRINTT "\n"


### PR DESCRIPTION
Fixes #368