### PR TITLE
Macro arguments within a string literal are read into the string, not expanded

### DIFF
--- a/test/asm/macro-arg-in-string.asm
+++ b/test/asm/macro-arg-in-string.asm
@@ -1,0 +1,19 @@
+print: MACRO
+	PRINTT "\1"
+	PRINTT "\n"
+ENDM
+
+	print John "Danger" Smith
+	print \\A\nB
+	print C\
+D
+	print E\!F ; illegal character escape
+
+
+iprint: MACRO
+	PRINTT "{\1}"
+	PRINTT "\n"
+ENDM
+
+s EQUS "hello"
+	iprint s

--- a/test/asm/macro-arg-in-string.err
+++ b/test/asm/macro-arg-in-string.err
@@ -1,0 +1,3 @@
+ERROR: macro-arg-in-string.asm(10) -> macro-arg-in-string.asm::print(2):
+    Illegal character escape '!'
+error: Assembly aborted (1 errors)!

--- a/test/asm/macro-arg-in-string.out
+++ b/test/asm/macro-arg-in-string.out
@@ -1,0 +1,6 @@
+John "Danger" Smith
+\A
+B
+CD
+E\F
+hello


### PR DESCRIPTION
Fixes #643