### PR TITLE
Support SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include <time.h>
 
 #include "asm/section.h"
 
@@ -140,7 +141,7 @@ struct Symbol *sym_AddMacro(char const *symName, int32_t defLineNo, char *body, 
 struct Symbol *sym_Ref(char const *symName);
 struct Symbol *sym_AddString(char const *symName, char const *value);
 void sym_Purge(char const *symName);
-void sym_Init(void);
+void sym_Init(time_t now);
 
 /* Functions to save and restore the current symbol scope. */
 char const *sym_GetCurrentSymbolScope(void);

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -218,7 +218,7 @@ static char *make_escape(const char *str)
 }
 
 /* Short options */
-static char const *optstring = "b:D:Eg:hi:LM:o:p:r:VvW:w";
+static const char *optstring = "b:D:Eg:hi:LM:o:p:r:VvW:w";
 
 /* Variables for the long-only options */
 static int depType; /* Variants of `-M` */
@@ -282,6 +282,16 @@ int main(int argc, char *argv[])
 	struct sOptions newopt;
 
 	char *tzMainfile;
+
+	time_t now = time(NULL);
+	char *sourceDateEpoch = getenv("SOURCE_DATE_EPOCH");
+
+	/*
+	 * Support SOURCE_DATE_EPOCH for reproducible builds
+	 * https://reproducible-builds.org/docs/source-date-epoch/
+	 */
+	if (sourceDateEpoch)
+		now = (time_t)strtoul(sourceDateEpoch, NULL, 0);
 
 	dependfile = NULL;
 
@@ -481,7 +491,7 @@ int main(int argc, char *argv[])
 
 	nTotalLines = 0;
 	nIFDepth = 0;
-	sym_Init();
+	sym_Init(now);
 	sym_SetExportAll(exportall);
 
 	opt_ParseDefines();

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -1092,6 +1092,12 @@ The following symbols are defined by the assembler:
 .It Ic EQU Ta Dv __RGBDS_MINOR__ Ta Minor version number of RGBDS
 .It Ic EQU Ta Dv __RGBDS_PATCH__ Ta Patch version number of RGBDS
 .El
+.Pp
+The current time values will be taken from the
+.Dv SOURCE_DATE_EPOCH
+environment variable if that is defined as a UNIX timestamp.
+Refer to the spec at
+.Lk https://reproducible-builds.org/docs/source-date-epoch/ .
 .Sh DEFINING DATA
 .Ss Declaring variables in a RAM section
 .Ic DS

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -655,7 +655,7 @@ static inline struct Symbol *createBuiltinSymbol(char const *name)
 /*
  * Initialize the symboltable
  */
-void sym_Init(void)
+void sym_Init(time_t now)
 {
 	PCSymbol = createBuiltinSymbol("@");
 	struct Symbol *_NARGSymbol = createBuiltinSymbol("_NARG");
@@ -676,8 +676,6 @@ void sym_Init(void)
 	sym_AddEqu("__RGBDS_MAJOR__", PACKAGE_VERSION_MAJOR)->isBuiltin = true;
 	sym_AddEqu("__RGBDS_MINOR__", PACKAGE_VERSION_MINOR)->isBuiltin = true;
 	sym_AddEqu("__RGBDS_PATCH__", PACKAGE_VERSION_PATCH)->isBuiltin = true;
-
-	time_t now = time(NULL);
 
 	if (now == (time_t)-1) {
 		warn("Couldn't determine current time");


### PR DESCRIPTION
`rgbasm -T` or `rgbasm --time-now` support both Unix timestamps and ISO 8601 local timestamps.

Fixes #286