### PR TITLE
Concatenate adjacent string literals, like C

### DIFF
--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -255,6 +255,12 @@ characters will be included as-is, without needing to escape them with
 or
 .Ql \[rs]n .
 .Pp
+Adjacent string literals are concatenated together, like in C.
+For instance,
+.Ql \&"poly\&" \&"\&"\&"syllabic\&"\&"\&"
+is the same as
+.Ql \&"polysyllabic\&" .
+.Pp
 A funky feature is
 .Ql {symbol}
 within a string, called

--- a/test/asm/concat-string-literals.asm
+++ b/test/asm/concat-string-literals.asm
@@ -1,0 +1,18 @@
+	println "Hello," /* comment */ " " \
+		"world""!"
+
+two EQUS "\"2\""
+
+	println "4^" two " = 16"
+
+	println """multi-
+line"""" """"con\ ; comment
+cat""" " works"
+
+makeprint: MACRO
+\1 EQUS "println " \2
+ENDM
+	makeprint printfour, {two}"+"{two}
+	printfour
+
+	println "literal" STRCAT("expr") ; error

--- a/test/asm/concat-string-literals.err
+++ b/test/asm/concat-string-literals.err
@@ -1,0 +1,3 @@
+ERROR: concat-string-literals.asm(17):
+    syntax error
+error: Assembly aborted (1 errors)!

--- a/test/asm/concat-string-literals.out
+++ b/test/asm/concat-string-literals.out
@@ -1,0 +1,5 @@
+Hello, world!
+4^2 = 16
+multi-
+line concat works
+$4


### PR DESCRIPTION
`STRCAT` does exist already, but there are times when you want to concatenate literal strings, not just any string expressions, and this is a simple and terse way to do that.

Note that the multi-line string in the test case breaks the counted line number for error messages; this is addressed in a bugfix commit in #685.