### PR TITLE
Consistently refer to "directives", not "pseudo-ops"

### DIFF
--- a/include/asm/warning.h
+++ b/include/asm/warning.h
@@ -18,7 +18,7 @@ enum WarningID {
 	WARNING_BUILTIN_ARG,	      /* Invalid args to builtins */
 	WARNING_CHARMAP_REDEF,        /* Charmap entry re-definition */
 	WARNING_DIV,		      /* Division undefined behavior */
-	WARNING_EMPTY_DATA_DIRECTIVE, /* `db`, `dw` or `dl` with no directive in ROM */
+	WARNING_EMPTY_DATA_DIRECTIVE, /* `db`, `dw` or `dl` directive without data in ROM */
 	WARNING_EMPTY_ENTRY,	      /* Empty entry in `db`, `dw` or `dl` */
 	WARNING_EMPTY_STRRPL,	      /* Empty second argument in `STRRPL` */
 	WARNING_LARGE_CONSTANT,	      /* Constants too large */

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -508,7 +508,7 @@ void yyerror(char const *str)
 %type	<forArgs> for_args
 
 %token	T_Z80_ADC "adc" T_Z80_ADD "add" T_Z80_AND "and"
-%token	T_Z80_BIT "bit"
+%token	T_Z80_BIT "bit" // There is no T_Z80_SET, only T_POP_SET
 %token	T_Z80_CALL "call" T_Z80_CCF "ccf" T_Z80_CP "cp" T_Z80_CPL "cpl"
 %token	T_Z80_DAA "daa" T_Z80_DEC "dec" T_Z80_DI "di"
 %token	T_Z80_EI "ei"
@@ -537,7 +537,7 @@ void yyerror(char const *str)
 %token	T_MODE_AF "af" T_MODE_BC "bc" T_MODE_DE "de" T_MODE_SP "sp"
 %token	T_MODE_HW_C "$ff00+c"
 %token	T_MODE_HL "hl" T_MODE_HL_DEC "hld/hl-" T_MODE_HL_INC "hli/hl+"
-%token	T_CC_NZ "nz" T_CC_Z "z" T_CC_NC "nc"
+%token	T_CC_NZ "nz" T_CC_Z "z" T_CC_NC "nc" // There is no T_CC_C, only T_TOKEN_C
 
 %type	<nConstValue>	reg_r
 %type	<nConstValue>	reg_ss
@@ -568,18 +568,18 @@ lines		: /* empty */
 line		: label T_NEWLINE
 		| label cpu_command T_NEWLINE
 		| label macro T_NEWLINE
-		| label simple_pseudoop T_NEWLINE
-		| assignment_pseudoop T_NEWLINE
-		| entire_line /* Commands that manage newlines themselves */
+		| label directive T_NEWLINE
+		| assignment_directive T_NEWLINE
+		| line_directive /* Directives that manage newlines themselves */
 ;
 
 /*
- * For "logistical" reasons, these commands must manage newlines themselves.
+ * For "logistical" reasons, these directives must manage newlines themselves.
  * This is because we need to switch the lexer's mode *after* the newline has been read,
  * and to avoid causing some grammar conflicts (token reducing is finicky).
  * This is DEFINITELY one of the more FRAGILE parts of the codebase, handle with care.
  */
-entire_line	: macrodef
+line_directive	: macrodef
 		| rept
 		| for
 		| break
@@ -677,7 +677,7 @@ macroargs	: /* empty */ {
 ;
 
 /* These commands start with a T_LABEL. */
-assignment_pseudoop	: equ
+assignment_directive	: equ
 		| set
 		| rb
 		| rw
@@ -685,7 +685,7 @@ assignment_pseudoop	: equ
 		| equs
 ;
 
-simple_pseudoop : include
+directive	: include
 		| print
 		| println
 		| printf

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -29,7 +29,7 @@ but any program that processes RGB object files (described in
 .Xr rgbds 5 )
 can be used in its place.
 .Sh SYNTAX
-The syntax is line‐based, just as in any other assembler, meaning that you do one instruction or pseudo‐op per line:
+The syntax is line‐based, just as in any other assembler, meaning that you do one instruction or directive per line:
 .Pp
 .Dl Oo Ar label Oc Oo Ar instruction Oc Oo Ar ;\ comment Oc
 .Pp
@@ -38,7 +38,7 @@ Example:
 John: ld a,87 ;Weee
 .Ed
 .Pp
-All reserved keywords (pseudo‐ops, mnemonics, registers, etc.) are case‐insensitive;
+All reserved keywords (directives, mnemonics, registers, etc.) are case‐insensitive;
 all identifiers (symbol names) are case-sensitive.
 .Pp
 Comments are used to give humans information about the code, such as explanations.

--- a/src/asm/util.c
+++ b/src/asm/util.c
@@ -16,7 +16,9 @@
 #include "extern/utf8decoder.h"
 
 /*
- * Calculate the hash value for a string
+ * Calculate the hash value for a string.
+ * Uses the djb2 algorithm (xor version).
+ * http://www.cse.yorku.ca/~oz/hash.html
  */
 uint32_t calchash(const char *s)
 {


### PR DESCRIPTION
Some docs and warnings already referred to SECTION and db/dw/dl "directives", but others used "pseudo-ops".

(This would let "pseudo-op" refer to "user-defined macro that outputs CPU operations".)