### PR TITLE
Update rgbds(5) object file format documentation

### DIFF
--- a/src/rgbds.5
+++ b/src/rgbds.5
@@ -41,7 +41,7 @@ LONG    NumberOfSections ; The number of sections used in this file.
 LONG    NumberOfNodes       ; The number of nodes contained in this file.
 
 REPT NumberOfNodes          ; IMPORTANT NOTE: the nodes are actually written in
-                            ; **reverse** order, meaningthe node with ID 0 is
+                            ; **reverse** order, meaning the node with ID 0 is
                             ; the last one in the file!
 
     LONG    ParentID        ; ID of the parent node, -1 means this is the root.
@@ -225,6 +225,7 @@ with some bytes being special prefixes for integers and symbols.
 .It Li $03 Ta Li / operator
 .It Li $04 Ta Li % operator
 .It Li $05 Ta Li unary -
+.It Li $06 Ta Li ** operator
 .It Li $10 Ta Li | operator
 .It Li $11 Ta Li & operator
 .It Li $12 Ta Li ^ operator


### PR DESCRIPTION
This documents the `RPN_EXP` value $06 for the `**` operator.

It does not document the recent `PATCH_ISOPERAND` mask 0x80 for `PatchType` because #738 reverts that.

Note that the current object file revision number (7) is not mentioned anywhere; should it be?