### PR TITLE
Add FUNDING.yml to show the Sponsor button on the repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: avivace
+patreon: gbdev01
+open_collective: gbdev


### PR DESCRIPTION
This PR adds the gbdev FUNDING.yml template to show the "Sponsor" button on the GitHub repository, showing links to our OpenCollective, Patreon and GitHub sponsor page.

Little disclaimer on why there is my personal GitHub sponsor username: I'm the only one with an active "sponsor-able" account and I have specified [here](https://github.com/sponsors/avivace) how and why I'm taking donations there on behalf of the gbdev organisation. Also, donations are currently doubled there.