### PR TITLE
Put all local symbols in object/sym/map files

### DIFF
--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -469,10 +469,10 @@ static void writeFileStackNode(struct FileStackNode const *node, FILE *f)
 	}
 }
 
-static void registerExportedSymbol(struct Symbol *symbol, void *arg)
+static void registerUnregisteredSymbol(struct Symbol *symbol, void *arg)
 {
 	(void)arg;
-	if (sym_IsExported(symbol) && symbol->ID == -1) {
+	if (symbol->src && symbol->ID == -1) {
 		registerSymbol(symbol);
 	}
 }
@@ -491,8 +491,8 @@ void out_WriteObject(void)
 	if (!f)
 		err(1, "Couldn't write file '%s'", tzObjectname);
 
-	/* Also write exported symbols that weren't written above */
-	sym_ForEach(registerExportedSymbol, NULL);
+	/* Also write symbols that weren't written above */
+	sym_ForEach(registerUnregisteredSymbol, NULL);
 
 	fprintf(f, RGBDS_OBJECT_VERSION_STRING, RGBDS_OBJECT_VERSION_NUMBER);
 	putlong(RGBDS_OBJECT_REV, f);

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -471,7 +471,9 @@ static void writeFileStackNode(struct FileStackNode const *node, FILE *f)
 
 static void registerUnregisteredSymbol(struct Symbol *symbol, void *arg)
 {
-	(void)arg;
+	(void)arg; // sym_ForEach requires a void* parameter, but we are not using it.
+
+	// Check for symbol->src, to skip any auto generated symbol from rgbasm
 	if (symbol->src && symbol->ID == -1) {
 		registerSymbol(symbol);
 	}


### PR DESCRIPTION
Store all the local symbols in object files, not only the ones that need linker patches. This generates better map/sym files, and thus allows for better debugging as well.

(I hoped this was a small step towards solving an issue for smart linking, but it is actually not, that needs elided patches/references from sections to symbols, which seems a bit more complex)