### PR TITLE
Alignment mask was incorrectly checked for 1 instead of 0

### DIFF
--- a/src/link/section.c
+++ b/src/link/section.c
@@ -248,7 +248,7 @@ static void doSanityChecks(struct Section *section, void *ptr)
 	 * Check if alignment is reasonable, this is important to avoid UB
 	 * An alignment of zero is equivalent to no alignment, basically
 	 */
-	if (section->isAlignFixed && section->alignMask == 1)
+	if (section->isAlignFixed && section->alignMask == 0)
 		section->isAlignFixed = false;
 
 	/* Too large an alignment may not be satisfiable */


### PR DESCRIPTION
This caused an `ALIGN[1]` to be ignored.