### PR TITLE
Do not evaluate an untaken ELIF's condition

### DIFF
--- a/test/asm/elif-after-taken-if.asm
+++ b/test/asm/elif-after-taken-if.asm
@@ -1,0 +1,23 @@
+if 1
+	println "taken if"
+elif 2 / 0 ; avoided fatal "Division by zero" error
+	println "untaken elif"
+elif 3 / 0 ; avoided fatal "Division by zero" error
+	println "untaken after untaken"
+endc
+
+if 0
+	println "untaken if"
+elif 1
+	println "taken elif"
+elif !@#$ ; avoided fatal syntax error
+	println "untaken elif"
+elif %^&* ; avoided fatal syntax error
+	println "untaken after untaken"
+endc
+
+if 0
+	println "untaken if"
+elif 1 / 0 ; fatal "Division by zero" error
+	println "unreached elif"
+endc

--- a/test/asm/elif-after-taken-if.err
+++ b/test/asm/elif-after-taken-if.err
@@ -1,0 +1,2 @@
+FATAL: elif-after-taken-if.asm(21):
+    Division by zero

--- a/test/asm/elif-after-taken-if.out
+++ b/test/asm/elif-after-taken-if.out
@@ -1,0 +1,2 @@
+taken if
+taken elif

--- a/test/asm/skip-elif-condition.asm
+++ b/test/asm/skip-elif-condition.asm
@@ -3,7 +3,7 @@ mac: MACRO
 		println "small \1"
 	elif (\1) > 100
 		println "large \1"
-	elif (\1) / 0 == 42 ; only evaluated if the "large" condition was taken
+	elif (\1) / 0 == 42 ; only evaluated if neither "small" nor "large" was taken
 		println "division by zero!?"
 	elif syntax! error?
 		println "X_X"
@@ -15,3 +15,4 @@ ENDM
 	mac 2 + 2
 	mac STRLEN("abcdef")
 	mac 101
+	mac 23

--- a/test/asm/skip-elif-condition.err
+++ b/test/asm/skip-elif-condition.err
@@ -1,2 +1,2 @@
-FATAL: skip-elif-condition.asm(17) -> skip-elif-condition.asm::mac(6):
+FATAL: skip-elif-condition.asm(18) -> skip-elif-condition.asm::mac(6):
     Division by zero


### PR DESCRIPTION
Fixes #764

How this works: when the lexer reaches an `ELIF` token under the right conditions (first token in the line, right after a taken `IF` or `ELIF` branch) it enters `SKIP_TO_ENDC` mode early, without needing to parse a whole `T_POP_ELIF const T_NEWLINE` sequence. This imitates what `SKIP_TO_ELIF` and `SKIP_TO_ENDC` do already (detecting `IF`/`ELIF`/`ELSE`/`ENDC` tokens starting lines and ignoring whatever's after them), except the `ELIF` has been lexed in normal mode instead of being "fake lexed" by `skipIfBlock`.