### PR TITLE
Allow DEF EQU, EQUS, or SET/= to define multiple variables

### DIFF
--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -567,6 +567,7 @@ enum {
 %token	<symName> T_ANON "anonymous label"
 %type	<symName> def_id
 %type	<symName> redef_id
+%type	<symName> comma_id
 %type	<symName> scoped_id
 %type	<symName> scoped_anon_id
 %token	T_POP_EQU "EQU"
@@ -764,6 +765,14 @@ def_id		: T_OP_DEF {
 ;
 
 redef_id	: T_POP_REDEF {
+			lexer_ToggleStringExpansion(false);
+		} T_ID {
+			lexer_ToggleStringExpansion(true);
+			strcpy($$, $3);
+		}
+;
+
+comma_id	: T_COMMA {
 			lexer_ToggleStringExpansion(false);
 		} T_ID {
 			lexer_ToggleStringExpansion(true);
@@ -1117,6 +1126,12 @@ dl		: T_POP_DL { sect_Skip(4, false); }
 
 def_equ		: def_id T_POP_EQU const {
 			sym_AddEqu($1, $3);
+		} more_equ trailing_comma
+;
+
+more_equ	: %empty
+		| more_equ comma_id T_POP_EQU const {
+			sym_AddEqu($2, $4);
 		}
 ;
 
@@ -1127,9 +1142,15 @@ redef_equ	: redef_id T_POP_EQU const {
 
 def_set		: def_id set_or_equal const {
 			sym_AddSet($1, $3);
-		}
+		} more_set trailing_comma
 		| redef_id set_or_equal const {
 			sym_AddSet($1, $3);
+		} more_set trailing_comma
+;
+
+more_set	: %empty
+		| more_set comma_id set_or_equal const {
+			sym_AddSet($2, $4);
 		}
 ;
 
@@ -1153,11 +1174,23 @@ def_rl		: def_id T_Z80_RL rs_uconst {
 
 def_equs	: def_id T_POP_EQUS string {
 			sym_AddString($1, $3);
+		} more_equs trailing_comma
+;
+
+more_equs	: %empty
+		| more_equs comma_id T_POP_EQUS string {
+			sym_AddString($2, $4);
 		}
 ;
 
 redef_equs	: redef_id T_POP_EQUS string {
 			sym_RedefString($1, $3);
+		} more_redef_equs trailing_comma
+;
+
+more_redef_equs	: %empty
+		| more_redef_equs comma_id T_POP_EQUS string {
+			sym_RedefString($2, $4);
 		}
 ;
 

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -968,6 +968,14 @@ Note that colons
 .Ql \&:
 following the name are not allowed.
 .Pp
+Multiple
+.Ic EQU
+constants can be defined on the same line;
+the definitions will happen left to right.
+.Bd -literal -offset indent
+def Y equ 0, X equ Y+1, TILE equ X+1, ATTR equ TILE+1
+.Ed
+.Pp
 If you
 .Em really
 need to, the
@@ -1007,6 +1015,16 @@ COUNT = COUNT*2
 Note that colons
 .Ql \&:
 following the name are not allowed.
+.Pp
+Multiple
+.Ic SET
+constants can be defined or redefined on the same line;
+the definitions will happen left to right.
+.Bd -literal -offset indent
+def INDEX set -1, ELEM set -1
+  def w = 0, x = 0, y = 0,
+redef w = 2, x = 10-w, y = w+x,
+.Ed
 .Ss Offset constants
 The RS group of commands is a handy way of defining structure offsets:
 .Bd -literal -offset indent
@@ -1098,6 +1116,15 @@ REDEF s EQUS "{s}world!"
 PRINTLN "{s}\n"
 .Ed
 .Pp
+Multiple
+.Ic EQUS
+strings can be defined or redefined on the same line;
+the definitions will happen left to right.
+.Bd -literal -offset indent
+DEF   NAME EQUS "John", FULLNAME EQUS "{NAME} Smith"
+REDEF NAME EQUS "Jane", FULLNAME EQUS "{NAME} Smith"
+.Ed
+.Pp
 .Sy Important note :
 An
 .Ic EQUS
@@ -1143,6 +1170,7 @@ have any whitespace before it;
 otherwise
 .Nm
 will treat it as a macro invocation.
+The older syntax also does not support multiple definitions on one line.
 Furthermore, without the
 .Ql DEF
 keyword,
@@ -1151,8 +1179,12 @@ This can lead to surprising results:
 .Bd -literal -offset indent
 X EQUS "Y"
 ; this defines Y, not X!
-X EQU 42
+X = 42
 ; prints "Y $2A"
+PRINTLN "{X} {Y}"
+; this also defines Y, since {X} is interpolated
+def {X} = 100
+; prints "Y $64"
 PRINTLN "{X} {Y}"
 .Ed
 .Ss Macros

--- a/test/asm/def-multiple.asm
+++ b/test/asm/def-multiple.asm
@@ -1,0 +1,21 @@
+def w = 1, x = w+1, y = x+1
+	println "{d:w} {d:x} {d:y}"
+def w set y+2, x set w+2, y set x+2,
+	println "{d:w} {d:x} {d:y}"
+redef w = w*2, x = w*2, y = x*2,
+	println "{d:w} {d:x} {d:y}"
+redef w set w-5, x set w-5, y set x-5
+	println "{d:w} {d:x} {d:y}"
+
+DEF spam EQU 6, eggs EQU 7, liff EQU spam*eggs
+	println "{d:spam} x {d:eggs} = {d:liff}"
+
+DEF true EQUS "no", false EQUS "yes", filenotfound EQUS "maybe"
+	println "{true} or {false} (or {filenotfound})"
+REDEF true EQUS "{false}", false EQUS "{true}" ; oops, this isn't Python!
+	println "{true} xor {false}"
+
+def toast EQU 1, spam EQU 2, lobster EQU 3 ; error, 'spam' already defined
+	println "{d:toast}, {d:spam}, {d:lobster}"
+
+def cannot = 10, mix EQU 20, types EQUS "30" ; syntax error

--- a/test/asm/def-multiple.err
+++ b/test/asm/def-multiple.err
@@ -1,0 +1,5 @@
+ERROR: def-multiple.asm(18):
+    'spam' already defined at def-multiple.asm(10)
+ERROR: def-multiple.asm(21):
+    syntax error, unexpected EQU, expecting SET or =
+error: Assembly aborted (2 errors)!

--- a/test/asm/def-multiple.out
+++ b/test/asm/def-multiple.out
@@ -1,0 +1,8 @@
+1 2 3
+5 7 9
+10 20 40
+5 0 -5
+6 x 7 = 42
+no or yes (or maybe)
+yes xor yes
+1, 6, 3

--- a/test/asm/def-multiple.simple.err
+++ b/test/asm/def-multiple.simple.err
@@ -1,0 +1,5 @@
+ERROR: def-multiple.asm(18):
+    'spam' already defined at def-multiple.asm(10)
+ERROR: def-multiple.asm(21):
+    syntax error
+error: Assembly aborted (2 errors)!

--- a/test/asm/def.asm
+++ b/test/asm/def.asm
@@ -20,7 +20,7 @@ def _z rl
 def _size rb 0
 	println "{_x} {_y} {_z} {_size}"
 
-def constant equ 6*7 ; fails
+def constant equ 6*9 ; error, already defined
 	println constant
 
 redef string equs "there"


### PR DESCRIPTION
Fixes #801

This is a basic edit to the parser, with most of the edits being test cases and documentation.