### PR TITLE
Handle errors when opening source file

### DIFF
--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -473,6 +473,11 @@ struct LexerState *lexer_OpenFile(char const *path)
 	state->path = path;
 	state->isFile = true;
 	state->fd = isStdin ? STDIN_FILENO : open(path, O_RDONLY);
+	if (state->fd < 0) {
+		error("Failed to open file \"%s\": %s\n", path, strerror(errno));
+		free(state);
+		return NULL;
+	}
 	state->isMmapped = false; /* By default, assume it won't be mmap()ed */
 	if (!isStdin && fileInfo.st_size > 0) {
 		/* Try using `mmap` for better performance */


### PR DESCRIPTION
Before this commit, opening a file for which the user didn't have
permission resulted in a "Bad file descriptor" error.