### PR TITLE
Define `__RGBDS_VERSION__` as the output of `rgbasm --version` (sans "rgbasm")

### DIFF
--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -1272,6 +1272,7 @@ The following symbols are defined by the assembler:
 .It Dv __RGBDS_MINOR__ Ta Ic EQU Ta Minor version number of RGBDS
 .It Dv __RGBDS_PATCH__ Ta Ic EQU Ta Patch version number of RGBDS
 .It Dv __RGBDS_RC__ Ta Ic EQU Ta Release candidate ID of RGBDS, not defined for final releases
+.It Dv __RGBDS_VERSION__ Ta Ic EQUS Ta Version of RGBDS, as printed by Ql rgbasm --version
 .El
 .Pp
 The current time values will be taken from the

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -774,6 +774,7 @@ void sym_Init(time_t now)
 	addString("__UTC_HOUR__", removeLeadingZeros(savedHOUR));
 	addString("__UTC_MINUTE__", removeLeadingZeros(savedMINUTE));
 	addString("__UTC_SECOND__", removeLeadingZeros(savedSECOND));
+	addString("__RGBDS_VERSION__", get_package_version_string());
 #undef addString
 
 	labelScope = NULL;

--- a/test/asm/test.sh
+++ b/test/asm/test.sh
@@ -38,12 +38,14 @@ tryCmp () {
 
 # Add the version constants test, outputting the closest tag to the HEAD
 if git describe --tags --abbrev=0 > version.out; then
+	$RGBASM --version >> version.out
 	cat > version.asm <<EOF
 IF !DEF(__RGBDS_RC__)
 	PRINTLN "v{d:__RGBDS_MAJOR__}.{d:__RGBDS_MINOR__}.{d:__RGBDS_PATCH__}"
 ELSE
 	PRINTLN "v{d:__RGBDS_MAJOR__}.{d:__RGBDS_MINOR__}.{d:__RGBDS_PATCH__}-rc{d:__RGBDS_RC__}"
 ENDC
+	PRINTLN "rgbasm {__RGBDS_VERSION__}"
 EOF
 else
 	echo "${bold}${orange}Warning: cannot run version test!${rescolors}${resbold}"


### PR DESCRIPTION
Fixes #824