### PR TITLE
New lexer 2½: store expansions from the inside out

### DIFF
--- a/test/asm/nested-expansions.asm
+++ b/test/asm/nested-expansions.asm
@@ -1,0 +1,6 @@
+def foo equs "bar"
+def bar equs "qux"
+MACRO test
+	\1
+ENDM
+	test foo 0

--- a/test/asm/nested-expansions.err
+++ b/test/asm/nested-expansions.err
@@ -1,0 +1,3 @@
+ERROR: nested-expansions.asm(6) -> nested-expansions.asm::test(4):
+    Macro "qux" not defined
+error: Assembly aborted (1 error)!


### PR DESCRIPTION
This shortens the lexer by 100 lines and simplifies access to expansion contents, since it usually needs the deepest one, not the top-level one.

(This eliminates the `lookupExpansion` macro, since all three uses can now be an ordinary `for (struct Expansion *exp = lexerState->expansions; exp; exp = exp->parent)` loop.)

Fixes #813 and resolves a `FIXME` comment in `shiftChar`

Note that this forks off of PR #799; that one is simpler and can be reviewed+merged on its own.

@NieDzejkob I'd really appreciate if you run the fuzzer on this branch to make sure the previous issue is resolved and see if there are any segfaults left.