### PR TITLE
Don't overflow the interpolation buffer when length is exceeded

### DIFF
--- a/src/asm/format.c
+++ b/src/asm/format.c
@@ -148,8 +148,11 @@ void fmt_PrintString(char *buf, size_t bufLen, struct FormatSpec const *fmt, cha
 	size_t len = strlen(value);
 	size_t totalLen = fmt->width > len ? fmt->width : len;
 
-	if (totalLen + 1 > bufLen) /* bufLen includes terminator */
+	if (totalLen + 1 > bufLen) { /* bufLen includes terminator */
 		error("Formatted string value too long\n");
+		buf[0] = '\0';
+		return;
+	}
 
 	size_t padLen = fmt->width > len ? fmt->width - len : 0;
 
@@ -253,8 +256,11 @@ void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uin
 
 	size_t totalLen = fmt->width > numLen ? fmt->width : numLen;
 
-	if (totalLen + 1 > bufLen) /* bufLen includes terminator */
+	if (totalLen + 1 > bufLen) { /* bufLen includes terminator */
 		error("Formatted numeric value too long\n");
+		buf[0] = '\0';
+		return;
+	}
 
 	size_t padLen = fmt->width > numLen ? fmt->width - numLen : 0;
 

--- a/test/asm/long-interpolate-number.asm
+++ b/test/asm/long-interpolate-number.asm
@@ -1,0 +1,4 @@
+; It seems that \1 was the easiest way to notice the memory corruption that
+; resulted from this overflow
+f=0
+{.99999999f:f}\1

--- a/test/asm/long-interpolate-number.err
+++ b/test/asm/long-interpolate-number.err
@@ -1,0 +1,4 @@
+ERROR: long-interpolate-number.asm(4):
+    Formatted numeric value too long
+FATAL: long-interpolate-number.asm(4):
+    Macro argument '\1' not defined


### PR DESCRIPTION
This is sorta-WIP — I couldn't write a test that exercises the string interpolation case due to #830