### PR TITLE
Enable address sanitizer in develop builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ else()
                   -fsanitize=unreachable -fsanitize=vla-bound
                   -fsanitize=signed-integer-overflow -fsanitize=bounds
                   -fsanitize=object-size -fsanitize=bool -fsanitize=enum
-                  -fsanitize=alignment -fsanitize=null)
+                  -fsanitize=alignment -fsanitize=null -fsanitize=address)
     add_compile_options(${SAN_FLAGS})
     link_libraries(${SAN_FLAGS})
   endif()

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ develop:
 		-fsanitize=unreachable -fsanitize=vla-bound \
 		-fsanitize=signed-integer-overflow -fsanitize=bounds \
 		-fsanitize=object-size -fsanitize=bool -fsanitize=enum \
-		-fsanitize=alignment -fsanitize=null" CFLAGS="-ggdb3 -O0"
+		-fsanitize=alignment -fsanitize=null -fsanitize=address" CFLAGS="-ggdb3 -O0"
 
 # Targets for the project maintainer to easily create Windows exes.
 # This is not for Windows users!

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -36,6 +36,12 @@
 #include "helpers.h"
 #include "version.h"
 
+#if defined(__SANITIZE_ADDRESS__) || (defined(__clang__) && __has_feature(address_sanitizer))
+// There are known, non-trivial to fix leaks. We would still like to have `make develop'
+// detect memory corruption, though.
+const char *__asan_default_options(void) { return "detect_leaks=0"; }
+#endif
+
 // Old Bison versions (confirmed for 2.3) do not forward-declare `yyparse` in the generated header
 // Unfortunately, macOS still ships 2.3, which is from 2008...
 int yyparse(void);

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -36,7 +36,13 @@
 #include "helpers.h"
 #include "version.h"
 
-#if defined(__SANITIZE_ADDRESS__) || (defined(__clang__) && __has_feature(address_sanitizer))
+#ifdef __clang__
+#if __has_feature(address_sanitizer) && !defined(__SANITIZE_ADDRESS__)
+#define __SANITIZE_ADDRESS__
+#endif /* __has_feature(address_sanitizer) && !defined(__SANITIZE_ADDRESS__) */
+#endif /* __clang__ */
+
+#ifdef __SANITIZE_ADDRESS__
 // There are known, non-trivial to fix leaks. We would still like to have `make develop'
 // detect memory corruption, though.
 const char *__asan_default_options(void) { return "detect_leaks=0"; }

--- a/src/link/main.c
+++ b/src/link/main.c
@@ -28,6 +28,12 @@
 #include "extern/getopt.h"
 #include "version.h"
 
+#if defined(__SANITIZE_ADDRESS__) || (defined(__clang__) && __has_feature(address_sanitizer))
+// There are known, non-trivial to fix leaks. We would still like to have `make develop'
+// detect memory corruption, though.
+const char *__asan_default_options(void) { return "detect_leaks=0"; }
+#endif
+
 bool isDmgMode;               /* -d */
 char       *linkerScriptName; /* -l */
 char const *mapFileName;      /* -m */

--- a/src/link/main.c
+++ b/src/link/main.c
@@ -28,7 +28,13 @@
 #include "extern/getopt.h"
 #include "version.h"
 
-#if defined(__SANITIZE_ADDRESS__) || (defined(__clang__) && __has_feature(address_sanitizer))
+#ifdef __clang__
+#if __has_feature(address_sanitizer) && !defined(__SANITIZE_ADDRESS__)
+#define __SANITIZE_ADDRESS__
+#endif /* __has_feature(address_sanitizer) && !defined(__SANITIZE_ADDRESS__) */
+#endif /* __clang__ */
+
+#ifdef __SANITIZE_ADDRESS__
 // There are known, non-trivial to fix leaks. We would still like to have `make develop'
 // detect memory corruption, though.
 const char *__asan_default_options(void) { return "detect_leaks=0"; }


### PR DESCRIPTION
WIP, because ASAN detects memory corruption in the test suite. I have minimized the failure
of builtin-overwrite.pipe, the root cause is running a long enough macro while reading from stdin:

```
macro tickle
;AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
;AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
;AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
;AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
;AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
;AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
endm

    tickle
```