### PR TITLE
Add an .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+root = true
+indent_style = tab
+indent_size = tab
+tab_width = 8
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf


### PR DESCRIPTION
This automatically sets up the formatting settings in a number of
editors, regardless of the user's preferences.

Do we want to set a hard `max_line_length`? Is there a standardized limit?