### PR TITLE
Make tests work on NixOS

### DIFF
--- a/test/link/test.sh
+++ b/test/link/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export LC_ALL=C
 set -o pipefail

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Return failure as soon as a command fails to execute
 


### PR DESCRIPTION
Some distributions, such as NixOS and Guix, only have the /bin/sh and
/usr/bin/env binaries in standard locations.