### PR TITLE
Return a marker token at the end of any buffer

### DIFF
--- a/include/asm/lexer.h
+++ b/include/asm/lexer.h
@@ -81,6 +81,7 @@ struct CaptureBody {
 	uint32_t lineNo;
 	char *body;
 	size_t size;
+	bool unterminated;
 };
 
 char const *lexer_GetFileName(void);

--- a/include/asm/lexer.h
+++ b/include/asm/lexer.h
@@ -81,7 +81,6 @@ struct CaptureBody {
 	uint32_t lineNo;
 	char *body;
 	size_t size;
-	bool unterminated;
 };
 
 char const *lexer_GetFileName(void);
@@ -89,8 +88,8 @@ uint32_t lexer_GetLineNo(void);
 uint32_t lexer_GetColNo(void);
 void lexer_DumpStringExpansions(void);
 int yylex(void);
-void lexer_CaptureRept(struct CaptureBody *capture);
-void lexer_CaptureMacroBody(struct CaptureBody *capture);
+bool lexer_CaptureRept(struct CaptureBody *capture);
+bool lexer_CaptureMacroBody(struct CaptureBody *capture);
 
 #define INITIAL_DS_ARG_SIZE 2
 struct DsArgList {

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -2330,9 +2330,8 @@ bool lexer_CaptureRept(struct CaptureBody *capture)
 	capture->lineNo = lexer_GetLineNo();
 
 	char *captureStart = startCapture();
-	bool terminated = false;
 	unsigned int level = 0;
-	int c;
+	int c = EOF;
 
 	/*
 	 * Due to parser internals, it reads the EOL after the expression before calling this.
@@ -2362,7 +2361,6 @@ bool lexer_CaptureRept(struct CaptureBody *capture)
 					 * We know we have read exactly "ENDR", not e.g. an EQUS
 					 */
 					lexerState->captureSize -= strlen("ENDR");
-					terminated = true;
 					goto finish;
 				}
 				level--;
@@ -2390,7 +2388,9 @@ finish:
 	lexerState->disableMacroArgs = false;
 	lexerState->disableInterpolation = false;
 	lexerState->atLineStart = false;
-	return terminated;
+
+	/* Returns true if an ENDR terminated the block, false if it reached EOF first */
+	return c != EOF;
 }
 
 bool lexer_CaptureMacroBody(struct CaptureBody *capture)
@@ -2398,8 +2398,7 @@ bool lexer_CaptureMacroBody(struct CaptureBody *capture)
 	capture->lineNo = lexer_GetLineNo();
 
 	char *captureStart = startCapture();
-	bool terminated = false;
-	int c;
+	int c = EOF;
 
 	/* If the file is `mmap`ed, we need not to unmap it to keep access to the macro */
 	if (lexerState->isMmapped)
@@ -2426,7 +2425,6 @@ bool lexer_CaptureMacroBody(struct CaptureBody *capture)
 				 * We know we have read exactly "ENDM", not e.g. an EQUS
 				 */
 				lexerState->captureSize -= strlen("ENDM");
-				terminated = true;
 				goto finish;
 			}
 		}
@@ -2452,5 +2450,7 @@ finish:
 	lexerState->disableMacroArgs = false;
 	lexerState->disableInterpolation = false;
 	lexerState->atLineStart = false;
-	return terminated;
+
+	/* Returns true if an ENDM terminated the block, false if it reached EOF first */
+	return c != EOF;
 }

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -354,7 +354,6 @@ struct LexerState {
 	uint32_t colNo;
 	int lastToken;
 	int nextToken;
-	bool isAtEOF;
 
 	struct IfStack *ifStack;
 
@@ -379,7 +378,6 @@ static void initState(struct LexerState *state)
 	state->atLineStart = true; /* yylex() will init colNo due to this */
 	state->lastToken = T_EOF;
 	state->nextToken = 0;
-	state->isAtEOF = false;
 
 	state->ifStack = NULL;
 
@@ -571,7 +569,7 @@ void lexer_DeleteState(struct LexerState *state)
 	// that lexer states lifetimes are always properly managed, since they're handled solely
 	// by the fstack... with *one* exception.
 	// Assume a context is pushed on top of the fstack, and the corresponding lexer state gets
-	// scheduled at EOF; `lexerStateAtEOL` thus becomes a (weak) ref to that lexer state...
+	// scheduled at EOF; `lexerStateEOL` thus becomes a (weak) ref to that lexer state...
 	// It has been possible, due to a bug, that the corresponding fstack context gets popped
 	// before EOL, deleting the associated state... but it would still be switched to at EOL.
 	// This assertion checks that this doesn't happen again.
@@ -2269,13 +2267,17 @@ finish:
 
 int yylex(void)
 {
-	if (lexerStateEOL) {
+	if (lexerState->atLineStart && lexerStateEOL) {
 		lexer_SetState(lexerStateEOL);
 		lexerStateEOL = NULL;
 	}
 	/* `lexer_SetState` updates `lexerState`, so check for EOF after it */
-	if (lexerState->isAtEOF)
-		return T_EOF;
+	if (lexerState->lastToken == T_EOB) {
+		if (yywrap()) {
+			dbgPrint("Reached end of input.\n");
+			return T_EOF;
+		}
+	}
 	if (lexerState->atLineStart) {
 		/* Newlines read within an expansion should not increase the line count */
 		if (!lexerState->expansions)
@@ -2292,16 +2294,10 @@ int yylex(void)
 	int token = lexerModeFuncs[lexerState->mode]();
 
 	if (token == T_EOF) {
-		/* Try to switch to new buffer; if it succeeds, scan again */
 		dbgPrint("Reached EOB!\n");
 		/* Captures end at their buffer's boundary no matter what */
-		if (!lexerState->capturing) {
-			if (yywrap()) {
-				dbgPrint("Reached end of input.\n");
-				lexerState->isAtEOF = true;
-			}
+		if (!lexerState->capturing)
 			token = T_EOB;
-		}
 	}
 	lexerState->lastToken = token;
 	lexerState->atLineStart = token == T_NEWLINE || token == T_EOB;

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -2325,12 +2325,12 @@ static char *startCapture(void)
 	}
 }
 
-void lexer_CaptureRept(struct CaptureBody *capture)
+bool lexer_CaptureRept(struct CaptureBody *capture)
 {
-	capture->unterminated = false;
 	capture->lineNo = lexer_GetLineNo();
 
 	char *captureStart = startCapture();
+	bool terminated = false;
 	unsigned int level = 0;
 	int c;
 
@@ -2362,6 +2362,7 @@ void lexer_CaptureRept(struct CaptureBody *capture)
 					 * We know we have read exactly "ENDR", not e.g. an EQUS
 					 */
 					lexerState->captureSize -= strlen("ENDR");
+					terminated = true;
 					goto finish;
 				}
 				level--;
@@ -2372,7 +2373,6 @@ void lexer_CaptureRept(struct CaptureBody *capture)
 		for (;;) {
 			if (c == EOF) {
 				error("Unterminated REPT/FOR block\n");
-				capture->unterminated = true;
 				goto finish;
 			} else if (c == '\n' || c == '\r') {
 				handleCRLF(c);
@@ -2390,14 +2390,15 @@ finish:
 	lexerState->disableMacroArgs = false;
 	lexerState->disableInterpolation = false;
 	lexerState->atLineStart = false;
+	return terminated;
 }
 
-void lexer_CaptureMacroBody(struct CaptureBody *capture)
+bool lexer_CaptureMacroBody(struct CaptureBody *capture)
 {
-	capture->unterminated = false;
 	capture->lineNo = lexer_GetLineNo();
 
 	char *captureStart = startCapture();
+	bool terminated = false;
 	int c;
 
 	/* If the file is `mmap`ed, we need not to unmap it to keep access to the macro */
@@ -2425,6 +2426,7 @@ void lexer_CaptureMacroBody(struct CaptureBody *capture)
 				 * We know we have read exactly "ENDM", not e.g. an EQUS
 				 */
 				lexerState->captureSize -= strlen("ENDM");
+				terminated = true;
 				goto finish;
 			}
 		}
@@ -2433,7 +2435,6 @@ void lexer_CaptureMacroBody(struct CaptureBody *capture)
 		for (;;) {
 			if (c == EOF) {
 				error("Unterminated macro definition\n");
-				capture->unterminated = true;
 				goto finish;
 			} else if (c == '\n' || c == '\r') {
 				handleCRLF(c);
@@ -2451,4 +2452,5 @@ finish:
 	lexerState->disableMacroArgs = false;
 	lexerState->disableInterpolation = false;
 	lexerState->atLineStart = false;
+	return terminated;
 }

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -354,6 +354,7 @@ struct LexerState {
 	uint32_t colNo;
 	int lastToken;
 	int nextToken;
+	bool isAtEOF;
 
 	struct IfStack *ifStack;
 
@@ -378,6 +379,7 @@ static void initState(struct LexerState *state)
 	state->atLineStart = true; /* yylex() will init colNo due to this */
 	state->lastToken = T_EOF;
 	state->nextToken = 0;
+	state->isAtEOF = false;
 
 	state->ifStack = NULL;
 
@@ -2267,11 +2269,13 @@ finish:
 
 int yylex(void)
 {
-restart:
-	if (lexerState->atLineStart && lexerStateEOL) {
+	if (lexerStateEOL) {
 		lexer_SetState(lexerStateEOL);
 		lexerStateEOL = NULL;
 	}
+	/* `lexer_SetState` updates `lexerState`, so check for EOF after it */
+	if (lexerState->isAtEOF)
+		return T_EOF;
 	if (lexerState->atLineStart) {
 		/* Newlines read within an expansion should not increase the line count */
 		if (!lexerState->expansions)
@@ -2288,23 +2292,19 @@ restart:
 	int token = lexerModeFuncs[lexerState->mode]();
 
 	if (token == T_EOF) {
-		if (lexerState->lastToken != T_NEWLINE) {
-			dbgPrint("Forcing EOL at EOF\n");
-			token = T_NEWLINE;
-		} else {
-			/* Try to switch to new buffer; if it succeeds, scan again */
-			dbgPrint("Reached EOF!\n");
-			/* Captures end at their buffer's boundary no matter what */
-			if (!lexerState->capturing) {
-				if (!yywrap())
-					goto restart;
+		/* Try to switch to new buffer; if it succeeds, scan again */
+		dbgPrint("Reached EOB!\n");
+		/* Captures end at their buffer's boundary no matter what */
+		if (!lexerState->capturing) {
+			if (yywrap()) {
 				dbgPrint("Reached end of input.\n");
-				return T_EOF;
+				lexerState->isAtEOF = true;
 			}
+			token = T_EOB;
 		}
 	}
 	lexerState->lastToken = token;
-	lexerState->atLineStart = token == T_NEWLINE;
+	lexerState->atLineStart = token == T_NEWLINE || token == T_EOB;
 
 	return token;
 }
@@ -2327,6 +2327,7 @@ static char *startCapture(void)
 
 void lexer_CaptureRept(struct CaptureBody *capture)
 {
+	capture->unterminated = false;
 	capture->lineNo = lexer_GetLineNo();
 
 	char *captureStart = startCapture();
@@ -2361,7 +2362,6 @@ void lexer_CaptureRept(struct CaptureBody *capture)
 					 * We know we have read exactly "ENDR", not e.g. an EQUS
 					 */
 					lexerState->captureSize -= strlen("ENDR");
-					lexerState->lastToken = T_POP_ENDR; // Force EOL at EOF
 					goto finish;
 				}
 				level--;
@@ -2372,6 +2372,7 @@ void lexer_CaptureRept(struct CaptureBody *capture)
 		for (;;) {
 			if (c == EOF) {
 				error("Unterminated REPT/FOR block\n");
+				capture->unterminated = true;
 				goto finish;
 			} else if (c == '\n' || c == '\r') {
 				handleCRLF(c);
@@ -2393,6 +2394,7 @@ finish:
 
 void lexer_CaptureMacroBody(struct CaptureBody *capture)
 {
+	capture->unterminated = false;
 	capture->lineNo = lexer_GetLineNo();
 
 	char *captureStart = startCapture();
@@ -2423,7 +2425,6 @@ void lexer_CaptureMacroBody(struct CaptureBody *capture)
 				 * We know we have read exactly "ENDM", not e.g. an EQUS
 				 */
 				lexerState->captureSize -= strlen("ENDM");
-				lexerState->lastToken = T_POP_ENDM; // Force EOL at EOF
 				goto finish;
 			}
 		}
@@ -2432,6 +2433,7 @@ void lexer_CaptureMacroBody(struct CaptureBody *capture)
 		for (;;) {
 			if (c == EOF) {
 				error("Unterminated macro definition\n");
+				capture->unterminated = true;
 				goto finish;
 			} else if (c == '\n' || c == '\r') {
 				handleCRLF(c);

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -455,6 +455,7 @@ enum {
 		int32_t step;
 	} forArgs;
 	struct StrFmtArgList strfmtArgs;
+	bool captureTerminated;
 }
 
 %type	<expr>		relocexpr
@@ -979,9 +980,9 @@ load		: T_POP_LOAD sectmod string T_COMMA sectiontype sectorg sectattrs {
 ;
 
 rept		: T_POP_REPT uconst T_NEWLINE {
-			lexer_CaptureRept(&captureBody);
+			$<captureTerminated>$ = lexer_CaptureRept(&captureBody);
 		} endofline {
-			if (!captureBody.unterminated)
+			if ($<captureTerminated>4)
 				fstk_RunRept($2, captureBody.lineNo, captureBody.body,
 					     captureBody.size);
 		}
@@ -992,9 +993,9 @@ for		: T_POP_FOR {
 		} T_ID {
 			lexer_ToggleStringExpansion(true);
 		} T_COMMA for_args T_NEWLINE {
-			lexer_CaptureRept(&captureBody);
+			$<captureTerminated>$ = lexer_CaptureRept(&captureBody);
 		} endofline {
-			if (!captureBody.unterminated)
+			if ($<captureTerminated>8)
 				fstk_RunFor($3, $6.start, $6.stop, $6.step, captureBody.lineNo,
 					    captureBody.body, captureBody.size);
 		}
@@ -1027,16 +1028,16 @@ macrodef	: T_POP_MACRO {
 		} T_ID {
 			lexer_ToggleStringExpansion(true);
 		} T_NEWLINE {
-			lexer_CaptureMacroBody(&captureBody);
+			$<captureTerminated>$ = lexer_CaptureMacroBody(&captureBody);
 		} endofline {
-			if (!captureBody.unterminated)
+			if ($<captureTerminated>6)
 				sym_AddMacro($3, captureBody.lineNo, captureBody.body,
 					     captureBody.size);
 		}
 		| T_LABEL T_COLON T_POP_MACRO T_NEWLINE {
-			lexer_CaptureMacroBody(&captureBody);
+			$<captureTerminated>$ = lexer_CaptureMacroBody(&captureBody);
 		} endofline {
-			if (!captureBody.unterminated)
+			if ($<captureTerminated>5)
 				sym_AddMacro($1, captureBody.lineNo, captureBody.body,
 					     captureBody.size);
 		}

--- a/test/asm/block-comment-termination-error.err
+++ b/test/asm/block-comment-termination-error.err
@@ -1,5 +1,5 @@
 ERROR: block-comment-termination-error.asm(1):
     Unterminated block comment
 ERROR: block-comment-termination-error.asm(1):
-    syntax error, unexpected newline
+    syntax error, unexpected end of buffer
 error: Assembly aborted (2 errors)!

--- a/test/asm/code-after-endm-endr-endc.err
+++ b/test/asm/code-after-endm-endr-endc.err
@@ -1,15 +1,15 @@
 ERROR: code-after-endm-endr-endc.asm(6):
-    syntax error, unexpected PRINTLN, expecting newline
+    syntax error, unexpected PRINTLN, expecting newline or end of buffer
 ERROR: code-after-endm-endr-endc.asm(7):
     Macro "mac" not defined
 ERROR: code-after-endm-endr-endc.asm(12):
-    syntax error, unexpected PRINTLN, expecting newline
+    syntax error, unexpected PRINTLN, expecting newline or end of buffer
 ERROR: code-after-endm-endr-endc.asm(17):
     syntax error, unexpected PRINTLN, expecting newline
 ERROR: code-after-endm-endr-endc.asm(19):
-    syntax error, unexpected PRINTLN, expecting newline
+    syntax error, unexpected PRINTLN, expecting newline or end of buffer
 ERROR: code-after-endm-endr-endc.asm(23):
     syntax error, unexpected PRINTLN, expecting newline
 ERROR: code-after-endm-endr-endc.asm(25):
-    syntax error, unexpected PRINTLN, expecting newline
+    syntax error, unexpected PRINTLN, expecting newline or end of buffer
 error: Assembly aborted (7 errors)!

--- a/test/asm/nested-macrodef.err
+++ b/test/asm/nested-macrodef.err
@@ -3,5 +3,5 @@ warning: nested-macrodef.asm(26) -> nested-macrodef.asm::outer(22): [-Wuser]
 ERROR: nested-macrodef.asm(26) -> nested-macrodef.asm::outer(24):
     Unterminated macro definition
 ERROR: nested-macrodef.asm(27):
-    syntax error, unexpected identifier, expecting newline
+    Macro "inner" not defined
 error: Assembly aborted (2 errors)!


### PR DESCRIPTION
Removes the lexer hack mentioned in #778