### PR TITLE
Support character escapes in linkerscript strings

### DIFF
--- a/test/link/linkerscript-escapes-test.link
+++ b/test/link/linkerscript-escapes-test.link
@@ -1,0 +1,3 @@
+ROM0
+	"A\"B\tC\rD\nE"
+	"in\{valid"

--- a/test/link/linkerscript-escapes-test.link
+++ b/test/link/linkerscript-escapes-test.link
@@ -1,3 +1,1 @@
-ROM0
-	"A\"B\tC\rD\nE"
-	"in\{valid"
+; This uses CR line endingsROM0	"A\"B\tC\rD\nE"	"in\{valid"

--- a/test/link/linkerscript-escapes-test.out
+++ b/test/link/linkerscript-escapes-test.out
@@ -1,0 +1,1 @@
+error: ./linkerscript-escapes-test.link(3): Illegal character escape

--- a/test/link/linkerscript-escapes-test.out
+++ b/test/link/linkerscript-escapes-test.out
@@ -1,1 +1,1 @@
-error: ./linkerscript-escapes-test.link(3): Illegal character escape
+error: ./linkerscript-escapes-test.link(4): Illegal character escape

--- a/test/link/linkerscript-escapes.asm
+++ b/test/link/linkerscript-escapes.asm
@@ -1,0 +1,4 @@
+SECTION "A\"B\tC\rD\nE", ROM0
+DS $1000
+SECTION "in\{valid", ROM0
+DS $1000


### PR DESCRIPTION
This allows linkerscripts to refer to section names even if they contain special characters: `'\r' '\n' '\t' '"' '\\'`.