### PR TITLE
Updated RGBFIX to report when non-zero bytes are overwritten

### DIFF
--- a/test/fix/bad-fix-char.err
+++ b/test/fix/bad-fix-char.err
@@ -1,3 +1,4 @@
 warning: Ignoring 'm' in fix spec
 warning: Ignoring 'a' in fix spec
 warning: Ignoring 'o' in fix spec
+warning: Overwrote a non-zero byte in the Nintendo logo

--- a/test/fix/color.err
+++ b/test/fix/color.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the CGB flag

--- a/test/fix/compatible.err
+++ b/test/fix/compatible.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the CGB flag

--- a/test/fix/fix-override.err
+++ b/test/fix/fix-override.err
@@ -1,1 +1,2 @@
 warning: 'l' overriding 'L' in fix spec
+warning: Overwrote a non-zero byte in the Nintendo logo

--- a/test/fix/gameid-trunc.err
+++ b/test/fix/gameid-trunc.err
@@ -1,1 +1,2 @@
 warning: Truncating game ID "FOUR!" to 4 chars
+warning: Overwrote a non-zero byte in the manufacturer code

--- a/test/fix/gameid.err
+++ b/test/fix/gameid.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the manufacturer code

--- a/test/fix/header-edit.err
+++ b/test/fix/header-edit.err
@@ -1,0 +1,2 @@
+warning: Overwrote a non-zero byte in the CGB flag
+warning: Overwrote a non-zero byte in the header checksum

--- a/test/fix/header-trash.err
+++ b/test/fix/header-trash.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the header checksum

--- a/test/fix/header.err
+++ b/test/fix/header.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the header checksum

--- a/test/fix/jp.err
+++ b/test/fix/jp.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the destination code

--- a/test/fix/logo-trash.err
+++ b/test/fix/logo-trash.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the Nintendo logo

--- a/test/fix/logo.err
+++ b/test/fix/logo.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the Nintendo logo

--- a/test/fix/mbc.err
+++ b/test/fix/mbc.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the cartridge type

--- a/test/fix/mbcless-ram.err
+++ b/test/fix/mbcless-ram.err
@@ -1,1 +1,3 @@
 warning: MBC "ROM" has no RAM, but RAM size was set to 2
+warning: Overwrote a non-zero byte in the cartridge type
+warning: Overwrote a non-zero byte in the RAM size

--- a/test/fix/new-lic-trunc.err
+++ b/test/fix/new-lic-trunc.err
@@ -1,1 +1,2 @@
 warning: Truncating new licensee "HOMEBREW" to 2 chars
+warning: Overwrote a non-zero byte in the new licensee code

--- a/test/fix/new-lic.err
+++ b/test/fix/new-lic.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the new licensee code

--- a/test/fix/old-lic-hex.err
+++ b/test/fix/old-lic-hex.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the old licensee code

--- a/test/fix/old-lic.err
+++ b/test/fix/old-lic.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the old licensee code

--- a/test/fix/ram.err
+++ b/test/fix/ram.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the RAM size

--- a/test/fix/ramful-mbc-no-ram.err
+++ b/test/fix/ramful-mbc-no-ram.err
@@ -1,1 +1,3 @@
 warning: MBC "MBC3+RAM" has RAM, but RAM size was set to 0
+warning: Overwrote a non-zero byte in the cartridge type
+warning: Overwrote a non-zero byte in the RAM size

--- a/test/fix/ramful-mbc.err
+++ b/test/fix/ramful-mbc.err
@@ -1,0 +1,2 @@
+warning: Overwrote a non-zero byte in the cartridge type
+warning: Overwrote a non-zero byte in the RAM size

--- a/test/fix/ramless-mbc.err
+++ b/test/fix/ramless-mbc.err
@@ -1,0 +1,2 @@
+warning: Overwrote a non-zero byte in the cartridge type
+warning: Overwrote a non-zero byte in the RAM size

--- a/test/fix/rom-ram.err
+++ b/test/fix/rom-ram.err
@@ -1,1 +1,2 @@
 warning: ROM+RAM / ROM+RAM+BATTERY are under-specified and poorly supported
+warning: Overwrote a non-zero byte in the cartridge type

--- a/test/fix/sgb-licensee.err
+++ b/test/fix/sgb-licensee.err
@@ -1,1 +1,3 @@
 warning: SGB compatibility enabled, but old licensee is 0x45, not 0x33
+warning: Overwrote a non-zero byte in the SGB flag
+warning: Overwrote a non-zero byte in the old licensee code

--- a/test/fix/sgb.err
+++ b/test/fix/sgb.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the SGB flag

--- a/test/fix/title-color-trunc-rev.err
+++ b/test/fix/title-color-trunc-rev.err
@@ -1,1 +1,3 @@
 warning: Truncating title "0123456789ABCDEF" to 15 chars
+warning: Overwrote a non-zero byte in the title
+warning: Overwrote a non-zero byte in the CGB flag

--- a/test/fix/title-color-trunc.err
+++ b/test/fix/title-color-trunc.err
@@ -1,1 +1,3 @@
 warning: Truncating title "0123456789ABCDEF" to 15 chars
+warning: Overwrote a non-zero byte in the title
+warning: Overwrote a non-zero byte in the CGB flag

--- a/test/fix/title-compat-trunc-rev.err
+++ b/test/fix/title-compat-trunc-rev.err
@@ -1,1 +1,3 @@
 warning: Truncating title "0123456789ABCDEF" to 15 chars
+warning: Overwrote a non-zero byte in the title
+warning: Overwrote a non-zero byte in the CGB flag

--- a/test/fix/title-compat-trunc.err
+++ b/test/fix/title-compat-trunc.err
@@ -1,1 +1,3 @@
 warning: Truncating title "0123456789ABCDEF" to 15 chars
+warning: Overwrote a non-zero byte in the title
+warning: Overwrote a non-zero byte in the CGB flag

--- a/test/fix/title-gameid-trunc-rev.err
+++ b/test/fix/title-gameid-trunc-rev.err
@@ -1,1 +1,3 @@
 warning: Truncating title "0123456789ABCDEF" to 11 chars
+warning: Overwrote a non-zero byte in the title
+warning: Overwrote a non-zero byte in the manufacturer code

--- a/test/fix/title-gameid-trunc.err
+++ b/test/fix/title-gameid-trunc.err
@@ -1,1 +1,3 @@
 warning: Truncating title "0123456789ABCDEF" to 11 chars
+warning: Overwrote a non-zero byte in the title
+warning: Overwrote a non-zero byte in the manufacturer code

--- a/test/fix/title-pad.err
+++ b/test/fix/title-pad.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the title

--- a/test/fix/title-trunc.err
+++ b/test/fix/title-trunc.err
@@ -1,1 +1,2 @@
 warning: Truncating title "0123456789ABCDEFGHIJK" to 16 chars
+warning: Overwrote a non-zero byte in the title

--- a/test/fix/title.err
+++ b/test/fix/title.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the title

--- a/test/fix/verify-pad.err
+++ b/test/fix/verify-pad.err
@@ -1,0 +1,2 @@
+warning: Overwrote a non-zero byte in the Nintendo logo
+warning: Overwrote a non-zero byte in the header checksum

--- a/test/fix/verify-trash.err
+++ b/test/fix/verify-trash.err
@@ -1,0 +1,2 @@
+warning: Overwrote a non-zero byte in the Nintendo logo
+warning: Overwrote a non-zero byte in the header checksum

--- a/test/fix/verify.err
+++ b/test/fix/verify.err
@@ -1,0 +1,2 @@
+warning: Overwrote a non-zero byte in the Nintendo logo
+warning: Overwrote a non-zero byte in the header checksum

--- a/test/fix/version.err
+++ b/test/fix/version.err
@@ -1,0 +1,1 @@
+warning: Overwrote a non-zero byte in the mask ROM version number


### PR DESCRIPTION
Closes #845. 
Updated RGBFIX to report when non-zero bytes are overwritten and updated .err files with the new warning.