### PR TITLE
Add option to list accepted MBC names and clarify man page

### DIFF
--- a/include/platform.h
+++ b/include/platform.h
@@ -11,9 +11,10 @@
 #ifndef RGBDS_PLATFORM_H
 #define RGBDS_PLATFORM_H
 
-/* MSVC doesn't have strncasecmp, use a suitable replacement */
+// MSVC doesn't have str(n)casecmp, use a suitable replacement
 #ifdef _MSC_VER
 # include <string.h>
+# define strcasecmp _stricmp
 # define strncasecmp _strnicmp
 #else
 # include <strings.h>

--- a/src/fix/main.c
+++ b/src/fix/main.c
@@ -127,6 +127,25 @@ enum MbcType {
 	MBC_BAD_RANGE, // MBC number out of range
 };
 
+static void printAcceptedMBCNames(void)
+{
+	fputs("\tROM ($00) [aka ROM_ONLY]", stderr);
+	fputs("\tMBC1 ($02), MBC1+RAM ($02), MBC1+RAM+BATTERY ($03)", stderr);
+	fputs("\tMBC2 ($05), MBC2+BATTERY ($06)", stderr);
+	fputs("\tROM+RAM ($08) [deprecated], ROM+RAM+BATTERY ($09) [deprecated]", stderr);
+	fputs("\tMMM01 ($0B), MMM01+RAM ($0C), MMM01+RAM+BATTERY ($0D)", stderr);
+	fputs("\tMBC3+TIMER+BATTERY ($0F), MBC3+TIMER+RAM+BATTERY ($10)", stderr);
+	fputs("\tMBC3 ($11), MBC3+RAM ($12), MBC3+RAM+BATTERY ($13)", stderr);
+	fputs("\tMBC5 ($19), MBC5+RAM ($1A), MBC5+RAM+BATTERY ($1B)", stderr);
+	fputs("\tMBC5+RUMBLE ($1C), MBC5+RUMBLE+RAM ($1D), MBC5+RUMBLE+RAM+BATTERY ($1E)", stderr);
+	fputs("\tMBC6 ($20)", stderr);
+	fputs("\tMBC7+SENSOR+RUMBLE+RAM+BATTERY ($22)", stderr);
+	fputs("\tPOCKET_CAMERA ($FC)", stderr);
+	fputs("\tBANDAI_TAMA5 ($FD)", stderr);
+	fputs("\tHUC3 ($FE)", stderr);
+	fputs("\tHUC1+RAM+BATTERY ($FF)", stderr);
+}
+
 /**
  * @return False on failure
  */
@@ -151,6 +170,12 @@ static bool readMBCSlice(char const **name, char const *expected)
 
 static enum MbcType parseMBC(char const *name)
 {
+	if (!strcasecmp(name, "help")) {
+		fputs("Accepted MBC names:\n", stderr);
+		printAcceptedMBCNames();
+		exit(0);
+	}
+
 	if ((name[0] >= '0' && name[0] <= '9') || name[0] == '$') {
 		int base = 0;
 
@@ -1134,10 +1159,13 @@ do { \
 		case 'm':
 			cartridgeType = parseMBC(musl_optarg);
 			if (cartridgeType == MBC_BAD) {
-				report("error: Unknown MBC \"%s\"\n", musl_optarg);
-			} else if (cartridgeType == MBC_WRONG_FEATURES) {
-				report("error: Features incompatible with MBC (\"%s\")\n",
+				report("error: Unknown MBC \"%s\"\nAccepted MBC names:\n",
 				       musl_optarg);
+				printAcceptedMBCNames();
+			} else if (cartridgeType == MBC_WRONG_FEATURES) {
+				report("error: Features incompatible with MBC (\"%s\")\nAccepted combinations:\n",
+				       musl_optarg);
+				printAcceptedMBCNames();
 			} else if (cartridgeType == MBC_BAD_RANGE) {
 				report("error: Specified MBC ID out of range 0-255: %s\n",
 				       musl_optarg);

--- a/src/fix/rgbfix.1
+++ b/src/fix/rgbfix.1
@@ -112,7 +112,10 @@ This value is deprecated and should be set to 0x33 in all new software.
 Set the MBC type
 .Pq Ad 0x147
 to a given value from 0 to 0xFF.
-This value may also be an MBC name from the Pan Docs.
+.Pp
+This value may also be an MBC name.
+The list of accepted names can be obtained by passing "help" as the argument.
+Any amount of whitespace (space and tabs) is allowed around plus signs, and the order of "components" is free, as long as the MBC name is first.
 .It Fl n Ar rom_version , Fl Fl rom-version Ar rom_version
 Set the ROM version
 .Pq Ad 0x14C


### PR DESCRIPTION
Referring to "Pan Docs names" skims over a lot of details.
Add `-m help` to list accepted names for clarity.