### PR TITLE
Make data output outside of a SECTION non-fatal

### DIFF
--- a/test/asm/align-pc-outside-section.err
+++ b/test/asm/align-pc-outside-section.err
@@ -1,2 +1,3 @@
-FATAL: align-pc-outside-section.asm(1):
+ERROR: align-pc-outside-section.asm(1):
     Cannot output data outside of a SECTION
+error: Assembly aborted (1 error)!

--- a/test/asm/incbin-end-0.err
+++ b/test/asm/incbin-end-0.err
@@ -1,0 +1,3 @@
+ERROR: incbin-end-0.asm(1):
+    Cannot output data outside of a SECTION
+error: Assembly aborted (1 error)!

--- a/test/asm/pops-restore-no-section.err
+++ b/test/asm/pops-restore-no-section.err
@@ -1,4 +1,5 @@
 ERROR: pops-restore-no-section.asm(9):
     Label "DisallowedContent" created outside of a SECTION
-FATAL: pops-restore-no-section.asm(10):
+ERROR: pops-restore-no-section.asm(10):
     Cannot output data outside of a SECTION
+error: Assembly aborted (2 errors)!

--- a/test/asm/pushs.err
+++ b/test/asm/pushs.err
@@ -1,2 +1,3 @@
-FATAL: pushs.asm(5):
+ERROR: pushs.asm(5):
     Cannot output data outside of a SECTION
+error: Assembly aborted (1 error)!


### PR DESCRIPTION
The interesting thing here is `test/asm/incbin-0-end.err`. I changed `INCBIN` to error out when used outside of a code SECTION even if the length is 0; does it sound sensible?