### PR TITLE
Fix `-Wformat` build warnings on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,8 @@ develop:
 		-fsanitize=unreachable -fsanitize=vla-bound \
 		-fsanitize=signed-integer-overflow -fsanitize=bounds \
 		-fsanitize=object-size -fsanitize=bool -fsanitize=enum \
-		-fsanitize=alignment -fsanitize=null -fsanitize=address" CFLAGS="-ggdb3 -O0"
+		-fsanitize=alignment -fsanitize=null -fsanitize=address" \
+		CFLAGS="-ggdb3 -O0"
 
 # Targets for the project maintainer to easily create Windows exes.
 # This is not for Windows users!

--- a/src/link/assign.c
+++ b/src/link/assign.c
@@ -337,7 +337,7 @@ static void placeSection(struct Section *section)
 		     section->name, typeNames[section->type], where);
 	/* If the section just can't fit the bank, report that */
 	else if (section->org + section->size > endaddr(section->type) + 1)
-		errx(1, "Unable to place \"%s\" (%s section) %s: section runs past end of region ($%04" PRIx16 " > $%04" PRIx16 ")",
+		errx(1, "Unable to place \"%s\" (%s section) %s: section runs past end of region ($%04x > $%04x)",
 		     section->name, typeNames[section->type], where,
 		     section->org + section->size, endaddr(section->type) + 1);
 	/* Otherwise there is overlap with another section */

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -384,7 +384,8 @@ static uint16_t writeMapBank(struct SortedSections const *sectList,
 		used += sect->size;
 
 		if (sect->size != 0)
-			fprintf(mapFile, "  SECTION: $%04" PRIx16 "-$%04" PRIx16 " ($%04" PRIx16 " byte%s) [\"%s\"]\n",
+			fprintf(mapFile, "  SECTION: $%04" PRIx16 "-$%04x ($%04" PRIx16
+				" byte%s) [\"%s\"]\n",
 				sect->org, sect->org + sect->size - 1,
 				sect->size, sect->size == 1 ? "" : "s",
 				sect->name);

--- a/src/link/section.c
+++ b/src/link/section.c
@@ -49,8 +49,8 @@ static void checkSectUnionCompat(struct Section *target, struct Section *other)
 				     other->name, target->org, other->org);
 		} else if (target->isAlignFixed) {
 			if ((other->org - target->alignOfs) & target->alignMask)
-				errx(1, "Section \"%s\" is defined with conflicting %" PRIu16
-				     "-byte alignment (offset %" PRIu16 ") and address $%04" PRIx16,
+				errx(1, "Section \"%s\" is defined with conflicting %d-byte alignment (offset %"
+				     PRIu16 ") and address $%04" PRIx16,
 				     other->name, target->alignMask + 1,
 				     target->alignOfs, other->org);
 		}
@@ -61,15 +61,14 @@ static void checkSectUnionCompat(struct Section *target, struct Section *other)
 		if (target->isAddressFixed) {
 			if ((target->org - other->alignOfs) & other->alignMask)
 				errx(1, "Section \"%s\" is defined with conflicting address $%04"
-				     PRIx16 " and %" PRIu16 "-byte alignment (offset %" PRIu16 ")",
+				     PRIx16 " and %d-byte alignment (offset %" PRIu16 ")",
 				     other->name, target->org,
 				     other->alignMask + 1, other->alignOfs);
 		} else if (target->isAlignFixed
 			&& (other->alignMask & target->alignOfs)
 				 != (target->alignMask & other->alignOfs)) {
-			errx(1, "Section \"%s\" is defined with conflicting %" PRIu16
-			     "-byte alignment (offset %" PRIu16 ") and %" PRIu16
-			     "-byte alignment (offset %" PRIu16 ")",
+			errx(1, "Section \"%s\" is defined with conflicting %d-byte alignment (offset %"
+			     PRIu16 ") and %d-byte alignment (offset %" PRIu16 ")",
 			     other->name, target->alignMask + 1, target->alignOfs,
 			     other->alignMask + 1, other->alignOfs);
 		} else if (!target->isAlignFixed || (other->alignMask > target->alignMask)) {
@@ -92,8 +91,8 @@ static void checkFragmentCompat(struct Section *target, struct Section *other)
 
 		} else if (target->isAlignFixed) {
 			if ((org - target->alignOfs) & target->alignMask)
-				errx(1, "Section \"%s\" is defined with conflicting %" PRIu16
-				     "-byte alignment (offset %" PRIu16 ") and address $%04" PRIx16,
+				errx(1, "Section \"%s\" is defined with conflicting %d-byte alignment (offset %"
+				     PRIu16 ") and address $%04" PRIx16,
 				     other->name, target->alignMask + 1,
 				     target->alignOfs, other->org);
 		}
@@ -109,15 +108,14 @@ static void checkFragmentCompat(struct Section *target, struct Section *other)
 		if (target->isAddressFixed) {
 			if ((target->org - ofs) & other->alignMask)
 				errx(1, "Section \"%s\" is defined with conflicting address $%04"
-				     PRIx16 " and %" PRIu16 "-byte alignment (offset %" PRIu16 ")",
+				     PRIx16 " and %d-byte alignment (offset %" PRIu16 ")",
 				     other->name, target->org,
 				     other->alignMask + 1, other->alignOfs);
 
 		} else if (target->isAlignFixed
 			&& (other->alignMask & target->alignOfs) != (target->alignMask & ofs)) {
-			errx(1, "Section \"%s\" is defined with conflicting %" PRIu16
-			     "-byte alignment (offset %" PRIu16 ") and %" PRIu16
-			     "-byte alignment (offset %" PRIu16 ")",
+			errx(1, "Section \"%s\" is defined with conflicting %d-byte alignment (offset %"
+			     PRIu16 ") and %d-byte alignment (offset %" PRIu16 ")",
 			     other->name, target->alignMask + 1, target->alignOfs,
 			     other->alignMask + 1, other->alignOfs);
 
@@ -252,7 +250,7 @@ static void doSanityChecks(struct Section *section, void *ptr)
 
 	/* Too large an alignment may not be satisfiable */
 	if (section->isAlignFixed && (section->alignMask & startaddr[section->type]))
-		fail("%s: %s sections cannot be aligned to $%04" PRIx16 " bytes",
+		fail("%s: %s sections cannot be aligned to $%04x bytes",
 		     section->name, typeNames[section->type], section->alignMask + 1);
 
 	uint32_t minbank = bankranges[section->type][0], maxbank = bankranges[section->type][1];
@@ -292,9 +290,9 @@ static void doSanityChecks(struct Section *section, void *ptr)
 			     startaddr[section->type], endaddr(section->type));
 
 		if (section->org + section->size > endaddr(section->type) + 1)
-			fail("Section \"%s\"'s end address %#" PRIx16
-			     " is greater than last address %#" PRIx16, section->name,
-			     section->org + section->size, endaddr(section->type) + 1);
+			fail("Section \"%s\"'s end address %#x is greater than last address %#x",
+			     section->name, section->org + section->size,
+			     endaddr(section->type) + 1);
 	}
 
 #undef fail


### PR DESCRIPTION
C arithmetic promotes certain expressions to `int`, so formatting has to use `"%d"` or `"%x"`, not inttypes.h.

Fixes #883