### PR TITLE
Syntax error message hints to indent macro invocations

### DIFF
--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -688,6 +688,15 @@ line		: plain_directive endofline
 			fstk_StopRept();
 			yyerrok;
 		}
+		| T_LABEL error endofline { /* Hint about unindented macros parsed as labels */
+			struct Symbol *macro = sym_FindExactSymbol($1);
+
+			if (macro && macro->type == SYM_MACRO)
+				fprintf(stderr,
+					"    To invoke `%s` as a macro it must be indented\n", $1);
+			fstk_StopRept();
+			yyerrok;
+		}
 ;
 
 /*

--- a/test/asm/syntax-error-after-syntax-error.err
+++ b/test/asm/syntax-error-after-syntax-error.err
@@ -2,8 +2,10 @@ ERROR: syntax-error-after-syntax-error.asm(6):
     syntax error, unexpected newline
 ERROR: syntax-error-after-syntax-error.asm(7):
     syntax error, unexpected newline
+    To invoke `mac` as a macro it must be indented
 ERROR: syntax-error-after-syntax-error.asm(8):
     syntax error, unexpected number
+    To invoke `mac` as a macro it must be indented
 ERROR: syntax-error-after-syntax-error.asm(9):
     'mac' already defined at syntax-error-after-syntax-error.asm(1)
 ERROR: syntax-error-after-syntax-error.asm(10):

--- a/test/asm/syntax-error-after-syntax-error.simple.err
+++ b/test/asm/syntax-error-after-syntax-error.simple.err
@@ -2,8 +2,10 @@ ERROR: syntax-error-after-syntax-error.asm(6):
     syntax error
 ERROR: syntax-error-after-syntax-error.asm(7):
     syntax error
+    To invoke `mac` as a macro it must be indented
 ERROR: syntax-error-after-syntax-error.asm(8):
     syntax error
+    To invoke `mac` as a macro it must be indented
 ERROR: syntax-error-after-syntax-error.asm(9):
     'mac' already defined at syntax-error-after-syntax-error.asm(1)
 ERROR: syntax-error-after-syntax-error.asm(10):


### PR DESCRIPTION
This message is only printed for identifiers parsed as `T_LABEL` (since they're at the start of a line) but already defined as macros. Otherwise it may not be relevant, e.g. for `MyLabel;:` or `My Label::`.