### PR TITLE
`make checkdiff` does CI documentation checks

### DIFF
--- a/.github/workflows/checkdiff.yml
+++ b/.github/workflows/checkdiff.yml
@@ -1,0 +1,17 @@
+name: "Code coverage checking"
+on: pull_request
+
+jobs:
+  checkdiff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up repo
+        run: |
+          git clone -b "${{ github.event.pull_request.head.ref }}" "${{ github.event.pull_request.head.repo.clone_url }}" rgbds
+          cd rgbds
+          git remote add upstream "${{ github.event.pull_request.base.repo.clone_url }}"
+          git fetch upstream
+      - name: Checkdiff
+        working-directory: rgbds
+        run: |
+          make checkdiff "BASE_REF=${{ github.event.pull_request.base.sha }}" Q= | tee log

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ YFLAGS		?= -Wall
 BISON		:= bison
 RM		:= rm -rf
 
+# Used for checking pull requests
+BASE_REF	:= origin/master
+
 # Rules to build the RGBDS binaries
 
 all: rgbasm rgblink rgbfix rgbgfx
@@ -189,7 +192,6 @@ checkcodebase:
 # the first common commit between the HEAD and origin/master.
 # `.y` files aren't checked, unfortunately...
 
-BASE_REF:= origin/master
 checkpatch:
 	$Qeval COMMON_COMMIT=$$(git merge-base HEAD ${BASE_REF});	\
 	for commit in `git rev-list $$COMMON_COMMIT..HEAD`; do		\
@@ -198,6 +200,12 @@ checkpatch:
 			-- src include '!src/extern' '!include/extern'	\
 			| ${CHECKPATCH} - || true;			\
 	done
+
+# Target used to check for suspiciously missing changed files.
+
+checkdiff:
+	$Qeval COMMON_COMMIT=$$(git merge-base HEAD ${BASE_REF});	\
+	contrib/checkdiff.bash $$COMMON_COMMIT
 
 # This target is used during development in order to prevent adding new issues
 # to the source code. All warnings are treated as errors in order to block the

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ checkcodebase:
 # `.y` files aren't checked, unfortunately...
 
 checkpatch:
-	$Qeval COMMON_COMMIT=$$(git merge-base HEAD ${BASE_REF});	\
+	$QCOMMON_COMMIT=`git merge-base HEAD ${BASE_REF}`;		\
 	for commit in `git rev-list $$COMMON_COMMIT..HEAD`; do		\
 		echo "[*] Analyzing commit '$$commit'";			\
 		git format-patch --stdout "$$commit~..$$commit"		\
@@ -204,8 +204,7 @@ checkpatch:
 # Target used to check for suspiciously missing changed files.
 
 checkdiff:
-	$Qeval COMMON_COMMIT=$$(git merge-base HEAD ${BASE_REF});	\
-	contrib/checkdiff.bash $$COMMON_COMMIT
+	$Qcontrib/checkdiff.bash `git merge-base HEAD ${BASE_REF}`
 
 # This target is used during development in order to prevent adding new issues
 # to the source code. All warnings are treated as errors in order to block the

--- a/contrib/checkdiff.bash
+++ b/contrib/checkdiff.bash
@@ -40,14 +40,35 @@ dependency () {
 # Pull requests that edit the first file without the second may be correct,
 # but are suspicious enough to require review.
 dependency include/linkdefs.h    src/rgbds.5        \
-           "Should the object file format changes be documented?"
+           "Was the object file format changed?"
+
 dependency src/asm/parser.y      src/asm/rgbasm.5   \
-           "Should the parser changes be documented?"
+           "Was the parser changed?"
+
 dependency include/asm/warning.h src/asm/rgbasm.1   \
-           "Should the rgbasm warning changes be documented?"
+           "Were rgbasm warnings changed?"
+
 dependency src/asm/object.c      include/linkdefs.h \
            "Should the object file revision be bumped?"
 dependency src/link/object.c     include/linkdefs.h \
            "Should the object file revision be bumped?"
+
 dependency Makefile              CMakeLists.txt
 dependency Makefile              src/CMakeLists.txt
+
+dependency src/asm/main.c        src/asm/rgbasm.1 \
+           "Did the CLI change?"
+dependency src/asm/main.c        contrib/zsh_compl/_rgbasm \
+           "Did the CLI change?"
+dependency src/link/main.c       src/link/rgblink.1 \
+           "Did the CLI change?"
+dependency src/link/main.c       contrib/zsh_compl/_rgblink \
+           "Did the CLI change?"
+dependency src/fix/main.c        src/fix/rgbfix.1 \
+           "Did the CLI change?"
+dependency src/fix/main.c        contrib/zsh_compl/_rgbfix \
+           "Did the CLI change?"
+dependency src/gfx/main.c        src/gfx/rgbgfx.1 \
+           "Did the CLI change?"
+dependency src/gfx/main.c        contrib/zsh_compl/_rgbgfx \
+           "Did the CLI change?"

--- a/contrib/checkdiff.bash
+++ b/contrib/checkdiff.bash
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2021 Rangi
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+FILES=`git diff --name-only $1 HEAD`
+
+edited () {
+	echo "$FILES" | grep -Fxq "$1"
+}
+
+dependency () {
+	if edited $1 && ! edited $2; then
+		echo "Edited '$1' but not '$2'!"
+	fi
+}
+
+# Pull requests that edit the first file without the second may be correct,
+# but are suspicious enough to require review.
+dependency include/linkdefs.h    src/rgbds.5
+dependency src/asm/parser.y      src/asm/rgbasm.5
+dependency include/asm/warning.h src/asm/rgbasm.1

--- a/contrib/checkdiff.bash
+++ b/contrib/checkdiff.bash
@@ -39,36 +39,39 @@ dependency () {
 
 # Pull requests that edit the first file without the second may be correct,
 # but are suspicious enough to require review.
-dependency include/linkdefs.h    src/rgbds.5        \
+
+dependency include/linkdefs.h    src/rgbds.5 \
            "Was the object file format changed?"
 
-dependency src/asm/parser.y      src/asm/rgbasm.5   \
-           "Was the parser changed?"
+dependency src/asm/parser.y      src/asm/rgbasm.5 \
+           "Was the rgbasm grammar changed?"
 
-dependency include/asm/warning.h src/asm/rgbasm.1   \
-           "Were rgbasm warnings changed?"
+dependency include/asm/warning.h src/asm/rgbasm.1 \
+           "Were the rgbasm warnings changed?"
 
 dependency src/asm/object.c      include/linkdefs.h \
            "Should the object file revision be bumped?"
 dependency src/link/object.c     include/linkdefs.h \
            "Should the object file revision be bumped?"
 
-dependency Makefile              CMakeLists.txt
-dependency Makefile              src/CMakeLists.txt
+dependency Makefile              CMakeLists.txt \
+           "Did the build process change?"
+dependency Makefile              src/CMakeLists.txt \
+           "Did the build process change?"
 
 dependency src/asm/main.c        src/asm/rgbasm.1 \
-           "Did the CLI change?"
+           "Did the rgbasm CLI change?"
 dependency src/asm/main.c        contrib/zsh_compl/_rgbasm \
-           "Did the CLI change?"
+           "Did the rgbasm CLI change?"
 dependency src/link/main.c       src/link/rgblink.1 \
-           "Did the CLI change?"
+           "Did the rgblink CLI change?"
 dependency src/link/main.c       contrib/zsh_compl/_rgblink \
-           "Did the CLI change?"
+           "Did the rgblink CLI change?"
 dependency src/fix/main.c        src/fix/rgbfix.1 \
-           "Did the CLI change?"
+           "Did the rgbfix CLI change?"
 dependency src/fix/main.c        contrib/zsh_compl/_rgbfix \
-           "Did the CLI change?"
+           "Did the rgbfix CLI change?"
 dependency src/gfx/main.c        src/gfx/rgbgfx.1 \
-           "Did the CLI change?"
+           "Did the rgbgfx CLI change?"
 dependency src/gfx/main.c        contrib/zsh_compl/_rgbgfx \
-           "Did the CLI change?"
+           "Did the rgbgfx CLI change?"

--- a/contrib/checkdiff.bash
+++ b/contrib/checkdiff.bash
@@ -33,11 +33,7 @@ edited () {
 
 dependency () {
 	if edited "$1" && ! edited "$2"; then
-		echo "'$1' was modified, but not '$2'!"
-		shift 2
-		if [ "$#" -gt 0 ]; then
-			echo "$@"
-		fi
+		echo "'$1' was modified, but not '$2'! $3" | xargs
 	fi
 }
 

--- a/contrib/checkdiff.bash
+++ b/contrib/checkdiff.bash
@@ -33,16 +33,25 @@ edited () {
 
 dependency () {
 	if edited "$1" && ! edited "$2"; then
-		default_msg="'$1' was modified, but not '$2'!"
+		echo "'$1' was modified, but not '$2'!"
 		shift 2
-		echo "$@" "$default_msg"
+		if [ "$#" -gt 0 ]; then
+			echo "$@"
+		fi
 	fi
 }
 
 # Pull requests that edit the first file without the second may be correct,
 # but are suspicious enough to require review.
-dependency include/linkdefs.h    src/rgbds.5         "Should rgbds(5) be synced with the obj file format changes?"
-dependency src/asm/parser.y      src/asm/rgbasm.5    "Should rgbasm(5) be synced with the parser changes?"
-dependency include/asm/warning.h src/asm/rgbasm.1    "Should rgbasm(1) be synced with the warning changes?"
-dependency src/asm/object.c      include/linkdefs.h  "Should the obj file revision be bumped?"
-dependency src/link/object.c     include/linkdefs.h  "Should the obj file revision be bumped?"
+dependency include/linkdefs.h    src/rgbds.5        \
+           "Should the object file format changes be documented?"
+dependency src/asm/parser.y      src/asm/rgbasm.5   \
+           "Should the parser changes be documented?"
+dependency include/asm/warning.h src/asm/rgbasm.1   \
+           "Should the rgbasm warning changes be documented?"
+dependency src/asm/object.c      include/linkdefs.h \
+           "Should the object file revision be bumped?"
+dependency src/link/object.c     include/linkdefs.h \
+           "Should the object file revision be bumped?"
+dependency Makefile              CMakeLists.txt
+dependency Makefile              src/CMakeLists.txt

--- a/include/asm/rpn.h
+++ b/include/asm/rpn.h
@@ -24,7 +24,7 @@ struct Expression {
 	uint8_t  *rpn;         // Array of bytes serializing the RPN expression
 	uint32_t rpnCapacity;  // Size of the `rpn` buffer
 	uint32_t rpnLength;    // Used size of the `rpn` buffer
-	uint32_t rpnPatchSize; // Size the expression will take in the obj file
+	uint32_t rpnPatchSize; // Size the expression will take in the object file
 };
 
 /*


### PR DESCRIPTION
Fixes #744

Still needs us to pick `dependency` rules for documentation and shell completion.