### PR TITLE
Compare `FOR` ranges to Python's `range`

### DIFF
--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -1734,7 +1734,9 @@ N = 256
 .Pp
 You can customize the range of
 .Ic FOR
-values:
+values, similarly to Python's
+.Ql range
+function:
 .Bl -column "FOR V, start, stop, step"
 .It Sy Code Ta Sy Range
 .It Ic FOR Ar V , stop Ta Ar V No increments from 0 to Ar stop


### PR DESCRIPTION
Other comparisons are made a few times to corresponding features in C.