### PR TITLE
Fix section merge alignment error message

### DIFF
--- a/src/asm/section.c
+++ b/src/asm/section.c
@@ -160,9 +160,9 @@ static unsigned int mergeSectUnion(struct Section *sect, enum SectionType type, 
 		/* Check if alignment offsets are compatible */
 		} else if ((alignOffset & mask(sect->align))
 			   != (sect->alignOfs & mask(alignment))) {
-			fail("Section already declared with incompatible %d"
+			fail("Section already declared with incompatible %u"
 			     "-byte alignment (offset %" PRIu16 ")\n",
-			     1 << sect->align, sect->alignOfs);
+			     1u << sect->align, sect->alignOfs);
 		} else if (alignment > sect->align) {
 			// If the section is not fixed, its alignment is the largest of both
 			sect->align = alignment;
@@ -213,9 +213,9 @@ static unsigned int mergeFragments(struct Section *sect, enum SectionType type, 
 				     PRIx32 "\n", sect->org);
 		/* Check if alignment offsets are compatible */
 		} else if ((curOfs & mask(sect->align)) != (sect->alignOfs & mask(alignment))) {
-			fail("Section already declared with incompatible %d"
+			fail("Section already declared with incompatible %u"
 			     "-byte alignment (offset %" PRIu16 ")\n",
-			     1 << sect->align, sect->alignOfs);
+			     1u << sect->align, sect->alignOfs);
 		} else if (alignment > sect->align) {
 			// If the section is not fixed, its alignment is the largest of both
 			sect->align = alignment;

--- a/src/asm/section.c
+++ b/src/asm/section.c
@@ -162,7 +162,7 @@ static unsigned int mergeSectUnion(struct Section *sect, enum SectionType type, 
 			   != (sect->alignOfs & mask(alignment))) {
 			fail("Section already declared with incompatible %" PRIu8
 			     "-byte alignment (offset %" PRIu16 ")\n",
-			     sect->align, sect->alignOfs);
+			     1U << sect->align, sect->alignOfs);
 		} else if (alignment > sect->align) {
 			// If the section is not fixed, its alignment is the largest of both
 			sect->align = alignment;
@@ -215,7 +215,7 @@ static unsigned int mergeFragments(struct Section *sect, enum SectionType type, 
 		} else if ((curOfs & mask(sect->align)) != (sect->alignOfs & mask(alignment))) {
 			fail("Section already declared with incompatible %" PRIu8
 			     "-byte alignment (offset %" PRIu16 ")\n",
-			     sect->align, sect->alignOfs);
+			     1U << sect->align, sect->alignOfs);
 		} else if (alignment > sect->align) {
 			// If the section is not fixed, its alignment is the largest of both
 			sect->align = alignment;

--- a/src/asm/section.c
+++ b/src/asm/section.c
@@ -160,9 +160,9 @@ static unsigned int mergeSectUnion(struct Section *sect, enum SectionType type, 
 		/* Check if alignment offsets are compatible */
 		} else if ((alignOffset & mask(sect->align))
 			   != (sect->alignOfs & mask(alignment))) {
-			fail("Section already declared with incompatible %" PRIu8
+			fail("Section already declared with incompatible %d"
 			     "-byte alignment (offset %" PRIu16 ")\n",
-			     1U << sect->align, sect->alignOfs);
+			     1 << sect->align, sect->alignOfs);
 		} else if (alignment > sect->align) {
 			// If the section is not fixed, its alignment is the largest of both
 			sect->align = alignment;
@@ -213,9 +213,9 @@ static unsigned int mergeFragments(struct Section *sect, enum SectionType type, 
 				     PRIx32 "\n", sect->org);
 		/* Check if alignment offsets are compatible */
 		} else if ((curOfs & mask(sect->align)) != (sect->alignOfs & mask(alignment))) {
-			fail("Section already declared with incompatible %" PRIu8
+			fail("Section already declared with incompatible %d"
 			     "-byte alignment (offset %" PRIu16 ")\n",
-			     1U << sect->align, sect->alignOfs);
+			     1 << sect->align, sect->alignOfs);
 		} else if (alignment > sect->align) {
 			// If the section is not fixed, its alignment is the largest of both
 			sect->align = alignment;

--- a/test/asm/incompatible-alignment.asm
+++ b/test/asm/incompatible-alignment.asm
@@ -1,0 +1,8 @@
+; These section fragments have alignments that make them non-contiguous,
+; and thus are incompatible
+
+SECTION FRAGMENT "Test", ROM0,ALIGN[8]
+
+	ds 1
+
+SECTION FRAGMENT "Test", ROM0,ALIGN[8]

--- a/test/asm/incompatible-alignment.err
+++ b/test/asm/incompatible-alignment.err
@@ -1,0 +1,4 @@
+ERROR: incompatible-alignment.asm(8):
+    Section already declared with incompatible 256-byte alignment (offset 0)
+FATAL: incompatible-alignment.asm(8):
+    Cannot create section "Test" (1 error)

--- a/test/link/section-union/align-ofs-conflict.out
+++ b/test/link/section-union/align-ofs-conflict.out
@@ -1,6 +1,6 @@
 error: Section "conflicting alignment" is defined with conflicting 8-byte alignment (offset 7) and 16-byte alignment (offset 14)
 ---
 ERROR: <stdin>(18):
-    Section already declared with incompatible 3-byte alignment (offset 7)
+    Section already declared with incompatible 8-byte alignment (offset 7)
 FATAL: <stdin>(18):
     Cannot create section "conflicting alignment" (1 error)

--- a/test/link/section-union/different-ofs.out
+++ b/test/link/section-union/different-ofs.out
@@ -1,6 +1,6 @@
 error: Section "conflicting alignment" is defined with conflicting 8-byte alignment (offset 7) and 8-byte alignment (offset 6)
 ---
 ERROR: <stdin>(18):
-    Section already declared with incompatible 3-byte alignment (offset 7)
+    Section already declared with incompatible 8-byte alignment (offset 7)
 FATAL: <stdin>(18):
     Cannot create section "conflicting alignment" (1 error)


### PR DESCRIPTION
I ran into this error a little while ago and noticed it said "8-byte alignment" when I had used `ALIGN[8]`.