### PR TITLE
Remove unused `#include "extern/utf8decoder.h"`

### DIFF
--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -24,7 +24,6 @@
 #include <unistd.h>
 #endif
 
-#include "extern/utf8decoder.h"
 #include "platform.h" /* For `ssize_t` */
 
 #include "asm/lexer.h"


### PR DESCRIPTION
Fixes #937