### PR TITLE
Standardize on "east const" (`type const *` not `const type *`)

### DIFF
--- a/include/asm/charmap.h
+++ b/include/asm/charmap.h
@@ -11,9 +11,9 @@
 
 #include <stdint.h>
 
-struct Charmap *charmap_New(const char *name, const char *baseName);
+struct Charmap *charmap_New(char const *name, char const *baseName);
 void charmap_Delete(struct Charmap *charmap);
-void charmap_Set(const char *name);
+void charmap_Set(char const *name);
 void charmap_Push(void);
 void charmap_Pop(void);
 void charmap_Add(char *mapping, uint8_t value);

--- a/include/asm/section.h
+++ b/include/asm/section.h
@@ -43,7 +43,7 @@ struct SectionSpec {
 
 extern struct Section *currentSection;
 
-struct Section *sect_FindSectionByName(const char *name);
+struct Section *sect_FindSectionByName(char const *name);
 void sect_NewSection(char const *name, uint32_t secttype, uint32_t org,
 		     struct SectionSpec const *attributes, enum SectionModifier mod);
 void sect_SetLoadSection(char const *name, uint32_t secttype, uint32_t org,

--- a/include/asm/warning.h
+++ b/include/asm/warning.h
@@ -71,7 +71,7 @@ void processWarningFlag(char *flag);
  * Used to warn the user about problems that don't prevent the generation of
  * valid code.
  */
-void warning(enum WarningID id, const char *fmt, ...) format_(printf, 2, 3);
+void warning(enum WarningID id, char const *fmt, ...) format_(printf, 2, 3);
 
 /*
  * Used for errors that compromise the whole assembly process by affecting the
@@ -80,7 +80,7 @@ void warning(enum WarningID id, const char *fmt, ...) format_(printf, 2, 3);
  * It is also used when the assembler goes into an invalid state (for example,
  * when it fails to allocate memory).
  */
-_Noreturn void fatalerror(const char *fmt, ...) format_(printf, 1, 2);
+_Noreturn void fatalerror(char const *fmt, ...) format_(printf, 1, 2);
 
 /*
  * Used for errors that make it impossible to assemble correctly, but don't
@@ -88,6 +88,6 @@ _Noreturn void fatalerror(const char *fmt, ...) format_(printf, 1, 2);
  * get a list of all errors at the end, making it easier to fix all of them at
  * once.
  */
-void error(const char *fmt, ...) format_(printf, 1, 2);
+void error(char const *fmt, ...) format_(printf, 1, 2);
 
 #endif

--- a/include/extern/err.h
+++ b/include/extern/err.h
@@ -29,15 +29,15 @@
 #define errx rgbds_errx
 #define verrx rgbds_verrx
 
-void warn(const char *fmt, ...) format_(printf, 1, 2);
-void vwarn(const char *fmt, va_list ap) format_(printf, 1, 0);
-void warnx(const char *fmt, ...) format_(printf, 1, 2);
-void vwarnx(const char *fmt, va_list ap) format_(printf, 1, 0);
+void warn(char const *fmt, ...) format_(printf, 1, 2);
+void vwarn(char const *fmt, va_list ap) format_(printf, 1, 0);
+void warnx(char const *fmt, ...) format_(printf, 1, 2);
+void vwarnx(char const *fmt, va_list ap) format_(printf, 1, 0);
 
-_Noreturn void err(int status, const char *fmt, ...) format_(printf, 2, 3);
-_Noreturn void verr(int status, const char *fmt, va_list ap) format_(printf, 2, 0);
-_Noreturn void errx(int status, const char *fmt, ...) format_(printf, 2, 3);
-_Noreturn void verrx(int status, const char *fmt, va_list ap) format_(printf, 2, 0);
+_Noreturn void err(int status, char const *fmt, ...) format_(printf, 2, 3);
+_Noreturn void verr(int status, char const *fmt, va_list ap) format_(printf, 2, 0);
+_Noreturn void errx(int status, char const *fmt, ...) format_(printf, 2, 3);
+_Noreturn void verrx(int status, char const *fmt, va_list ap) format_(printf, 2, 0);
 
 #endif /* ERR_IN_LIBC */
 

--- a/include/extern/getopt.h
+++ b/include/extern/getopt.h
@@ -30,13 +30,14 @@ extern char *musl_optarg;
 extern int musl_optind, musl_opterr, musl_optopt, musl_optreset;
 
 struct option {
-	const char *name;
+	char const *name;
 	int has_arg;
 	int *flag;
 	int val;
 };
 
-int musl_getopt_long_only(int, char **, const char *, const struct option *, int *);
+int musl_getopt_long_only(int argc, char **argv, char const *optstring,
+			  const struct option *longopts, int *idx);
 
 #define no_argument        0
 #define required_argument  1

--- a/include/version.h
+++ b/include/version.h
@@ -13,6 +13,6 @@
 #define PACKAGE_VERSION_MINOR 5
 #define PACKAGE_VERSION_PATCH 1
 
-const char *get_package_version_string(void);
+char const *get_package_version_string(void);
 
 #endif /* EXTERN_VERSION_H */

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -78,7 +78,7 @@ static void initNode(struct Charnode *node)
 	memset(node->next, 0, sizeof(node->next));
 }
 
-struct Charmap *charmap_New(const char *name, const char *baseName)
+struct Charmap *charmap_New(char const *name, char const *baseName)
 {
 	struct Charmap *base = NULL;
 
@@ -120,7 +120,7 @@ void charmap_Delete(struct Charmap *charmap)
 	free(charmap);
 }
 
-void charmap_Set(const char *name)
+void charmap_Set(char const *name)
 {
 	struct Charmap **charmap = (struct Charmap **)hash_GetNode(charmaps, name);
 

--- a/src/asm/fixpoint.c
+++ b/src/asm/fixpoint.c
@@ -46,7 +46,7 @@ int32_t fix_Callback_PI(void)
 void fix_Print(int32_t i)
 {
 	uint32_t u = i;
-	const char *sign = "";
+	char const *sign = "";
 
 	if (i < 0) {
 		u = -u;

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -45,7 +45,7 @@
 #ifdef __SANITIZE_ADDRESS__
 // There are known, non-trivial to fix leaks. We would still like to have `make develop'
 // detect memory corruption, though.
-const char *__asan_default_options(void) { return "detect_leaks=0"; }
+char const *__asan_default_options(void) { return "detect_leaks=0"; }
 #endif
 
 // Old Bison versions (confirmed for 2.3) do not forward-declare `yyparse` in the generated header
@@ -68,7 +68,7 @@ bool verbose;
 bool warnings; /* True to enable warnings, false to disable them. */
 
 /* Escapes Make-special chars from a string */
-static char *make_escape(const char *str)
+static char *make_escape(char const *str)
 {
 	char * const escaped_str = malloc(strlen(str) * 2 + 1);
 	char *dest = escaped_str;

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -72,7 +72,7 @@ static uint32_t str2int2(uint8_t *s, uint32_t length)
 	return r;
 }
 
-static char const *strrstr(char const *s1, char const *s2)
+static const char *strrstr(char const *s1, char const *s2)
 {
 	size_t len1 = strlen(s1);
 	size_t len2 = strlen(s2);

--- a/src/asm/section.c
+++ b/src/asm/section.c
@@ -110,7 +110,7 @@ attr_(warn_unused_result) static bool reserveSpace(uint32_t delta_size)
 		&& (!currentLoadSection || currentLoadSection->size != UINT32_MAX);
 }
 
-struct Section *sect_FindSectionByName(const char *name)
+struct Section *sect_FindSectionByName(char const *name)
 {
 	for (struct Section *sect = sectionList; sect; sect = sect->next) {
 		if (strcmp(name, sect->name) == 0)

--- a/src/asm/warning.c
+++ b/src/asm/warning.c
@@ -324,7 +324,7 @@ void processWarningFlag(char *flag)
 	warnx("Unknown warning `%s`", flag);
 }
 
-void printDiag(const char *fmt, va_list args, char const *type,
+void printDiag(char const *fmt, va_list args, char const *type,
 	       char const *flagfmt, char const *flag)
 {
 	fputs(type, stderr);
@@ -334,7 +334,7 @@ void printDiag(const char *fmt, va_list args, char const *type,
 	lexer_DumpStringExpansions();
 }
 
-void error(const char *fmt, ...)
+void error(char const *fmt, ...)
 {
 	va_list args;
 
@@ -344,7 +344,7 @@ void error(const char *fmt, ...)
 	nbErrors++;
 }
 
-_Noreturn void fatalerror(const char *fmt, ...)
+_Noreturn void fatalerror(char const *fmt, ...)
 {
 	va_list args;
 

--- a/src/extern/err.c
+++ b/src/extern/err.c
@@ -14,7 +14,7 @@
 
 #include "extern/err.h"
 
-void rgbds_vwarn(const char *fmt, va_list ap)
+void rgbds_vwarn(char const *fmt, va_list ap)
 {
 	fprintf(stderr, "warning: ");
 	if (fmt) {
@@ -24,7 +24,7 @@ void rgbds_vwarn(const char *fmt, va_list ap)
 	perror(NULL);
 }
 
-void rgbds_vwarnx(const char *fmt, va_list ap)
+void rgbds_vwarnx(char const *fmt, va_list ap)
 {
 	fprintf(stderr, "warning");
 	if (fmt) {
@@ -34,7 +34,7 @@ void rgbds_vwarnx(const char *fmt, va_list ap)
 	putc('\n', stderr);
 }
 
-_Noreturn void rgbds_verr(int status, const char *fmt, va_list ap)
+_Noreturn void rgbds_verr(int status, char const *fmt, va_list ap)
 {
 	fprintf(stderr, "error: ");
 	if (fmt) {
@@ -46,7 +46,7 @@ _Noreturn void rgbds_verr(int status, const char *fmt, va_list ap)
 	exit(status);
 }
 
-_Noreturn void rgbds_verrx(int status, const char *fmt, va_list ap)
+_Noreturn void rgbds_verrx(int status, char const *fmt, va_list ap)
 {
 	fprintf(stderr, "error");
 	if (fmt) {
@@ -57,7 +57,7 @@ _Noreturn void rgbds_verrx(int status, const char *fmt, va_list ap)
 	exit(status);
 }
 
-void rgbds_warn(const char *fmt, ...)
+void rgbds_warn(char const *fmt, ...)
 {
 	va_list ap;
 
@@ -66,7 +66,7 @@ void rgbds_warn(const char *fmt, ...)
 	va_end(ap);
 }
 
-void rgbds_warnx(const char *fmt, ...)
+void rgbds_warnx(char const *fmt, ...)
 {
 	va_list ap;
 
@@ -75,7 +75,7 @@ void rgbds_warnx(const char *fmt, ...)
 	va_end(ap);
 }
 
-_Noreturn void rgbds_err(int status, const char *fmt, ...)
+_Noreturn void rgbds_err(int status, char const *fmt, ...)
 {
 	va_list ap;
 
@@ -84,7 +84,7 @@ _Noreturn void rgbds_err(int status, const char *fmt, ...)
 	va_end(ap);
 }
 
-_Noreturn void rgbds_errx(int status, const char *fmt, ...)
+_Noreturn void rgbds_errx(int status, char const *fmt, ...)
 {
 	va_list ap;
 

--- a/src/extern/getopt.c
+++ b/src/extern/getopt.c
@@ -37,7 +37,7 @@ int musl_optind = 1, musl_opterr = 1, musl_optopt;
 int musl_optreset = 0;
 static int musl_optpos;
 
-static void musl_getopt_msg(const char *a, const char *b, const char *c, size_t l)
+static void musl_getopt_msg(char const *a, char const *b, char const *c, size_t l)
 {
 	FILE *f = stderr;
 
@@ -47,7 +47,7 @@ static void musl_getopt_msg(const char *a, const char *b, const char *c, size_t 
 		putc('\n', f);
 }
 
-static int getopt(int argc, char *argv[], const char *optstring)
+static int getopt(int argc, char *argv[], char const *optstring)
 {
 	int i;
 	wchar_t c, d;
@@ -140,9 +140,11 @@ static void permute(char **argv, int dest, int src)
 	argv[dest] = tmp;
 }
 
-static int musl_getopt_long_core(int argc, char **argv, const char *optstring, const struct option *longopts, int *idx, int longonly);
+static int musl_getopt_long_core(int argc, char **argv, char const *optstring,
+				 const struct option *longopts, int *idx, int longonly);
 
-static int musl_getopt_long(int argc, char **argv, const char *optstring, const struct option *longopts, int *idx, int longonly)
+static int musl_getopt_long(int argc, char **argv, char const *optstring,
+			    const struct option *longopts, int *idx, int longonly)
 {
 	int ret, skipped, resumed;
 
@@ -178,7 +180,8 @@ static int musl_getopt_long(int argc, char **argv, const char *optstring, const 
 	return ret;
 }
 
-static int musl_getopt_long_core(int argc, char **argv, const char *optstring, const struct option *longopts, int *idx, int longonly)
+static int musl_getopt_long_core(int argc, char **argv, char const *optstring,
+				 const struct option *longopts, int *idx, int longonly)
 {
 	musl_optarg = 0;
 	if (longopts && argv[musl_optind][0] == '-' &&
@@ -189,7 +192,7 @@ static int musl_getopt_long_core(int argc, char **argv, const char *optstring, c
 		char *arg = 0, *opt, *start = argv[musl_optind] + 1;
 
 		for (cnt = i = 0; longopts[i].name; i++) {
-			const char *name = longopts[i].name;
+			char const *name = longopts[i].name;
 
 			opt = start;
 			if (*opt == '-')
@@ -277,7 +280,8 @@ static int musl_getopt_long_core(int argc, char **argv, const char *optstring, c
 	return getopt(argc, argv, optstring);
 }
 
-int musl_getopt_long_only(int argc, char **argv, const char *optstring, const struct option *longopts, int *idx)
+int musl_getopt_long_only(int argc, char **argv, char const *optstring,
+			  const struct option *longopts, int *idx)
 {
 	return musl_getopt_long(argc, argv, optstring, longopts, idx, 1);
 }

--- a/src/fix/main.c
+++ b/src/fix/main.c
@@ -915,16 +915,16 @@ static void processFile(int input, int output, char const *name, off_t fileSize)
 	}
 
 	if (title)
-		overwriteBytes(rom0, 0x134, (const uint8_t *)title, titleLen, "title");
+		overwriteBytes(rom0, 0x134, (uint8_t const *)title, titleLen, "title");
 
 	if (gameID)
-		overwriteBytes(rom0, 0x13F, (const uint8_t *)gameID, gameIDLen, "manufacturer code");
+		overwriteBytes(rom0, 0x13F, (uint8_t const *)gameID, gameIDLen, "manufacturer code");
 
 	if (model != DMG)
 		overwriteByte(rom0, 0x143, model == BOTH ? 0x80 : 0xC0, "CGB flag");
 
 	if (newLicensee)
-		overwriteBytes(rom0, 0x144, (const uint8_t *)newLicensee, newLicenseeLen,
+		overwriteBytes(rom0, 0x144, (uint8_t const *)newLicensee, newLicenseeLen,
 			       "new licensee code");
 
 	if (sgb)

--- a/src/gfx/makepng.c
+++ b/src/gfx/makepng.c
@@ -182,7 +182,7 @@ static void read_png(struct PNGImage *img);
 static struct RawIndexedImage *create_raw_image(int width, int height,
 						int num_colors);
 static void set_raw_image_palette(struct RawIndexedImage *raw_image,
-				  const png_color *palette, int num_colors);
+				  png_color const *palette, int num_colors);
 
 static struct RawIndexedImage *indexed_png_to_raw(struct PNGImage *img)
 {
@@ -291,7 +291,7 @@ static void rgba_png_palette(struct PNGImage *img,
 			     png_color **palette_ptr_ptr, int *num_colors);
 static struct RawIndexedImage
 	*processed_rgba_png_to_raw(const struct PNGImage *img,
-				   const png_color *palette,
+				   png_color const *palette,
 				   int colors_in_palette);
 
 static struct RawIndexedImage *truecolor_png_to_raw(struct PNGImage *img)
@@ -352,7 +352,7 @@ static void rgba_PLTE_palette(struct PNGImage *img,
 }
 
 static void update_built_palette(png_color *palette,
-				 const png_color *pixel_color, png_byte alpha,
+				 png_color const *pixel_color, png_byte alpha,
 				 int *num_colors, bool *only_grayscale);
 static int fit_grayscale_palette(png_color *palette, int *num_colors);
 static void order_color_palette(png_color *palette, int num_colors);
@@ -398,7 +398,7 @@ static void rgba_build_palette(struct PNGImage *img,
 }
 
 static void update_built_palette(png_color *palette,
-				 const png_color *pixel_color, png_byte alpha,
+				 png_color const *pixel_color, png_byte alpha,
 				 int *num_colors, bool *only_grayscale)
 {
 	bool color_exists;
@@ -491,7 +491,7 @@ struct ColorWithLuminance {
 	int luminance;
 };
 
-static int compare_luminance(const void *a, const void *b)
+static int compare_luminance(void const *a, void const *b)
 {
 	const struct ColorWithLuminance *x, *y;
 
@@ -531,12 +531,12 @@ static void order_color_palette(png_color *palette, int num_colors)
 static void put_raw_image_pixel(struct RawIndexedImage *raw_image,
 				const struct PNGImage *img,
 				int *value_index, int x, int y,
-				const png_color *palette,
+				png_color const *palette,
 				int colors_in_palette);
 
 static struct RawIndexedImage
 	*processed_rgba_png_to_raw(const struct PNGImage *img,
-				   const png_color *palette,
+				   png_color const *palette,
 				   int colors_in_palette)
 {
 	struct RawIndexedImage *raw_image;
@@ -561,13 +561,13 @@ static struct RawIndexedImage
 	return raw_image;
 }
 
-static uint8_t palette_index_of(const png_color *palette,
-				int num_colors, const png_color *color);
+static uint8_t palette_index_of(png_color const *palette,
+				int num_colors, png_color const *color);
 
 static void put_raw_image_pixel(struct RawIndexedImage *raw_image,
 				const struct PNGImage *img,
 				int *value_index, int x, int y,
-				const png_color *palette,
+				png_color const *palette,
 				int colors_in_palette)
 {
 	png_color pixel_color;
@@ -588,8 +588,8 @@ static void put_raw_image_pixel(struct RawIndexedImage *raw_image,
 	}
 }
 
-static uint8_t palette_index_of(const png_color *palette,
-				int num_colors, const png_color *color)
+static uint8_t palette_index_of(png_color const *palette,
+				int num_colors, png_color const *color)
 {
 	uint8_t i;
 
@@ -660,7 +660,7 @@ static struct RawIndexedImage *create_raw_image(int width, int height,
 }
 
 static void set_raw_image_palette(struct RawIndexedImage *raw_image,
-				  const png_color *palette, int num_colors)
+				  png_color const *palette, int num_colors)
 {
 	int i;
 

--- a/src/version.c
+++ b/src/version.c
@@ -12,7 +12,7 @@
 #include "helpers.h"
 #include "version.h"
 
-const char *get_package_version_string(void)
+char const *get_package_version_string(void)
 {
 	// The following conditional should be simplified by the compiler.
 	if (strlen(BUILD_VERSION_STRING) == 0) {


### PR DESCRIPTION
Avoid "`WARNING: Move const after static - use 'static const char'`" too.