### PR TITLE
Deprecate `SET` in favor of `=`

### DIFF
--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -897,10 +897,11 @@ trailing_comma	: %empty | T_COMMA
 equ		: T_LABEL T_POP_EQU const { sym_AddEqu($1, $3); }
 ;
 
-set_or_equal	: T_POP_SET | T_POP_EQUAL
-;
-
-set		: T_LABEL set_or_equal const { sym_AddSet($1, $3); }
+set		: T_LABEL T_POP_EQUAL const { sym_AddSet($1, $3); }
+		| T_LABEL T_POP_SET const {
+			warning(WARNING_OBSOLETE, "`SET` is deprecated; use `=`\n");
+			sym_AddSet($1, $3);
+		}
 ;
 
 equs		: T_LABEL T_POP_EQUS string { sym_AddString($1, $3); }
@@ -1090,9 +1091,7 @@ rsset		: T_POP_RSSET uconst { sym_AddSet("_RS", $2); }
 rsreset		: T_POP_RSRESET { sym_AddSet("_RS", 0); }
 ;
 
-rs_uconst	: %empty {
-			$$ = 1;
-		}
+rs_uconst	: %empty { $$ = 1; }
 		| uconst
 ;
 
@@ -1138,20 +1137,20 @@ dl		: T_POP_DL { sect_Skip(4, false); }
 		| T_POP_DL constlist_32bit trailing_comma
 ;
 
-def_equ		: def_id T_POP_EQU const {
-			sym_AddEqu($1, $3);
-		}
+def_equ		: def_id T_POP_EQU const { sym_AddEqu($1, $3); }
 ;
 
-redef_equ	: redef_id T_POP_EQU const {
-			sym_RedefEqu($1, $3);
-		}
+redef_equ	: redef_id T_POP_EQU const { sym_RedefEqu($1, $3); }
 ;
 
-def_set		: def_id set_or_equal const {
+def_set		: def_id T_POP_EQUAL const { sym_AddSet($1, $3); }
+		| redef_id T_POP_EQUAL const { sym_AddSet($1, $3); }
+		| def_id T_POP_SET const {
+			warning(WARNING_OBSOLETE, "`SET` is deprecated; use `=`\n");
 			sym_AddSet($1, $3);
 		}
-		| redef_id set_or_equal const {
+		| redef_id T_POP_SET const {
+			warning(WARNING_OBSOLETE, "`SET` is deprecated; use `=`\n");
 			sym_AddSet($1, $3);
 		}
 ;
@@ -1174,14 +1173,10 @@ def_rl		: def_id T_Z80_RL rs_uconst {
 		}
 ;
 
-def_equs	: def_id T_POP_EQUS string {
-			sym_AddString($1, $3);
-		}
+def_equs	: def_id T_POP_EQUS string { sym_AddString($1, $3); }
 ;
 
-redef_equs	: redef_id T_POP_EQUS string {
-			sym_RedefString($1, $3);
-		}
+redef_equs	: redef_id T_POP_EQUS string { sym_RedefString($1, $3); }
 ;
 
 purge		: T_POP_PURGE {

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -101,7 +101,7 @@ of string equates:
 .Ql name
 will be expanded in all of
 .Ql DEF({name}) ,
-.Ql DEF {name} EQU/SET/EQUS/etc ... ,
+.Ql DEF {name} EQU/=/EQUS/etc ... ,
 .Ql PURGE {name} ,
 and
 .Ql MACRO {name} ,
@@ -987,7 +987,7 @@ and so on.
 .Ic EQU
 is used to define numerical constant symbols.
 Unlike
-.Ic SET
+.Ic =
 below, constants defined this way cannot be redefined.
 These constants can be used for unchanging values such as properties of the hardware.
 .Bd -literal -offset indent
@@ -1019,18 +1019,16 @@ ENDM
     assert ITEM_04 == 16
 .Ed
 .Ss Mutable constants
-.Ic SET ,
-or its synonym
-.Ic = ,
+.Ic =
 is used to define numerical symbols like
 .Ic EQU ,
 but these symbols can be redefined.
 This is useful for variables in macros, for counters, etc.
 .Bd -literal -offset indent
 DEF ARRAY_SIZE EQU 4
-DEF   COUNT SET 2
-DEF   COUNT SET 3
-REDEF COUNT SET ARRAY_SIZE+COUNT
+DEF COUNT = 2
+DEF COUNT = 3
+REDEF COUNT = ARRAY_SIZE + COUNT
 COUNT = COUNT*2
 ;\ COUNT now has the value 14
 .Ed
@@ -1085,7 +1083,7 @@ If you are familiar with C, you can think of it as similar to
 .Fd #define .
 This expansion is disabled in a few contexts:
 .Ql DEF(name) ,
-.Ql DEF name EQU/SET/EQUS/etc ... ,
+.Ql DEF name EQU/=/EQUS/etc ... ,
 .Ql PURGE name ,
 and
 .Ql MACRO name
@@ -1149,8 +1147,6 @@ which calls the same macro, which causes the same problem.
 .Pp
 The examples above for
 .Ql EQU ,
-.Ql SET
-or
 .Ql = ,
 .Ql RB ,
 .Ql RW ,
@@ -1159,9 +1155,7 @@ and
 .Ql EQUS
 all start with
 .Ql DEF .
-(A
-.Ql SET
-or
+(An
 .Ql =
 definition may start with
 .Ql REDEF
@@ -1316,7 +1310,7 @@ The following symbols are defined by the assembler:
 .Bl -column -offset indent "EQUS" "__ISO_8601_LOCAL__"
 .It Sy Name Ta Sy Type Ta Sy Contents
 .It Dv @ Ta Ic EQU Ta PC value (essentially, the current memory address)
-.It Dv _RS Ta Ic SET Ta _RS Counter
+.It Dv _RS Ta Ic = Ta _RS Counter
 .It Dv _NARG Ta Ic EQU Ta Number of arguments passed to macro, updated by Ic SHIFT
 .It Dv __LINE__ Ta Ic EQU Ta The current line number
 .It Dv __FILE__ Ta Ic EQUS Ta The current filename

--- a/test/asm/def.asm
+++ b/test/asm/def.asm
@@ -1,10 +1,10 @@
 def variable = 1
 	println variable
-def variable set 2
+def variable = 2
 	println variable
 redef variable = 3
 	println variable
-redef variable set 4
+redef variable = 4
 	println variable
 
 DEF constant EQU 42

--- a/test/asm/symbol-override.asm
+++ b/test/asm/symbol-override.asm
@@ -1,14 +1,14 @@
-V set 0
-V set 1
+V = 0
+V = 1
     PRINTLN "V={V}"
 
 W equ 1
-W set 0
+W = 0
 
 rsset 1
 X rb 0
-X set 0
+X = 0
 
 SECTION "Test", ROM0[1]
 Y:
-Y set 0
+Y = 0

--- a/test/link/all-instructions.asm
+++ b/test/link/all-instructions.asm
@@ -57,7 +57,7 @@ ENDM
     ; Bit Operations Instructions
 
 bitop_u3_instruction_list: MACRO
-NBIT SET 0
+NBIT = 0
     REPT 8
         \1 NBIT,a
         \1 NBIT,b
@@ -67,7 +67,7 @@ NBIT SET 0
         \1 NBIT,h
         \1 NBIT,[hl]
         \1 NBIT,l
-NBIT SET NBIT + 1
+NBIT = NBIT + 1
     ENDR
 ENDM
 


### PR DESCRIPTION
`SET` is redundant with `=`, and is already the name of an instruction.