### PR TITLE
Add `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,94 @@
+AccessModifierOffset: -1 # Tabs, yes; spaces, no
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: Consecutive
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - format_
+  - attr_
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Attach
+BreakBeforeConceptDeclarations: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: AfterComma
+BreakStringLiterals: true
+ColumnLimit: 100
+CompactNamespaces: false
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+EmptyLineBeforeAccessModifier: Leave
+FixNamespaceComments: false
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^<sys/'
+  - Regex: '^<'
+  - Regex: '^"(asm|link|fix|gfx)/'
+  - Regex: '^"extern/'
+  - Regex: '^"'
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: NoIndent
+IndentGotoLabels: false
+IndentPPDirectives: BeforeHash
+IndentRequires: true
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+# Only support for Javascript as of clang-format 13...
+# InsertTrailingCommas: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+Language: Cpp
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PPIndentWidth: -1
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: CaseSensitive
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Both
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++20
+TabWidth: 4
+UseCRLF: false
+UseTab: AlignWithSpaces

--- a/README.rst
+++ b/README.rst
@@ -73,9 +73,13 @@ The RGBDS source code file structure somewhat resembles the following:
        ├── test/
        │   ├── ...
        │   └── run-tests.sh
+       ├── .clang-format
        ├── CMakeLists.txt
        ├── Makefile
        └── README.rst
+
+.. |clang-format| replace:: ``clang-format``
+.. _clang-format: https://clang.llvm.org/docs/ClangFormat.html
 
 - ``.github/`` - files and scripts related to the integration of the RGBDS codebase with
   GitHub.
@@ -98,6 +102,8 @@ The RGBDS source code file structure somewhat resembles the following:
     (rgbasm -> ``src/asm/``, for example). ``src/extern/`` contains code imported from external sources.
 
 - ``test/`` - testing framework used to verify that changes to the code don't break or modify the behavior of RGBDS.
+
+- ``.clang-format`` - code style for automated formatting with |clang-format|_. The C code does not currently follow this style, but all C++ code should.
 
 3. History
 ----------


### PR DESCRIPTION
Should not be followed for existing C files, to avoid mucking `blame`s, but will be applied during the gradual C++ rollout, since that will likely touch most lines in the codebase anyway.

Fixes #612.