### PR TITLE
Better shebangs

### DIFF
--- a/src/check_bison_ver.sh
+++ b/src/check_bison_ver.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 bison -V | awk -v major="$1" -v minor="$2" '
 /^bison.*[0-9]+(\.[0-9]+)(\.[0-9]+)?$/ {
 	match($0, /[0-9]+(\.[0-9]+)(\.[0-9]+)?$/);

--- a/test/asm/test.sh
+++ b/test/asm/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 export LC_ALL=C
 

--- a/test/asm/update-refs.sh
+++ b/test/asm/update-refs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 fname=$(mktemp)
 
 for i in *.asm; do


### PR DESCRIPTION
Unless there is a reason to believe those scripts will keep being posix-compliant (in which case we should change the *other* shebangs to be `/bin/sh`), this commit will make code more consistent