### PR TITLE
Do not skip last bank when relying on overlay feature (fixes #993)

### DIFF
--- a/src/link/output.c
+++ b/src/link/output.c
@@ -247,7 +247,7 @@ static void writeROM(void)
 			writeBank(sections[SECTTYPE_ROM0].banks[0].sections,
 				  startaddr[SECTTYPE_ROM0], maxsize[SECTTYPE_ROM0]);
 
-		for (uint32_t i = 0 ; i < sections[SECTTYPE_ROMX].nbBanks; i++)
+		for (uint32_t i = 0; i <= sections[SECTTYPE_ROMX].nbBanks; i++)
 			writeBank(sections[SECTTYPE_ROMX].banks[i].sections,
 				  startaddr[SECTTYPE_ROMX], maxsize[SECTTYPE_ROMX]);
 	}


### PR DESCRIPTION
I believe this resolves #993, but I may have misunderstood something.

The issue seems to have stemmed from a simple off-by-one when writing the data to the output file (as the data is already there).

This does resolve the issue on my end.