### PR TITLE
Update scramble to specially handle >8-bit banks

### DIFF
--- a/src/link/assign.c
+++ b/src/link/assign.c
@@ -129,7 +129,12 @@ static struct FreeSpace *getPlacement(struct Section const *section,
 	if (section->isBankFixed) {
 		location->bank = section->bank;
 	} else if (scrambleROMX && section->type == SECTTYPE_ROMX) {
-		location->bank = curScrambleROM++;
+		if (scrambleROMX > 255) {
+			location->bank = (curScrambleROM + 1) / 2 + !(curScrambleROM % 2) * 255;
+			curScrambleROM++;
+		} else {
+			location->bank = curScrambleROM++;
+		}
 		if (curScrambleROM > scrambleROMX)
 			curScrambleROM = 1;
 	} else if (scrambleWRAMX && section->type == SECTTYPE_WRAMX) {

--- a/src/link/assign.c
+++ b/src/link/assign.c
@@ -130,6 +130,7 @@ static struct FreeSpace *getPlacement(struct Section const *section,
 		location->bank = section->bank;
 	} else if (scrambleROMX && section->type == SECTTYPE_ROMX) {
 		if (scrambleROMX > 255) {
+			// alternate between low and high banks: $01, $100, $02, $101, $03, $102, ...
 			location->bank = (curScrambleROM + 1) / 2 + !(curScrambleROM % 2) * 255;
 			curScrambleROM++;
 		} else {


### PR DESCRIPTION
I realized that scramble could be made more useful for 9-bit banks if it alternated between setting the 9th bit; now *both* bytes are scrambled.