### PR TITLE
More options for .map file output

### DIFF
--- a/contrib/bash_compl/_rgblink.bash
+++ b/contrib/bash_compl/_rgblink.bash
@@ -14,6 +14,7 @@ _rgblink_completions() {
 		[w]="wramx:normal"
 		[x]="nopad:normal"
 		[l]="linkerscript:glob-*"
+		[M]="no-sym-in-map:normal"
 		[m]="map:glob-*.map"
 		[n]="sym:glob-*.sym"
 		[O]="overlay:glob-*.gb *.gbc *.sgb"

--- a/contrib/zsh_compl/_rgblink
+++ b/contrib/zsh_compl/_rgblink
@@ -11,6 +11,7 @@ local args=(
 	'(-x --nopad)'{-x,--nopad}'[Disable padding the end of the final file]'
 
 	'(-l --linkerscript)'{-l,--linkerscript}"+[Use a linker script]:linker script:_files -g '*.link'"
+	'(-M --no-sym-in-map)'{-M,--no-sym-in-map}'[Do not output symbol names in map file]'
 	'(-m --map)'{-m,--map}"+[Produce a map file]:map file:_files -g '*.map'"
 	'(-n --sym)'(-n,--sym)"+[Produce a symbol file]:sym file:_files -g '*.sym'"
 	'(-O --overlay)'{-O,--overlay}'+[Overlay sections over on top of bin file]:base overlay:_files'

--- a/include/link/main.h
+++ b/include/link/main.h
@@ -20,6 +20,7 @@
 extern bool isDmgMode;
 extern char       *linkerScriptName;
 extern char const *mapFileName;
+extern bool noSymInMap;
 extern char const *symFileName;
 extern char const *overlayFileName;
 extern char const *outputFileName;

--- a/man/rgblink.1
+++ b/man/rgblink.1
@@ -13,7 +13,7 @@
 .Nd Game Boy linker
 .Sh SYNOPSIS
 .Nm
-.Op Fl dtVvwx
+.Op Fl dMtVvwx
 .Op Fl l Ar linker_script
 .Op Fl m Ar map_file
 .Op Fl n Ar sym_file
@@ -73,6 +73,8 @@ The attributes assigned in the linker script must be consistent with any assigne
 See
 .Xr rgblink 5
 for more information about the linker script format.
+.It Fl M , Fl Fl no-sym-in-map
+If specified, the map file will not list symbols, only sections.
 .It Fl m Ar map_file , Fl Fl map Ar map_file
 Write a map file to the given filename, listing how sections and symbols were assigned.
 .It Fl n Ar sym_file , Fl Fl sym Ar sym_file

--- a/src/link/main.c
+++ b/src/link/main.c
@@ -36,6 +36,7 @@
 bool isDmgMode;               /* -d */
 char       *linkerScriptName; /* -l */
 char const *mapFileName;      /* -m */
+bool noSymInMap;              /* -M */
 char const *symFileName;      /* -n */
 char const *overlayFileName;  /* -O */
 char const *outputFileName;   /* -o */
@@ -165,7 +166,7 @@ FILE *openFile(char const *fileName, char const *mode)
 }
 
 /* Short options */
-static const char *optstring = "dl:m:n:O:o:p:S:s:tVvWwx";
+static const char *optstring = "dl:m:Mn:O:o:p:S:s:tVvWwx";
 
 /*
  * Equivalent long options
@@ -181,6 +182,7 @@ static struct option const longopts[] = {
 	{ "dmg",           no_argument,       NULL, 'd' },
 	{ "linkerscript",  required_argument, NULL, 'l' },
 	{ "map",           required_argument, NULL, 'm' },
+	{ "no-sym-in-map", no_argument,       NULL, 'M' },
 	{ "sym",           required_argument, NULL, 'n' },
 	{ "overlay",       required_argument, NULL, 'O' },
 	{ "output",        required_argument, NULL, 'o' },
@@ -201,7 +203,7 @@ static struct option const longopts[] = {
 static void printUsage(void)
 {
 	fputs(
-"Usage: rgblink [-dtVvwx] [-l script] [-m map_file] [-n sym_file]\n"
+"Usage: rgblink [-dMtVvwx] [-l script] [-m map_file] [-n sym_file]\n"
 "               [-O overlay_file] [-o out_file] [-p pad_value]\n"
 "               [-S spec] [-s symbol] <file> ...\n"
 "Useful options:\n"
@@ -373,6 +375,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'l':
 			linkerScriptName = musl_optarg;
+			break;
+		case 'M':
+			noSymInMap = true;
 			break;
 		case 'm':
 			mapFileName = musl_optarg;

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -438,7 +438,7 @@ static uint16_t writeMapBank(struct SortedSections const *sectList,
 	} else {
 		uint16_t slack = sectionTypeInfo[type].size - used;
 
-		fprintf(mapFile, "    SLACK: $%04" PRIx16 " byte%s\n\n", slack,
+		fprintf(mapFile, "  SLACK: $%04" PRIx16 " byte%s\n\n", slack,
 			slack == 1 ? "" : "s");
 	}
 

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -394,16 +394,21 @@ static uint16_t writeMapBank(struct SortedSections const *sectList,
 			fprintf(mapFile, "  SECTION: $%04" PRIx16 " (0 bytes) [\"%s\"]\n",
 				sect->org, sect->name);
 
-		uint16_t org = sect->org;
+		if (!noSymInMap) {
+			uint16_t org = sect->org;
 
-		while (sect) {
-			fprintf(mapFile, "    ; New %s\n", sect->modifier == SECTION_FRAGMENT ? "fragment": "union");
-			for (size_t i = 0; i < sect->nbSymbols; i++)
-				fprintf(mapFile, "           $%04" PRIx32 " = %s\n",
-					sect->symbols[i]->offset + org,
-					sect->symbols[i]->name);
+			while (sect) {
+				if (sect->modifier == SECTION_UNION)
+					fprintf(mapFile, "    ; New union\n");
+				else if (sect->modifier == SECTION_FRAGMENT)
+					fprintf(mapFile, "    ; New fragment\n");
+				for (size_t i = 0; i < sect->nbSymbols; i++)
+					fprintf(mapFile, "           $%04" PRIx32 " = %s\n",
+						sect->symbols[i]->offset + org,
+						sect->symbols[i]->name);
 
-			sect = sect->nextu; // Also print symbols in the following "pieces"
+				sect = sect->nextu; // Also print symbols in the following "pieces"
+			}
 		}
 
 		*pickedSection = (*pickedSection)->next;


### PR DESCRIPTION
Fixes #983

- `rgblink -M` omits symbol names from the .map file, making it easier to browse the section names and sizes
- `EMPTY` space is printed between sections, in addition to the total `SLACK` space of each bank
- `SLACK` is indented at the same level as the `SECTION` headers, since it summarizes all of them and applies to the `bank` under which it's indented (currently it looks like it applies to the final `SECTION`)
- This also fixes printing "`; New union`" even for non-union sections

The two commits are independent, so no need to squash them.