### PR TITLE
Test that `OPT r` fails immediately if the recursion depth is already exceeded

### DIFF
--- a/test/asm/opt-r-decrease.asm
+++ b/test/asm/opt-r-decrease.asm
@@ -1,0 +1,11 @@
+MACRO m
+  DEF depth += 1
+  IF depth == 10
+    OPT r9
+  ENDC
+  println "at depth {d:depth}"
+  m
+ENDM
+
+  DEF depth = 0
+  m

--- a/test/asm/opt-r-decrease.err
+++ b/test/asm/opt-r-decrease.err
@@ -1,0 +1,2 @@
+FATAL: opt-r-decrease.asm(11) -> opt-r-decrease.asm::m(7) -> opt-r-decrease.asm::m(7) -> opt-r-decrease.asm::m(7) -> opt-r-decrease.asm::m(7) -> opt-r-decrease.asm::m(7) -> opt-r-decrease.asm::m(7) -> opt-r-decrease.asm::m(7) -> opt-r-decrease.asm::m(7) -> opt-r-decrease.asm::m(7) -> opt-r-decrease.asm::m(4):
+    Recursion limit (9) exceeded

--- a/test/asm/opt-r-decrease.out
+++ b/test/asm/opt-r-decrease.out
@@ -1,0 +1,9 @@
+at depth 1
+at depth 2
+at depth 3
+at depth 4
+at depth 5
+at depth 6
+at depth 7
+at depth 8
+at depth 9


### PR DESCRIPTION
Fixes #1034