### PR TITLE
Make comments more consistent

### DIFF
--- a/include/asm/charmap.h
+++ b/include/asm/charmap.h
@@ -20,4 +20,4 @@ void charmap_Add(char *mapping, uint8_t value);
 size_t charmap_Convert(char const *input, uint8_t *output);
 size_t charmap_ConvertNext(char const **input, uint8_t **output);
 
-#endif /* RGBDS_ASM_CHARMAP_H */
+#endif // RGBDS_ASM_CHARMAP_H

--- a/include/asm/fixpoint.h
+++ b/include/asm/fixpoint.h
@@ -28,4 +28,4 @@ int32_t fix_Round(int32_t i);
 int32_t fix_Ceil(int32_t i);
 int32_t fix_Floor(int32_t i);
 
-#endif /* RGBDS_ASM_FIXPOINT_H */
+#endif // RGBDS_ASM_FIXPOINT_H

--- a/include/asm/format.h
+++ b/include/asm/format.h
@@ -60,4 +60,4 @@ void fmt_FinishCharacters(struct FormatSpec *fmt);
 void fmt_PrintString(char *buf, size_t bufLen, struct FormatSpec const *fmt, char const *value);
 void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uint32_t value);
 
-#endif /* RGBDS_FORMAT_SPEC_H */
+#endif // RGBDS_FORMAT_SPEC_H

--- a/include/asm/fstack.h
+++ b/include/asm/fstack.h
@@ -6,9 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/*
- * Contains some assembler-wide defines and externs
- */
+// Contains some assembler-wide defines and externs
 
 #ifndef RGBDS_ASM_FSTACK_H
 #define RGBDS_ASM_FSTACK_H
@@ -21,13 +19,13 @@
 
 
 struct FileStackNode {
-	struct FileStackNode *parent; /* Pointer to parent node, for error reporting */
-	/* Line at which the parent context was exited; meaningless for the root level */
+	struct FileStackNode *parent; // Pointer to parent node, for error reporting
+	// Line at which the parent context was exited; meaningless for the root level
 	uint32_t lineNo;
 
-	struct FileStackNode *next; /* Next node in the output linked list */
-	bool referenced; /* If referenced, don't free! */
-	uint32_t ID; /* Set only if referenced: ID within the object file, -1 if not output yet */
+	struct FileStackNode *next; // Next node in the output linked list
+	bool referenced; // If referenced, don't free!
+	uint32_t ID; // Set only if referenced: ID within the object file, -1 if not output yet
 
 	enum {
 		NODE_REPT,
@@ -36,16 +34,16 @@ struct FileStackNode {
 	} type;
 };
 
-struct FileStackReptNode { /* NODE_REPT */
+struct FileStackReptNode { // NODE_REPT
 	struct FileStackNode node;
 	uint32_t reptDepth;
-	/* WARNING: if changing this type, change overflow check in `fstk_Init` */
-	uint32_t iters[]; /* REPT iteration counts since last named node, in reverse depth order */
+	// WARNING: if changing this type, change overflow check in `fstk_Init`
+	uint32_t iters[]; // REPT iteration counts since last named node, in reverse depth order
 };
 
-struct FileStackNamedNode { /* NODE_FILE, NODE_MACRO */
+struct FileStackNamedNode { // NODE_FILE, NODE_MACRO
 	struct FileStackNode node;
-	char name[]; /* File name for files, file::macro name for macros */
+	char name[]; // File name for files, file::macro name for macros
 };
 
 #define DEFAULT_MAX_DEPTH 64
@@ -56,11 +54,11 @@ struct MacroArgs;
 void fstk_Dump(struct FileStackNode const *node, uint32_t lineNo);
 void fstk_DumpCurrent(void);
 struct FileStackNode *fstk_GetFileStack(void);
-/* The lifetime of the returned chars is until reaching the end of that file */
+// The lifetime of the returned chars is until reaching the end of that file
 char const *fstk_GetFileName(void);
 
 void fstk_AddIncludePath(char const *s);
-/**
+/*
  * @param path The user-provided file name
  * @param fullPath The address of a pointer, which will be made to point at the full path
  *                 The pointer's value must be a valid argument to `realloc`, including NULL
@@ -81,4 +79,4 @@ bool fstk_Break(void);
 void fstk_NewRecursionDepth(size_t newDepth);
 void fstk_Init(char const *mainPath, size_t maxDepth);
 
-#endif /* RGBDS_ASM_FSTACK_H */
+#endif // RGBDS_ASM_FSTACK_H

--- a/include/asm/lexer.h
+++ b/include/asm/lexer.h
@@ -11,7 +11,7 @@
 
 #include <stdbool.h>
 
-#define MAXSTRLEN	255
+#define MAXSTRLEN 255
 
 struct LexerState;
 extern struct LexerState *lexerState;
@@ -49,9 +49,7 @@ static inline void lexer_SetGfxDigits(char const digits[4])
 	gfxDigits[3] = digits[3];
 }
 
-/*
- * `path` is referenced, but not held onto..!
- */
+// `path` is referenced, but not held onto..!
 struct LexerState *lexer_OpenFile(char const *path);
 struct LexerState *lexer_OpenFileView(char const *path, char *buf, size_t size, uint32_t lineNo);
 void lexer_RestartRept(uint32_t lineNo);
@@ -99,4 +97,4 @@ struct DsArgList {
 	struct Expression *args;
 };
 
-#endif /* RGBDS_ASM_LEXER_H */
+#endif // RGBDS_ASM_LEXER_H

--- a/include/asm/macro.h
+++ b/include/asm/macro.h
@@ -34,4 +34,4 @@ uint32_t macro_UseNewUniqueID(void);
 void macro_ShiftCurrentArgs(int32_t count);
 uint32_t macro_NbArgs(void);
 
-#endif
+#endif // RGBDS_MACRO_H

--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -20,7 +20,7 @@ extern bool warnOnHaltNop;
 extern bool optimizeLoads;
 extern bool warnOnLdOpt;
 extern bool verbose;
-extern bool warnings; /* True to enable warnings, false to disable them. */
+extern bool warnings; // True to enable warnings, false to disable them.
 
 extern FILE *dependfile;
 extern char *targetFileName;
@@ -28,4 +28,4 @@ extern bool generatedMissingIncludes;
 extern bool failedOnMissingInclude;
 extern bool generatePhonyDeps;
 
-#endif /* RGBDS_MAIN_H */
+#endif // RGBDS_MAIN_H

--- a/include/asm/opt.h
+++ b/include/asm/opt.h
@@ -22,4 +22,4 @@ void opt_Parse(char const *option);
 void opt_Push(void);
 void opt_Pop(void);
 
-#endif
+#endif // RGBDS_OPT_H

--- a/include/asm/output.h
+++ b/include/asm/output.h
@@ -27,4 +27,4 @@ bool out_CreateAssert(enum AssertionType type, struct Expression const *expr,
 		      char const *message, uint32_t ofs);
 void out_WriteObject(void);
 
-#endif /* RGBDS_ASM_OUTPUT_H */
+#endif // RGBDS_ASM_OUTPUT_H

--- a/include/asm/rpn.h
+++ b/include/asm/rpn.h
@@ -27,17 +27,13 @@ struct Expression {
 	uint32_t rpnPatchSize; // Size the expression will take in the object file
 };
 
-/*
- * Determines if an expression is known at assembly time
- */
+// Determines if an expression is known at assembly time
 static inline bool rpn_isKnown(struct Expression const *expr)
 {
 	return expr->isKnown;
 }
 
-/*
- * Determines if an expression is a symbol suitable for const diffing
- */
+// Determines if an expression is a symbol suitable for const diffing
 static inline bool rpn_isSymbol(const struct Expression *expr)
 {
 	return expr->isSymbol;
@@ -67,4 +63,4 @@ void rpn_CheckRST(struct Expression *expr, const struct Expression *src);
 void rpn_CheckNBit(struct Expression const *expr, uint8_t n);
 int32_t rpn_GetConstVal(struct Expression const *expr);
 
-#endif /* RGBDS_ASM_RPN_H */
+#endif // RGBDS_ASM_RPN_H

--- a/include/asm/section.h
+++ b/include/asm/section.h
@@ -23,8 +23,8 @@ struct Section {
 	char *name;
 	enum SectionType type;
 	enum SectionModifier modifier;
-	struct FileStackNode *src; /* Where the section was defined */
-	uint32_t fileLine; /* Line where the section was defined */
+	struct FileStackNode *src; // Where the section was defined
+	uint32_t fileLine; // Line where the section was defined
 	uint32_t size;
 	uint32_t org;
 	uint32_t bank;
@@ -79,4 +79,4 @@ void sect_PopSection(void);
 
 bool sect_IsSizeKnown(struct Section const NONNULL(name));
 
-#endif
+#endif // RGBDS_SECTION_H

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -32,28 +32,28 @@ enum SymbolType {
 struct Symbol {
 	char name[MAXSYMLEN + 1];
 	enum SymbolType type;
-	bool isExported; /* Whether the symbol is to be exported */
-	bool isBuiltin;  /* Whether the symbol is a built-in */
+	bool isExported; // Whether the symbol is to be exported
+	bool isBuiltin;  // Whether the symbol is a built-in
 	struct Section *section;
-	struct FileStackNode *src; /* Where the symbol was defined */
-	uint32_t fileLine; /* Line where the symbol was defined */
+	struct FileStackNode *src; // Where the symbol was defined
+	uint32_t fileLine; // Line where the symbol was defined
 
 	bool hasCallback;
 	union {
-		/* If sym_IsNumeric */
+		// If sym_IsNumeric
 		int32_t value;
 		int32_t (*numCallback)(void);
-		/* For SYM_MACRO and SYM_EQUS; TODO: have separate fields */
+		// For SYM_MACRO and SYM_EQUS; TODO: have separate fields
 		struct {
 			size_t macroSize;
 			char *macro;
 		};
-		/* For SYM_EQUS */
+		// For SYM_EQUS
 		char const *(*strCallback)(void);
 	};
 
-	uint32_t ID; /* ID of the symbol in the object file (-1 if none) */
-	struct Symbol *next; /* Next object to output in the object file */
+	uint32_t ID; // ID of the symbol in the object file (-1 if none)
+	struct Symbol *next; // Next object to output in the object file
 };
 
 bool sym_IsPC(struct Symbol const *sym);
@@ -98,9 +98,7 @@ static inline bool sym_IsExported(struct Symbol const *sym)
 	return sym->isExported;
 }
 
-/*
- * Get a string equate's value
- */
+// Get a string equate's value
 static inline char const *sym_GetStringValue(struct Symbol const *sym)
 {
 	if (sym->hasCallback)
@@ -123,17 +121,11 @@ struct Symbol *sym_AddVar(char const *symName, int32_t value);
 uint32_t sym_GetPCValue(void);
 uint32_t sym_GetConstantSymValue(struct Symbol const *sym);
 uint32_t sym_GetConstantValue(char const *symName);
-/*
- * Find a symbol by exact name, bypassing expansion checks
- */
+// Find a symbol by exact name, bypassing expansion checks
 struct Symbol *sym_FindExactSymbol(char const *symName);
-/*
- * Find a symbol by exact name; may not be scoped, produces an error if it is
- */
+// Find a symbol by exact name; may not be scoped, produces an error if it is
 struct Symbol *sym_FindUnscopedSymbol(char const *symName);
-/*
- * Find a symbol, possibly scoped, by name
- */
+// Find a symbol, possibly scoped, by name
 struct Symbol *sym_FindScopedSymbol(char const *symName);
 struct Symbol const *sym_GetPC(void);
 struct Symbol *sym_AddMacro(char const *symName, int32_t defLineNo, char *body, size_t size);
@@ -143,8 +135,8 @@ struct Symbol *sym_RedefString(char const *symName, char const *value);
 void sym_Purge(char const *symName);
 void sym_Init(time_t now);
 
-/* Functions to save and restore the current symbol scope. */
+// Functions to save and restore the current symbol scope.
 char const *sym_GetCurrentSymbolScope(void);
 void sym_SetCurrentSymbolScope(char const *newScope);
 
-#endif /* RGBDS_SYMBOL_H */
+#endif // RGBDS_SYMBOL_H

--- a/include/asm/util.h
+++ b/include/asm/util.h
@@ -18,4 +18,4 @@ char const *printChar(int c);
  */
 size_t readUTF8Char(uint8_t *dest, char const *src);
 
-#endif /* RGBDS_UTIL_H */
+#endif // RGBDS_UTIL_H

--- a/include/asm/warning.h
+++ b/include/asm/warning.h
@@ -91,4 +91,4 @@ _Noreturn void fatalerror(char const *fmt, ...) format_(printf, 1, 2);
  */
 void error(char const *fmt, ...) format_(printf, 1, 2);
 
-#endif
+#endif // WARNING_H

--- a/include/defaultinitalloc.hpp
+++ b/include/defaultinitalloc.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Allocator adaptor that interposes construct() calls to convert value-initialization
  * (which is what you get with e.g. `vector::resize`) into default-initialization (which does not
  * zero out non-class types).
@@ -36,4 +36,4 @@ public:
 template<typename T>
 using DefaultInitVec = std::vector<T, default_init_allocator<T>>;
 
-#endif
+#endif // DEFAULT_INIT_ALLOC_H

--- a/include/error.h
+++ b/include/error.h
@@ -26,4 +26,4 @@ _Noreturn void errx(char const NONNULL(fmt), ...) format_(printf, 1, 2);
 }
 #endif
 
-#endif /* RGBDS_ERROR_H */
+#endif // RGBDS_ERROR_H

--- a/include/extern/utf8decoder.h
+++ b/include/extern/utf8decoder.h
@@ -11,4 +11,4 @@
 
 uint32_t decode(uint32_t *state, uint32_t *codep, uint8_t byte);
 
-#endif /* EXTERN_UTF8DECODER_H */
+#endif // EXTERN_UTF8DECODER_H

--- a/include/gfx/main.hpp
+++ b/include/gfx/main.hpp
@@ -71,19 +71,19 @@ struct Options {
 
 extern Options options;
 
-/**
+/*
  * Prints the error count, and exits with failure
  */
 [[noreturn]] void giveUp();
-/**
+/*
  * Prints a warning, and does not change the error count
  */
 void warning(char const *fmt, ...);
-/**
+/*
  * Prints an error, and increments the error count
  */
 void error(char const *fmt, ...);
-/**
+/*
  * Prints a fatal error, increments the error count, and gives up
  */
 [[noreturn]] void fatal(char const *fmt, ...);
@@ -120,4 +120,4 @@ static constexpr auto flipTable(std::integer_sequence<T, i...>) {
 // Flipping tends to happen fairly often, so take a bite out of dcache to speed it up
 static constexpr auto flipTable = detail::flipTable(std::make_integer_sequence<uint16_t, 256>());
 
-#endif /* RGBDS_GFX_MAIN_HPP */
+#endif // RGBDS_GFX_MAIN_HPP

--- a/include/gfx/pal_packing.hpp
+++ b/include/gfx/pal_packing.hpp
@@ -21,7 +21,7 @@ class ProtoPalette;
 
 namespace packing {
 
-/**
+/*
  * Returns which palette each proto-palette maps to, and how many palettes are necessary
  */
 std::tuple<DefaultInitVec<size_t>, size_t>
@@ -29,4 +29,4 @@ std::tuple<DefaultInitVec<size_t>, size_t>
 
 }
 
-#endif /* RGBDS_GFX_PAL_PACKING_HPP */
+#endif // RGBDS_GFX_PAL_PACKING_HPP

--- a/include/gfx/pal_sorting.hpp
+++ b/include/gfx/pal_sorting.hpp
@@ -29,4 +29,4 @@ void rgb(std::vector<Palette> &palettes);
 
 }
 
-#endif /* RGBDS_GFX_PAL_SORTING_HPP */
+#endif // RGBDS_GFX_PAL_SORTING_HPP

--- a/include/gfx/pal_spec.hpp
+++ b/include/gfx/pal_spec.hpp
@@ -12,4 +12,4 @@
 void parseInlinePalSpec(char const * const arg);
 void parseExternalPalSpec(char const *arg);
 
-#endif /* RGBDS_GFX_PAL_SPEC_HPP */
+#endif // RGBDS_GFX_PAL_SPEC_HPP

--- a/include/gfx/process.hpp
+++ b/include/gfx/process.hpp
@@ -11,4 +11,4 @@
 
 void process();
 
-#endif /* RGBDS_GFX_CONVERT_HPP */
+#endif // RGBDS_GFX_CONVERT_HPP

--- a/include/gfx/proto_palette.hpp
+++ b/include/gfx/proto_palette.hpp
@@ -21,7 +21,7 @@ class ProtoPalette {
 	std::array<uint16_t, 4> _colorIndices{UINT16_MAX, UINT16_MAX, UINT16_MAX, UINT16_MAX};
 
 public:
-	/**
+	/*
 	 * Adds the specified color to the set
 	 * Returns false if the set is full
 	 */
@@ -41,4 +41,4 @@ public:
 	decltype(_colorIndices)::const_iterator end() const;
 };
 
-#endif /* RGBDS_GFX_PROTO_PALETTE_HPP */
+#endif // RGBDS_GFX_PROTO_PALETTE_HPP

--- a/include/gfx/reverse.hpp
+++ b/include/gfx/reverse.hpp
@@ -11,4 +11,4 @@
 
 void reverse();
 
-#endif /* RGBDS_GFX_REVERSE_HPP */
+#endif // RGBDS_GFX_REVERSE_HPP

--- a/include/gfx/rgba.hpp
+++ b/include/gfx/rgba.hpp
@@ -20,7 +20,7 @@ struct Rgba {
 
 	constexpr Rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 	    : red(r), green(g), blue(b), alpha(a) {}
-	/**
+	/*
 	 * Constructs the color from a "packed" RGBA representation (0xRRGGBBAA)
 	 */
 	explicit constexpr Rgba(uint32_t rgba = 0)
@@ -35,7 +35,7 @@ struct Rgba {
 		        (uint8_t)(cgbColor & 0x8000 ? 0x00 : 0xFF)};
 	}
 
-	/**
+	/*
 	 * Returns this RGBA as a 32-bit number that can be printed in hex (`%08x`) to yield its CSS
 	 * representation
 	 */
@@ -45,7 +45,7 @@ struct Rgba {
 	}
 	friend bool operator!=(Rgba const &lhs, Rgba const &rhs) { return lhs.toCSS() != rhs.toCSS(); }
 
-	/**
+	/*
 	 * CGB colors are RGB555, so we use bit 15 to signify that the color is transparent instead
 	 * Since the rest of the bits don't matter then, we return 0x8000 exactly.
 	 */
@@ -55,7 +55,7 @@ struct Rgba {
 	bool isTransparent() const { return alpha < transparency_threshold; }
 	static constexpr uint8_t opacity_threshold = 0xF0;
 	bool isOpaque() const { return alpha >= opacity_threshold; }
-	/**
+	/*
 	 * Computes the equivalent CGB color, respects the color curve depending on options
 	 */
 	uint16_t cgbColor() const;
@@ -64,4 +64,4 @@ struct Rgba {
 	uint8_t grayIndex() const;
 };
 
-#endif /* RGBDS_GFX_RGBA_HPP */
+#endif // RGBDS_GFX_RGBA_HPP

--- a/include/hashmap.h
+++ b/include/hashmap.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* Generic hashmap implementation (C++ templates are calling...) */
+// Generic hashmap implementation (C++ templates are calling...)
 #ifndef RGBDS_LINK_HASHMAP_H
 #define RGBDS_LINK_HASHMAP_H
 
@@ -18,10 +18,10 @@
 static_assert(HALF_HASH_NB_BITS * 2 == HASH_NB_BITS, "");
 #define HASHMAP_NB_BUCKETS (1 << HALF_HASH_NB_BITS)
 
-/* HashMapEntry is internal, please do not attempt to use it */
+// HashMapEntry is internal, please do not attempt to use it
 typedef struct HashMapEntry *HashMap[HASHMAP_NB_BUCKETS];
 
-/**
+/*
  * Adds an element to a hashmap.
  * @warning Adding a new element with an already-present key will not cause an
  *          error, this must be handled externally.
@@ -33,7 +33,7 @@ typedef struct HashMapEntry *HashMap[HASHMAP_NB_BUCKETS];
  */
 void **hash_AddElement(HashMap map, char const *key, void *element);
 
-/**
+/*
  * Removes an element from a hashmap.
  * @param map The HashMap to remove the element from
  * @param key The key to search the element with
@@ -41,7 +41,7 @@ void **hash_AddElement(HashMap map, char const *key, void *element);
  */
 bool hash_RemoveElement(HashMap map, char const *key);
 
-/**
+/*
  * Finds an element in a hashmap, and returns a pointer to its value field.
  * @param map The map to consider the elements of
  * @param key The key to search an element for
@@ -49,7 +49,7 @@ bool hash_RemoveElement(HashMap map, char const *key);
  */
 void **hash_GetNode(HashMap const map, char const *key);
 
-/**
+/*
  * Finds an element in a hashmap.
  * @param map The map to consider the elements of
  * @param key The key to search an element for
@@ -58,7 +58,7 @@ void **hash_GetNode(HashMap const map, char const *key);
  */
 void *hash_GetElement(HashMap const map, char const *key);
 
-/**
+/*
  * Executes a function on each element in a hashmap.
  * @param map The map to consider the elements of
  * @param func The function to run. The first argument will be the element,
@@ -67,11 +67,11 @@ void *hash_GetElement(HashMap const map, char const *key);
  */
 void hash_ForEach(HashMap const map, void (*func)(void *, void *), void *arg);
 
-/**
+/*
  * Cleanly empties a hashmap from its contents.
  * This does not `free` the data structure itself!
  * @param map The map to empty
  */
 void hash_EmptyMap(HashMap map);
 
-#endif /* RGBDS_LINK_HASHMAP_H */
+#endif // RGBDS_LINK_HASHMAP_H

--- a/include/helpers.h
+++ b/include/helpers.h
@@ -93,4 +93,4 @@
 // (Having two instances of `arr` is OK because the contents of `sizeof` are not evaluated.)
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof *(arr))
 
-#endif /* HELPERS_H */
+#endif // HELPERS_H

--- a/include/itertools.hpp
+++ b/include/itertools.hpp
@@ -79,12 +79,10 @@ using Holder = std::conditional_t<std::is_lvalue_reference_v<T>, T,
                                   std::remove_cv_t<std::remove_reference_t<T>>>;
 }
 
-/**
- * Does the same number of iterations as the first container's iterator!
- */
+// Does the same number of iterations as the first container's iterator!
 template<typename... Containers>
 static constexpr auto zip(Containers &&...cs) {
 	return detail::ZipContainer<detail::Holder<Containers>...>(std::forward<Containers>(cs)...);
 }
 
-#endif /* RGBDS_ITERTOOLS_HPP */
+#endif // RGBDS_ITERTOOLS_HPP

--- a/include/link/assign.h
+++ b/include/link/assign.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* Assigning all sections a place */
+// Assigning all sections a place
 #ifndef RGBDS_LINK_ASSIGN_H
 #define RGBDS_LINK_ASSIGN_H
 
@@ -14,14 +14,10 @@
 
 extern uint64_t nbSectionsToAssign;
 
-/**
- * Assigns all sections a slice of the address space
- */
+// Assigns all sections a slice of the address space
 void assign_AssignSections(void);
 
-/**
- * `free`s all assignment memory that was allocated.
- */
+// `free`s all assignment memory that was allocated
 void assign_Cleanup(void);
 
-#endif /* RGBDS_LINK_ASSIGN_H */
+#endif // RGBDS_LINK_ASSIGN_H

--- a/include/link/main.h
+++ b/include/link/main.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* Declarations that all modules use, as well as `main` and related */
+// Declarations that all modules use, as well as `main` and related
 #ifndef RGBDS_LINK_MAIN_H
 #define RGBDS_LINK_MAIN_H
 
@@ -16,7 +16,7 @@
 
 #include "helpers.h"
 
-/* Variables related to CLI options */
+// Variables related to CLI options
 extern bool isDmgMode;
 extern char       *linkerScriptName;
 extern char const *mapFileName;
@@ -35,7 +35,7 @@ extern bool disablePadding;
 
 struct FileStackNode {
 	struct FileStackNode *parent;
-	/* Line at which the parent context was exited; meaningless for the root level */
+	// Line at which the parent context was exited; meaningless for the root level
 	uint32_t lineNo;
 
 	enum {
@@ -44,21 +44,21 @@ struct FileStackNode {
 		NODE_MACRO,
 	} type;
 	union {
-		char *name; /* NODE_FILE, NODE_MACRO */
-		struct { /* NODE_REPT */
+		char *name; // NODE_FILE, NODE_MACRO
+		struct { // NODE_REPT
 			uint32_t reptDepth;
 			uint32_t *iters;
 		};
 	};
 };
 
-/* Helper macro for printing verbose-mode messages */
+// Helper macro for printing verbose-mode messages
 #define verbosePrint(...)   do { \
 					if (beVerbose) \
 						fprintf(stderr, __VA_ARGS__); \
 				} while (0)
 
-/**
+/*
  * Dump a file stack to stderr
  * @param node The leaf node to dump the context of
  */
@@ -73,7 +73,7 @@ void error(struct FileStackNode const *where, uint32_t lineNo,
 _Noreturn void fatal(struct FileStackNode const *where, uint32_t lineNo,
 		     char const *fmt, ...) format_(printf, 3, 4);
 
-/**
+/*
  * Opens a file if specified, and aborts on error.
  * @param fileName The name of the file to open; if NULL, no file will be opened
  * @param mode The mode to open the file with
@@ -87,4 +87,4 @@ FILE *openFile(char const *fileName, char const *mode);
 					fclose(tmp); \
 			} while (0)
 
-#endif /* RGBDS_LINK_MAIN_H */
+#endif // RGBDS_LINK_MAIN_H

--- a/include/link/object.h
+++ b/include/link/object.h
@@ -6,37 +6,37 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* Declarations related to processing of object (.o) files */
+// Declarations related to processing of object (.o) files
 
 #ifndef RGBDS_LINK_OBJECT_H
 #define RGBDS_LINK_OBJECT_H
 
-/**
+/*
  * Read an object (.o) file, and add its info to the data structures.
  * @param fileName A path to the object file to be read
  * @param i The ID of the file
  */
 void obj_ReadFile(char const *fileName, unsigned int i);
 
-/**
+/*
  * Perform validation on the object files' contents
  */
 void obj_DoSanityChecks(void);
 
-/**
+/*
  * Evaluate all assertions
  */
 void obj_CheckAssertions(void);
 
-/**
+/*
  * Sets up object file reading
  * @param nbFiles The number of object files that will be read
  */
 void obj_Setup(unsigned int nbFiles);
 
-/**
+/*
  * `free`s all object memory that was allocated.
  */
 void obj_Cleanup(void);
 
-#endif /* RGBDS_LINK_OBJECT_H */
+#endif // RGBDS_LINK_OBJECT_H

--- a/include/link/output.h
+++ b/include/link/output.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* Outputting the result of linking */
+// Outputting the result of linking
 #ifndef RGBDS_LINK_OUTPUT_H
 #define RGBDS_LINK_OUTPUT_H
 
@@ -14,22 +14,22 @@
 
 #include "link/section.h"
 
-/**
+/*
  * Registers a section for output.
  * @param section The section to add
  */
 void out_AddSection(struct Section const *section);
 
-/**
+/*
  * Finds an assigned section overlapping another one.
  * @param section The section that is being overlapped
  * @return A section overlapping it
  */
 struct Section const *out_OverlappingSection(struct Section const *section);
 
-/**
+/*
  * Writes all output (bin, sym, map) files.
  */
 void out_WriteFiles(void);
 
-#endif /* RGBDS_LINK_OUTPUT_H */
+#endif // RGBDS_LINK_OUTPUT_H

--- a/include/link/patch.h
+++ b/include/link/patch.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* Applying patches to SECTIONs */
+// Applying patches to SECTIONs
 #ifndef RGBDS_LINK_PATCH_H
 #define RGBDS_LINK_PATCH_H
 
@@ -27,15 +27,15 @@ struct Assertion {
 	struct Assertion *next;
 };
 
-/**
+/*
  * Checks all assertions
  * @return true if assertion failed
  */
 void patch_CheckAssertions(struct Assertion *assertion);
 
-/**
+/*
  * Applies all SECTIONs' patches to them
  */
 void patch_ApplyPatches(void);
 
-#endif /* RGBDS_LINK_PATCH_H */
+#endif // RGBDS_LINK_PATCH_H

--- a/include/link/script.h
+++ b/include/link/script.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* Parsing a linker script */
+// Parsing a linker script
 #ifndef RGBDS_LINK_SCRIPT_H
 #define RGBDS_LINK_SCRIPT_H
 
@@ -24,15 +24,15 @@ struct SectionPlacement {
 
 extern uint64_t script_lineNo;
 
-/**
+/*
  * Parses the linker script to return the next section constraint
  * @return A pointer to a struct, or NULL on EOF. The pointer shouldn't be freed
  */
 struct SectionPlacement *script_NextSection(void);
 
-/**
+/*
  * `free`s all assignment memory that was allocated.
  */
 void script_Cleanup(void);
 
-#endif /* RGBDS_LINK_SCRIPT_H */
+#endif // RGBDS_LINK_SCRIPT_H

--- a/include/link/sdas_obj.h
+++ b/include/link/sdas_obj.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* Assigning all sections a place */
+// Assigning all sections a place
 #ifndef RGBDS_LINK_SDAS_OBJ_H
 #define RGBDS_LINK_SDAS_OBJ_H
 
@@ -16,4 +16,4 @@ struct FileStackNode;
 
 void sdobj_ReadFile(struct FileStackNode const *fileName, FILE *file);
 
-#endif /* RGBDS_LINK_SDAS_OBJ_H */
+#endif // RGBDS_LINK_SDAS_OBJ_H

--- a/include/link/section.h
+++ b/include/link/section.h
@@ -6,11 +6,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* Declarations manipulating symbols */
+// Declarations manipulating symbols
 #ifndef RGBDS_LINK_SECTION_H
 #define RGBDS_LINK_SECTION_H
 
-/* GUIDELINE: external code MUST NOT BE AWARE of the data structure used!! */
+// GUIDELINE: external code MUST NOT BE AWARE of the data structure used!!
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -41,7 +41,7 @@ struct Patch {
 };
 
 struct Section {
-	/* Info contained in the object files */
+	// Info contained in the object files
 	char *name;
 	uint16_t size;
 	uint16_t offset;
@@ -56,14 +56,14 @@ struct Section {
 	bool isAlignFixed;
 	uint16_t alignMask;
 	uint16_t alignOfs;
-	uint8_t *data; /* Array of size `size`*/
+	uint8_t *data; // Array of size `size`
 	uint32_t nbPatches;
 	struct Patch *patches;
-	/* Extra info computed during linking */
+	// Extra info computed during linking
 	struct Symbol **fileSymbols;
 	uint32_t nbSymbols;
 	struct Symbol **symbols;
-	struct Section *nextu; /* The next "component" of this unionized sect */
+	struct Section *nextu; // The next "component" of this unionized sect
 };
 
 /*
@@ -76,27 +76,27 @@ struct Section {
  */
 void sect_ForEach(void (*callback)(struct Section *, void *), void *arg);
 
-/**
+/*
  * Registers a section to be processed.
  * @param section The section to register.
  */
 void sect_AddSection(struct Section *section);
 
-/**
+/*
  * Finds a section by its name.
  * @param name The name of the section to look for
  * @return A pointer to the section, or NULL if it wasn't found
  */
 struct Section *sect_GetSection(char const *name);
 
-/**
+/*
  * `free`s all section memory that was allocated.
  */
 void sect_CleanupSections(void);
 
-/**
+/*
  * Checks if all sections meet reasonable criteria, such as max size
  */
 void sect_DoSanityChecks(void);
 
-#endif /* RGBDS_LINK_SECTION_H */
+#endif // RGBDS_LINK_SECTION_H

--- a/include/link/symbol.h
+++ b/include/link/symbol.h
@@ -6,11 +6,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* Declarations manipulating symbols */
+// Declarations manipulating symbols
 #ifndef RGBDS_LINK_SYMBOL_H
 #define RGBDS_LINK_SYMBOL_H
 
-/* GUIDELINE: external code MUST NOT BE AWARE of the data structure used!! */
+// GUIDELINE: external code MUST NOT BE AWARE of the data structure used!!
 
 #include <stdint.h>
 
@@ -19,7 +19,7 @@
 struct FileStackNode;
 
 struct Symbol {
-	/* Info contained in the object files */
+	// Info contained in the object files
 	char *name;
 	enum ExportLevel type;
 	char const *objFileName;
@@ -31,7 +31,7 @@ struct Symbol {
 		int32_t offset;
 		int32_t value;
 	};
-	/* Extra info computed during linking */
+	// Extra info computed during linking
 	struct Section *section;
 };
 
@@ -47,16 +47,16 @@ void sym_ForEach(void (*callback)(struct Symbol *, void *), void *arg);
 
 void sym_AddSymbol(struct Symbol *symbol);
 
-/**
+/*
  * Finds a symbol in all the defined symbols.
  * @param name The name of the symbol to look for
  * @return A pointer to the symbol, or NULL if not found.
  */
 struct Symbol *sym_GetSymbol(char const *name);
 
-/**
+/*
  * `free`s all symbol memory that was allocated.
  */
 void sym_CleanupSymbols(void);
 
-#endif /* RGBDS_LINK_SYMBOL_H */
+#endif // RGBDS_LINK_SYMBOL_H

--- a/include/linkdefs.h
+++ b/include/linkdefs.h
@@ -88,7 +88,7 @@ extern struct SectionTypeInfo {
 	uint32_t lastBank;
 } sectionTypeInfo[SECTTYPE_INVALID];
 
-/**
+/*
  * Tells whether a section has data in its object file definition,
  * depending on type.
  * @param type The section's type
@@ -100,7 +100,7 @@ static inline bool sect_HasData(enum SectionType type)
 	return type == SECTTYPE_ROM0 || type == SECTTYPE_ROMX;
 }
 
-/**
+/*
  * Computes a memory region's end address (last byte), eg. 0x7FFF
  * @return The address of the last byte in that memory region
  */
@@ -109,7 +109,7 @@ static inline uint16_t endaddr(enum SectionType type)
 	return sectionTypeInfo[type].startAddr + sectionTypeInfo[type].size - 1;
 }
 
-/**
+/*
  * Computes a memory region's number of banks
  * @return The number of banks, 1 for regions without banking
  */
@@ -141,4 +141,4 @@ enum PatchType {
 	PATCHTYPE_INVALID
 };
 
-#endif /* RGBDS_LINKDEFS_H */
+#endif // RGBDS_LINKDEFS_H

--- a/include/opmath.h
+++ b/include/opmath.h
@@ -18,4 +18,4 @@ int32_t op_shift_left(int32_t value, int32_t amount);
 int32_t op_shift_right(int32_t value, int32_t amount);
 int32_t op_shift_right_unsigned(int32_t value, int32_t amount);
 
-#endif /* RGBDS_OP_MATH_H */
+#endif // RGBDS_OP_MATH_H

--- a/include/platform.h
+++ b/include/platform.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* platform-specific hacks */
+// platform-specific hacks
 
 #ifndef RGBDS_PLATFORM_H
 #define RGBDS_PLATFORM_H
@@ -20,20 +20,20 @@
 # include <strings.h>
 #endif
 
-/* MSVC has deprecated strdup in favor of _strdup */
+// MSVC has deprecated strdup in favor of _strdup
 #ifdef _MSC_VER
 # define strdup _strdup
 #endif
 
-/* MSVC prefixes the names of S_* macros with underscores,
-   and doesn't define any S_IS* macros. Define them ourselves */
+// MSVC prefixes the names of S_* macros with underscores,
+// and doesn't define any S_IS* macros; define them ourselves
 #ifdef _MSC_VER
 # define S_IFMT _S_IFMT
 # define S_IFDIR _S_IFDIR
 # define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
 #endif
 
-/* MSVC doesn't use POSIX types or defines for `read` */
+// MSVC doesn't use POSIX types or defines for `read`
 #ifdef _MSC_VER
 # include <io.h>
 # define STDIN_FILENO 0
@@ -46,7 +46,7 @@
 # include <unistd.h>
 #endif
 
-/* MSVC doesn't support `[static N]` for array arguments from C99 or C11 */
+// MSVC doesn't support `[static N]` for array arguments from C99 or C11
 #ifdef _MSC_VER
 # define MIN_NB_ELMS(N)
 # define ARR_QUALS(...)
@@ -75,4 +75,4 @@
 # define setmode(fd, mode) ((void)0)
 #endif
 
-#endif /* RGBDS_PLATFORM_H */
+#endif // RGBDS_PLATFORM_H

--- a/include/version.h
+++ b/include/version.h
@@ -24,4 +24,4 @@ char const *get_package_version_string(void);
 }
 #endif
 
-#endif /* EXTERN_VERSION_H */
+#endif // EXTERN_VERSION_H

--- a/src/asm/fixpoint.c
+++ b/src/asm/fixpoint.c
@@ -6,9 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/*
- * Fixed-point math routines
- */
+// Fixed-point math routines
 
 #include <inttypes.h>
 #include <math.h>
@@ -30,9 +28,6 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-/*
- * Print a fixed point value
- */
 void fix_Print(int32_t i)
 {
 	uint32_t u = i;
@@ -47,121 +42,76 @@ void fix_Print(int32_t i)
 	       ((uint32_t)(fix2double(u) * 100000 + 0.5)) % 100000);
 }
 
-/*
- * Calculate sine
- */
 int32_t fix_Sin(int32_t i)
 {
 	return double2fix(sin(fdeg2rad(fix2double(i))));
 }
 
-/*
- * Calculate cosine
- */
 int32_t fix_Cos(int32_t i)
 {
 	return double2fix(cos(fdeg2rad(fix2double(i))));
 }
 
-/*
- * Calculate tangent
- */
 int32_t fix_Tan(int32_t i)
 {
 	return double2fix(tan(fdeg2rad(fix2double(i))));
 }
 
-/*
- * Calculate arcsine
- */
 int32_t fix_ASin(int32_t i)
 {
 	return double2fix(rad2fdeg(asin(fix2double(i))));
 }
 
-/*
- * Calculate arccosine
- */
 int32_t fix_ACos(int32_t i)
 {
 	return double2fix(rad2fdeg(acos(fix2double(i))));
 }
 
-/*
- * Calculate arctangent
- */
 int32_t fix_ATan(int32_t i)
 {
 	return double2fix(rad2fdeg(atan(fix2double(i))));
 }
 
-/*
- * Calculate atan2
- */
 int32_t fix_ATan2(int32_t i, int32_t j)
 {
 	return double2fix(rad2fdeg(atan2(fix2double(i), fix2double(j))));
 }
 
-/*
- * Multiplication
- */
 int32_t fix_Mul(int32_t i, int32_t j)
 {
 	return double2fix(fix2double(i) * fix2double(j));
 }
 
-/*
- * Division
- */
 int32_t fix_Div(int32_t i, int32_t j)
 {
 	return double2fix(fix2double(i) / fix2double(j));
 }
 
-/*
- * Modulo
- */
 int32_t fix_Mod(int32_t i, int32_t j)
 {
 	return double2fix(fmod(fix2double(i), fix2double(j)));
 }
 
-/*
- * Power
- */
 int32_t fix_Pow(int32_t i, int32_t j)
 {
 	return double2fix(pow(fix2double(i), fix2double(j)));
 }
 
-/*
- * Logarithm
- */
 int32_t fix_Log(int32_t i, int32_t j)
 {
 	return double2fix(log(fix2double(i)) / log(fix2double(j)));
 }
 
-/*
- * Round
- */
 int32_t fix_Round(int32_t i)
 {
 	return double2fix(round(fix2double(i)));
 }
 
-/*
- * Ceil
- */
 int32_t fix_Ceil(int32_t i)
 {
 	return double2fix(ceil(fix2double(i)));
 }
 
-/*
- * Floor
- */
 int32_t fix_Floor(int32_t i)
 {
 	return double2fix(floor(fix2double(i)));

--- a/src/asm/format.c
+++ b/src/asm/format.c
@@ -46,7 +46,7 @@ void fmt_UseCharacter(struct FormatSpec *fmt, int c)
 		return;
 
 	switch (c) {
-	/* sign */
+	// sign
 	case ' ':
 	case '+':
 		if (fmt->state > FORMAT_SIGN)
@@ -55,7 +55,7 @@ void fmt_UseCharacter(struct FormatSpec *fmt, int c)
 		fmt->sign = c;
 		break;
 
-	/* prefix */
+	// prefix
 	case '#':
 		if (fmt->state > FORMAT_PREFIX)
 			goto invalid;
@@ -63,7 +63,7 @@ void fmt_UseCharacter(struct FormatSpec *fmt, int c)
 		fmt->prefix = true;
 		break;
 
-	/* align */
+	// align
 	case '-':
 		if (fmt->state > FORMAT_ALIGN)
 			goto invalid;
@@ -71,11 +71,11 @@ void fmt_UseCharacter(struct FormatSpec *fmt, int c)
 		fmt->alignLeft = true;
 		break;
 
-	/* pad and width */
+	// pad and width
 	case '0':
 		if (fmt->state < FORMAT_WIDTH)
 			fmt->padZero = true;
-		/* fallthrough */
+		// fallthrough
 	case '1':
 	case '2':
 	case '3':
@@ -104,7 +104,7 @@ void fmt_UseCharacter(struct FormatSpec *fmt, int c)
 		fmt->hasFrac = true;
 		break;
 
-	/* type */
+	// type
 	case 'd':
 	case 'u':
 	case 'X':
@@ -149,7 +149,7 @@ void fmt_PrintString(char *buf, size_t bufLen, struct FormatSpec const *fmt, cha
 	size_t len = strlen(value);
 	size_t totalLen = fmt->width > len ? fmt->width : len;
 
-	if (totalLen > bufLen - 1) { /* bufLen includes terminator */
+	if (totalLen > bufLen - 1) { // bufLen includes terminator
 		error("Formatted string value too long\n");
 		totalLen = bufLen - 1;
 		if (len > totalLen)
@@ -182,7 +182,7 @@ void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uin
 	if (fmt->type == 's')
 		error("Formatting number as type 's'\n");
 
-	char sign = fmt->sign; /* 0 or ' ' or '+' */
+	char sign = fmt->sign; // 0 or ' ' or '+'
 
 	if (fmt->type == 'd' || fmt->type == 'f') {
 		int32_t v = value;
@@ -200,10 +200,10 @@ void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uin
 		: fmt->type == 'o' ? '&'
 		: 0;
 
-	char valueBuf[262]; /* Max 5 digits + decimal + 255 fraction digits + terminator */
+	char valueBuf[262]; // Max 5 digits + decimal + 255 fraction digits + terminator
 
 	if (fmt->type == 'b') {
-		/* Special case for binary */
+		// Special case for binary
 		char *ptr = valueBuf;
 
 		do {
@@ -213,7 +213,7 @@ void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uin
 
 		*ptr = '\0';
 
-		/* Reverse the digits */
+		// Reverse the digits
 		size_t valueLen = ptr - valueBuf;
 
 		for (size_t i = 0, j = valueLen - 1; i < j; i++, j--) {
@@ -223,9 +223,9 @@ void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uin
 			valueBuf[j] = c;
 		}
 	} else if (fmt->type == 'f') {
-		/* Special case for fixed-point */
+		// Special case for fixed-point
 
-		/* Default fractional width (C's is 6 for "%f"; here 5 is enough) */
+		// Default fractional width (C's is 6 for "%f"; here 5 is enough)
 		size_t fracWidth = fmt->hasFrac ? fmt->fracWidth : 5;
 
 		if (fracWidth > 255) {
@@ -250,7 +250,7 @@ void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uin
 	size_t numLen = !!sign + !!prefix + len;
 	size_t totalLen = fmt->width > numLen ? fmt->width : numLen;
 
-	if (totalLen > bufLen - 1) { /* bufLen includes terminator */
+	if (totalLen > bufLen - 1) { // bufLen includes terminator
 		error("Formatted numeric value too long\n");
 		totalLen = bufLen - 1;
 		if (numLen > totalLen) {
@@ -273,7 +273,7 @@ void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uin
 			buf[i] = ' ';
 	} else {
 		if (fmt->padZero) {
-			/* sign, then prefix, then zero padding */
+			// sign, then prefix, then zero padding
 			if (sign)
 				buf[pos++] = sign;
 			if (prefix)
@@ -281,7 +281,7 @@ void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uin
 			for (size_t i = 0; i < padLen; i++)
 				buf[pos++] = '0';
 		} else {
-			/* space padding, then sign, then prefix */
+			// space padding, then sign, then prefix
 			for (size_t i = 0; i < padLen; i++)
 				buf[pos++] = ' ';
 			if (sign)

--- a/src/asm/macro.c
+++ b/src/asm/macro.c
@@ -1,3 +1,10 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2022, Eldred Habert and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #include <assert.h>
 #include <errno.h>
@@ -12,13 +19,11 @@
 
 #define MAXMACROARGS 99999
 
-/*
- * Your average macro invocation does not go past the tens, but some go further
- * This ensures that sane and slightly insane invocations suffer no penalties,
- * and the rest is insane and thus will assume responsibility.
- * Additionally, ~300 bytes (on x64) of memory per level of nesting has been
- * deemed reasonable. (Halve that on x86.)
- */
+// Your average macro invocation does not go past the tens, but some go further
+// This ensures that sane and slightly insane invocations suffer no penalties,
+// and the rest is insane and thus will assume responsibility.
+// Additionally, ~300 bytes (on x64) of memory per level of nesting has been
+// deemed reasonable. (Halve that on x86.)
 #define INITIAL_ARG_SIZE 32
 struct MacroArgs {
 	unsigned int nbArgs;
@@ -33,11 +38,9 @@ struct MacroArgs {
 static struct MacroArgs *macroArgs = NULL;
 static uint32_t uniqueID = 0;
 static uint32_t maxUniqueID = 0;
-/*
- * The initialization is somewhat harmful, since it is never used, but it
- * guarantees the size of the buffer will be correct. I was unable to find a
- * better solution, but if you have one, please feel free!
- */
+// The initialization is somewhat harmful, since it is never used, but it
+// guarantees the size of the buffer will be correct. I was unable to find a
+// better solution, but if you have one, please feel free!
 static char uniqueIDBuf[] = "_u4294967295"; // UINT32_MAX
 static char *uniqueIDPtr = NULL;
 
@@ -68,7 +71,7 @@ void macro_AppendArg(struct MacroArgs **argPtr, char *s)
 		error("A maximum of " EXPAND_AND_STR(MAXMACROARGS) " arguments is allowed\n");
 	if (macArgs->nbArgs >= macArgs->capacity) {
 		macArgs->capacity *= 2;
-		/* Check that overflow didn't roll us back */
+		// Check that overflow didn't roll us back
 		if (macArgs->capacity <= macArgs->nbArgs)
 			fatalerror("Failed to add new macro argument: capacity overflow\n");
 		macArgs = realloc(macArgs, SIZEOF_ARGS(macArgs->capacity));
@@ -112,9 +115,9 @@ char const *macro_GetAllArgs(void)
 	size_t len = 0;
 
 	for (uint32_t i = macroArgs->shift; i < macroArgs->nbArgs; i++)
-		len += strlen(macroArgs->args[i]) + 1; /* 1 for comma */
+		len += strlen(macroArgs->args[i]) + 1; // 1 for comma
 
-	char *str = malloc(len + 1); /* 1 for '\0' */
+	char *str = malloc(len + 1); // 1 for '\0'
 	char *ptr = str;
 
 	if (!str)
@@ -126,9 +129,9 @@ char const *macro_GetAllArgs(void)
 		memcpy(ptr, macroArgs->args[i], n);
 		ptr += n;
 
-		/* Commas go between args and after a last empty arg */
+		// Commas go between args and after a last empty arg
 		if (i < macroArgs->nbArgs - 1 || n == 0)
-			*ptr++ = ','; /* no space after comma */
+			*ptr++ = ','; // no space after comma
 	}
 	*ptr = '\0';
 
@@ -153,8 +156,8 @@ void macro_SetUniqueID(uint32_t id)
 	} else {
 		if (uniqueID > maxUniqueID)
 			maxUniqueID = uniqueID;
-		/* The buffer is guaranteed to be the correct size */
-		/* This is a valid label fragment, but not a valid numeric */
+		// The buffer is guaranteed to be the correct size
+		// This is a valid label fragment, but not a valid numeric
 		sprintf(uniqueIDBuf, "_u%" PRIu32, id);
 		uniqueIDPtr = uniqueIDBuf;
 	}

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -39,8 +39,8 @@
 #ifdef __clang__
 #if __has_feature(address_sanitizer) && !defined(__SANITIZE_ADDRESS__)
 #define __SANITIZE_ADDRESS__
-#endif /* __has_feature(address_sanitizer) && !defined(__SANITIZE_ADDRESS__) */
-#endif /* __clang__ */
+#endif // __has_feature(address_sanitizer) && !defined(__SANITIZE_ADDRESS__)
+#endif // __clang__
 
 #ifdef __SANITIZE_ADDRESS__
 // There are known, non-trivial to fix leaks. We would still like to have `make develop'
@@ -63,9 +63,9 @@ bool warnOnHaltNop;
 bool optimizeLoads;
 bool warnOnLdOpt;
 bool verbose;
-bool warnings; /* True to enable warnings, false to disable them. */
+bool warnings; // True to enable warnings, false to disable them.
 
-/* Escapes Make-special chars from a string */
+// Escapes Make-special chars from a string
 static char *make_escape(char const *str)
 {
 	char * const escaped_str = malloc(strlen(str) * 2 + 1);
@@ -75,7 +75,7 @@ static char *make_escape(char const *str)
 		err("%s: Failed to allocate memory", __func__);
 
 	while (*str) {
-		/* All dollars needs to be doubled */
+		// All dollars needs to be doubled
 		if (*str == '$')
 			*dest++ = '$';
 		*dest++ = *str++;
@@ -85,22 +85,20 @@ static char *make_escape(char const *str)
 	return escaped_str;
 }
 
-/* Short options */
+// Short options
 static const char *optstring = "b:D:Eg:Hhi:LlM:o:p:r:VvW:w";
 
-/* Variables for the long-only options */
-static int depType; /* Variants of `-M` */
+// Variables for the long-only options
+static int depType; // Variants of `-M`
 
-/*
- * Equivalent long options
- * Please keep in the same order as short opts
- *
- * Also, make sure long opts don't create ambiguity:
- * A long opt's name should start with the same letter as its short opt,
- * except if it doesn't create any ambiguity (`verbose` versus `version`).
- * This is because long opt matching, even to a single char, is prioritized
- * over short opt matching
- */
+// Equivalent long options
+// Please keep in the same order as short opts
+//
+// Also, make sure long opts don't create ambiguity:
+// A long opt's name should start with the same letter as its short opt,
+// except if it doesn't create any ambiguity (`verbose` versus `version`).
+// This is because long opt matching, even to a single char, is prioritized
+// over short opt matching
 static struct option const longopts[] = {
 	{ "binary-digits",    required_argument, NULL,     'b' },
 	{ "define",           required_argument, NULL,     'D' },
@@ -152,10 +150,8 @@ int main(int argc, char *argv[])
 	time_t now = time(NULL);
 	char const *sourceDateEpoch = getenv("SOURCE_DATE_EPOCH");
 
-	/*
-	 * Support SOURCE_DATE_EPOCH for reproducible builds
-	 * https://reproducible-builds.org/docs/source-date-epoch/
-	 */
+	// Support SOURCE_DATE_EPOCH for reproducible builds
+	// https://reproducible-builds.org/docs/source-date-epoch/
 	if (sourceDateEpoch)
 		now = (time_t)strtoul(sourceDateEpoch, NULL, 0);
 
@@ -289,7 +285,7 @@ int main(int argc, char *argv[])
 			warnings = false;
 			break;
 
-		/* Long-only options */
+		// Long-only options
 		case 0:
 			switch (depType) {
 			case 'G':
@@ -321,10 +317,10 @@ int main(int argc, char *argv[])
 			}
 			break;
 
-		/* Unrecognized options */
+		// Unrecognized options
 		default:
 			print_usage();
-			/* NOTREACHED */
+			// NOTREACHED
 		}
 	}
 
@@ -376,7 +372,7 @@ int main(int argc, char *argv[])
 	if (failedOnMissingInclude)
 		return 0;
 
-	/* If no path specified, don't write file */
+	// If no path specified, don't write file
 	if (objectName != NULL)
 		out_WriteObject();
 	return 0;

--- a/src/asm/opt.c
+++ b/src/asm/opt.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2022, RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <ctype.h>
 #include <errno.h>
 #include <stdbool.h>

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -36,7 +36,7 @@
 #include "linkdefs.h"
 #include "platform.h" // strncasecmp, strdup
 
-static struct CaptureBody captureBody; /* Captures a REPT/FOR or MACRO */
+static struct CaptureBody captureBody; // Captures a REPT/FOR or MACRO
 
 static void upperstring(char *dest, char const *src)
 {
@@ -104,14 +104,14 @@ static size_t strlenUTF8(char const *s)
 		case 1:
 			errorInvalidUTF8Byte(byte, "STRLEN");
 			state = 0;
-			/* fallthrough */
+			// fallthrough
 		case 0:
 			len++;
 			break;
 		}
 	}
 
-	/* Check for partial code point. */
+	// Check for partial code point.
 	if (state != 0)
 		error("STRLEN: Incomplete UTF-8 character\n");
 
@@ -127,13 +127,13 @@ static void strsubUTF8(char *dest, size_t destLen, char const *src, uint32_t pos
 	uint32_t curLen = 0;
 	uint32_t curPos = 1;
 
-	/* Advance to starting position in source string. */
+	// Advance to starting position in source string.
 	while (src[srcIndex] && curPos < pos) {
 		switch (decode(&state, &codep, src[srcIndex])) {
 		case 1:
 			errorInvalidUTF8Byte(src[srcIndex], "STRSUB");
 			state = 0;
-			/* fallthrough */
+			// fallthrough
 		case 0:
 			curPos++;
 			break;
@@ -141,21 +141,19 @@ static void strsubUTF8(char *dest, size_t destLen, char const *src, uint32_t pos
 		srcIndex++;
 	}
 
-	/*
-	 * A position 1 past the end of the string is allowed, but will trigger the
-	 * "Length too big" warning below if the length is nonzero.
-	 */
+	// A position 1 past the end of the string is allowed, but will trigger the
+	// "Length too big" warning below if the length is nonzero.
 	if (!src[srcIndex] && pos > curPos)
 		warning(WARNING_BUILTIN_ARG,
 			"STRSUB: Position %" PRIu32 " is past the end of the string\n", pos);
 
-	/* Copy from source to destination. */
+	// Copy from source to destination.
 	while (src[srcIndex] && destIndex < destLen - 1 && curLen < len) {
 		switch (decode(&state, &codep, src[srcIndex])) {
 		case 1:
 			errorInvalidUTF8Byte(src[srcIndex], "STRSUB");
 			state = 0;
-			/* fallthrough */
+			// fallthrough
 		case 0:
 			curLen++;
 			break;
@@ -166,7 +164,7 @@ static void strsubUTF8(char *dest, size_t destLen, char const *src, uint32_t pos
 	if (curLen < len)
 		warning(WARNING_BUILTIN_ARG, "STRSUB: Length too big: %" PRIu32 "\n", len);
 
-	/* Check for partial code point. */
+	// Check for partial code point.
 	if (state != 0)
 		error("STRSUB: Incomplete UTF-8 character\n");
 
@@ -187,7 +185,7 @@ static void charsubUTF8(char *dest, char const *src, uint32_t pos)
 {
 	size_t charLen = 1;
 
-	/* Advance to starting position in source string. */
+	// Advance to starting position in source string.
 	for (uint32_t curPos = 1; charLen && curPos < pos; curPos++)
 		charLen = charmap_ConvertNext(&src, NULL);
 
@@ -197,7 +195,7 @@ static void charsubUTF8(char *dest, char const *src, uint32_t pos)
 		warning(WARNING_BUILTIN_ARG,
 			"CHARSUB: Position %" PRIu32 " is past the end of the string\n", pos);
 
-	/* Copy from source to destination. */
+	// Copy from source to destination.
 	memcpy(dest, start, src - start);
 
 	dest[src - start] = '\0';
@@ -205,10 +203,8 @@ static void charsubUTF8(char *dest, char const *src, uint32_t pos)
 
 static uint32_t adjustNegativePos(int32_t pos, size_t len, char const *functionName)
 {
-	/*
-	 * STRSUB and CHARSUB adjust negative `pos` arguments the same way,
-	 * such that position -1 is the last character of a string.
-	 */
+	// STRSUB and CHARSUB adjust negative `pos` arguments the same way,
+	// such that position -1 is the last character of a string.
 	if (pos < 0)
 		pos += len + 1;
 	if (pos < 1) {
@@ -545,7 +541,7 @@ enum {
 %left	T_OP_SHL T_OP_SHR T_OP_USHR
 %left	T_OP_MUL T_OP_DIV T_OP_MOD
 
-%precedence	NEG /* negation -- unary minus */
+%precedence	NEG // negation -- unary minus
 
 %token	T_OP_EXP "**"
 %left	T_OP_EXP
@@ -588,7 +584,6 @@ enum {
 %type	<symName> scoped_id
 %type	<symName> scoped_anon_id
 %token	T_POP_EQU "EQU"
-%token	T_POP_SET "SET"
 %token	T_POP_EQUAL "="
 %token	T_POP_EQUS "EQUS"
 
@@ -642,7 +637,7 @@ enum {
 %type	<forArgs> for_args
 
 %token	T_Z80_ADC "adc" T_Z80_ADD "add" T_Z80_AND "and"
-%token	T_Z80_BIT "bit" // There is no T_Z80_SET, only T_POP_SET
+%token	T_Z80_BIT "bit"
 %token	T_Z80_CALL "call" T_Z80_CCF "ccf" T_Z80_CP "cp" T_Z80_CPL "cpl"
 %token	T_Z80_DAA "daa" T_Z80_DEC "dec" T_Z80_DI "di"
 %token	T_Z80_EI "ei"
@@ -659,7 +654,7 @@ enum {
 %token	T_Z80_RES "res" T_Z80_RET "ret" T_Z80_RETI "reti" T_Z80_RST "rst"
 %token	T_Z80_RL "rl" T_Z80_RLA "rla" T_Z80_RLC "rlc" T_Z80_RLCA "rlca"
 %token	T_Z80_RR "rr" T_Z80_RRA "rra" T_Z80_RRC "rrc" T_Z80_RRCA "rrca"
-%token	T_Z80_SBC "sbc" T_Z80_SCF "scf" T_Z80_STOP "stop"
+%token	T_Z80_SBC "sbc" T_Z80_SCF "scf" T_Z80_SET "set" T_Z80_STOP "stop"
 %token	T_Z80_SLA "sla" T_Z80_SRA "sra" T_Z80_SRL "srl" T_Z80_SUB "sub"
 %token	T_Z80_SWAP "swap"
 %token	T_Z80_XOR "xor"
@@ -707,8 +702,8 @@ plain_directive	: label
 ;
 
 line		: plain_directive endofline
-		| line_directive /* Directives that manage newlines themselves */
-		/* Continue parsing the next line on a syntax error */
+		| line_directive // Directives that manage newlines themselves
+		// Continue parsing the next line on a syntax error
 		| error {
 			lexer_SetMode(LEXER_NORMAL);
 			lexer_ToggleStringExpansion(true);
@@ -716,7 +711,7 @@ line		: plain_directive endofline
 			fstk_StopRept();
 			yyerrok;
 		}
-		/* Hint about unindented macros parsed as labels */
+		// Hint about unindented macros parsed as labels
 		| T_LABEL error {
 			lexer_SetMode(LEXER_NORMAL);
 			lexer_ToggleStringExpansion(true);
@@ -731,19 +726,17 @@ line		: plain_directive endofline
 		}
 ;
 
-/*
- * For "logistical" reasons, these directives must manage newlines themselves.
- * This is because we need to switch the lexer's mode *after* the newline has been read,
- * and to avoid causing some grammar conflicts (token reducing is finicky).
- * This is DEFINITELY one of the more FRAGILE parts of the codebase, handle with care.
- */
+// For "logistical" reasons, these directives must manage newlines themselves.
+// This is because we need to switch the lexer's mode *after* the newline has been read,
+// and to avoid causing some grammar conflicts (token reducing is finicky).
+// This is DEFINITELY one of the more FRAGILE parts of the codebase, handle with care.
 line_directive	: macrodef
 		| rept
 		| for
 		| break
 		| include
 		| if
-		/* It's important that all of these require being at line start for `skipIfBlock` */
+		// It's important that all of these require being at line start for `skipIfBlock`
 		| elif
 		| else
 ;
@@ -854,7 +847,7 @@ macroargs	: %empty {
 		}
 ;
 
-/* These commands start with a T_LABEL. */
+// These commands start with a T_LABEL.
 assignment_directive	: equ
 		| assignment
 		| rb
@@ -1300,7 +1293,7 @@ constlist_8bit_entry : reloc_8bit_no_str {
 			sect_RelByte(&$1, 0);
 		}
 		| string {
-			uint8_t *output = malloc(strlen($1)); /* Cannot be larger than that */
+			uint8_t *output = malloc(strlen($1)); // Cannot be larger than that
 			size_t length = charmap_Convert($1, output);
 
 			sect_AbsByteGroup(output, length);
@@ -1316,7 +1309,7 @@ constlist_16bit_entry : reloc_16bit_no_str {
 			sect_RelWord(&$1, 0);
 		}
 		| string {
-			uint8_t *output = malloc(strlen($1)); /* Cannot be larger than that */
+			uint8_t *output = malloc(strlen($1)); // Cannot be larger than that
 			size_t length = charmap_Convert($1, output);
 
 			sect_AbsWordGroup(output, length);
@@ -1681,7 +1674,7 @@ sectattrs	: %empty {
 			$$.alignOfs = $7;
 		}
 		| sectattrs T_COMMA T_OP_BANK T_LBRACK uconst T_RBRACK {
-			/* We cannot check the validity of this now */
+			// We cannot check the validity of this now
 			$$.bank = $5;
 		}
 ;
@@ -1998,10 +1991,8 @@ z80_ld_ss	: T_Z80_LD T_MODE_BC T_COMMA reloc_16bit {
 			sect_AbsByte(0x01 | (REG_DE << 4));
 			sect_RelWord(&$4, 1);
 		}
-		/*
-		 * HL is taken care of in z80_ld_hl
-		 * SP is taken care of in z80_ld_sp
-		 */
+		// HL is taken care of in z80_ld_hl
+		// SP is taken care of in z80_ld_sp
 ;
 
 z80_nop		: T_Z80_NOP { sect_AbsByte(0x00); }
@@ -2089,7 +2080,7 @@ z80_sbc		: T_Z80_SBC op_a_n {
 z80_scf		: T_Z80_SCF { sect_AbsByte(0x37); }
 ;
 
-z80_set		: T_POP_SET const_3bit T_COMMA reg_r {
+z80_set		: T_Z80_SET const_3bit T_COMMA reg_r {
 			sect_AbsByte(0xCB);
 			sect_AbsByte(0xC0 | ($2 << 3) | $4);
 		}

--- a/src/asm/util.c
+++ b/src/asm/util.c
@@ -44,7 +44,7 @@ char const *printChar(int c)
 		buf[2] = 't';
 		break;
 
-	default: /* Print as hex */
+	default: // Print as hex
 		buf[0] = '0';
 		buf[1] = 'x';
 		snprintf(&buf[2], 3, "%02hhX", (uint8_t)c); // includes the '\0'

--- a/src/asm/warning.c
+++ b/src/asm/warning.c
@@ -49,19 +49,19 @@ static const enum WarningState defaultWarnings[ARRAY_SIZE(warningStates)] = {
 
 enum WarningState warningStates[ARRAY_SIZE(warningStates)];
 
-bool warningsAreErrors; /* Set if `-Werror` was specified */
+bool warningsAreErrors; // Set if `-Werror` was specified
 
 static enum WarningState warningState(enum WarningID id)
 {
-	/* Check if warnings are globally disabled */
+	// Check if warnings are globally disabled
 	if (!warnings)
 		return WARNING_DISABLED;
 
-	/* Get the actual state */
+	// Get the actual state
 	enum WarningState state = warningStates[id];
 
 	if (state == WARNING_DEFAULT)
-		/* The state isn't set, grab its default state */
+		// The state isn't set, grab its default state
 		state = defaultWarnings[id];
 
 	if (warningsAreErrors && state == WARNING_ENABLED)
@@ -95,10 +95,10 @@ static const char * const warningFlags[NB_WARNINGS] = {
 	"truncation",
 	"truncation",
 
-	/* Meta warnings */
+	// Meta warnings
 	"all",
 	"extra",
-	"everything", /* Especially useful for testing */
+	"everything", // Especially useful for testing
 };
 
 static const struct {
@@ -151,7 +151,7 @@ enum MetaWarningCommand {
 	META_WARNING_DONE = NB_WARNINGS
 };
 
-/* Warnings that probably indicate an error */
+// Warnings that probably indicate an error
 static uint8_t const _wallCommands[] = {
 	WARNING_BACKWARDS_FOR,
 	WARNING_BUILTIN_ARG,
@@ -167,7 +167,7 @@ static uint8_t const _wallCommands[] = {
 	META_WARNING_DONE
 };
 
-/* Warnings that are less likely to indicate an error */
+// Warnings that are less likely to indicate an error
 static uint8_t const _wextraCommands[] = {
 	WARNING_EMPTY_MACRO_ARG,
 	WARNING_MACRO_SHIFT,
@@ -179,7 +179,7 @@ static uint8_t const _wextraCommands[] = {
 	META_WARNING_DONE
 };
 
-/* Literally everything. Notably useful for testing */
+// Literally everything. Notably useful for testing
 static uint8_t const _weverythingCommands[] = {
 	WARNING_BACKWARDS_FOR,
 	WARNING_BUILTIN_ARG,
@@ -199,7 +199,7 @@ static uint8_t const _weverythingCommands[] = {
 	WARNING_NUMERIC_STRING_2,
 	WARNING_TRUNCATION_1,
 	WARNING_TRUNCATION_2,
-	/* WARNING_USER, */
+	// WARNING_USER,
 	META_WARNING_DONE
 };
 
@@ -213,18 +213,18 @@ void processWarningFlag(char *flag)
 {
 	static bool setError = false;
 
-	/* First, try to match against a "meta" warning */
+	// First, try to match against a "meta" warning
 	for (enum WarningID id = META_WARNINGS_START; id < NB_WARNINGS; id++) {
-		/* TODO: improve the matching performance? */
+		// TODO: improve the matching performance?
 		if (!strcmp(flag, warningFlags[id])) {
-			/* We got a match! */
+			// We got a match!
 			if (setError)
 				errx("Cannot make meta warning \"%s\" into an error",
 				     flag);
 
 			for (uint8_t const *ptr = metaWarningCommands[id - META_WARNINGS_START];
 			     *ptr != META_WARNING_DONE; ptr++) {
-				/* Warning flag, set without override */
+				// Warning flag, set without override
 				if (warningStates[*ptr] == WARNING_DEFAULT)
 					warningStates[*ptr] = WARNING_ENABLED;
 			}
@@ -233,31 +233,31 @@ void processWarningFlag(char *flag)
 		}
 	}
 
-	/* If it's not a meta warning, specially check against `-Werror` */
+	// If it's not a meta warning, specially check against `-Werror`
 	if (!strncmp(flag, "error", strlen("error"))) {
 		char *errorFlag = flag + strlen("error");
 
 		switch (*errorFlag) {
 		case '\0':
-			/* `-Werror` */
+			// `-Werror`
 			warningsAreErrors = true;
 			return;
 
 		case '=':
-			/* `-Werror=XXX` */
+			// `-Werror=XXX`
 			setError = true;
-			processWarningFlag(errorFlag + 1); /* Skip the `=` */
+			processWarningFlag(errorFlag + 1); // Skip the `=`
 			setError = false;
 			return;
 
-		/* Otherwise, allow parsing as another flag */
+		// Otherwise, allow parsing as another flag
 		}
 	}
 
-	/* Well, it's either a normal warning or a mistake */
+	// Well, it's either a normal warning or a mistake
 
 	enum WarningState state = setError ? WARNING_ERROR :
-				  /* Not an error, then check if this is a negation */
+				  // Not an error, then check if this is a negation
 				  strncmp(flag, "no-", strlen("no-")) ? WARNING_ENABLED
 								      : WARNING_DISABLED;
 	char const *rootFlag = state == WARNING_DISABLED ? flag + strlen("no-") : flag;
@@ -308,10 +308,10 @@ void processWarningFlag(char *flag)
 		}
 	}
 
-	/* Try to match the flag against a "normal" flag */
+	// Try to match the flag against a "normal" flag
 	for (enum WarningID id = 0; id < NB_PLAIN_WARNINGS; id++) {
 		if (!strcmp(rootFlag, warningFlags[id])) {
-			/* We got a match! */
+			// We got a match!
 			warningStates[id] = state;
 			return;
 		}
@@ -374,7 +374,7 @@ void warning(enum WarningID id, char const *fmt, ...)
 
 	case WARNING_DEFAULT:
 		unreachable_();
-		/* Not reached */
+		// Not reached
 
 	case WARNING_ENABLED:
 		break;

--- a/src/fix/main.c
+++ b/src/fix/main.c
@@ -29,7 +29,7 @@
 
 #define BANK_SIZE 0x4000
 
-/* Short options */
+// Short options
 static const char *optstring = "Ccf:i:jk:l:m:n:Op:r:st:Vv";
 
 /*
@@ -191,7 +191,7 @@ static void printAcceptedMBCNames(void)
 
 static uint8_t tpp1Rev[2];
 
-/**
+/*
  * @return False on failure
  */
 static bool readMBCSlice(char const **name, char const *expected)
@@ -837,7 +837,7 @@ static ssize_t writeBytes(int fd, void *buf, size_t len)
 	return total;
 }
 
-/**
+/*
  * @param rom0 A pointer to rom0
  * @param addr What address to check
  * @param fixedByte The fixed byte at the address
@@ -853,7 +853,7 @@ static void overwriteByte(uint8_t *rom0, uint16_t addr, uint8_t fixedByte, char 
 	rom0[addr] = fixedByte;
 }
 
-/**
+/*
  * @param rom0 A pointer to rom0
  * @param startAddr What address to begin checking from
  * @param fixed The fixed bytes at the address
@@ -878,7 +878,7 @@ static void overwriteBytes(uint8_t *rom0, uint16_t startAddr, uint8_t const *fix
 	memcpy(&rom0[startAddr], fixed, size);
 }
 
-/**
+/*
  * @param input File descriptor to be used for reading
  * @param output File descriptor to be used for writing, may be equal to `input`
  * @param name The file's name, to be displayed for error output

--- a/src/gfx/main.cpp
+++ b/src/gfx/main.cpp
@@ -153,7 +153,7 @@ static void printUsage(void) {
 	exit(1);
 }
 
-/**
+/*
  * Parses a number at the beginning of a string, moving the pointer to skip the parsed characters
  * Returns the provided errVal on error
  */
@@ -179,7 +179,7 @@ static uint16_t parseNumber(char *&string, char const *errPrefix, uint16_t errVa
 		}
 	}
 
-	/**
+	/*
 	 * Turns a digit into its numeric value in the current base, if it has one.
 	 * Maximum is inclusive. The string_view is modified to "consume" all digits.
 	 * Returns 255 on parse failure (including wrong char for base), in which case
@@ -248,7 +248,7 @@ static void registerInput(char const *arg) {
 	}
 }
 
-/**
+/*
  * Turn an "at-file"'s contents into an argv that `getopt` can handle
  * @param argPool Argument characters will be appended to this vector, for storage purposes.
  */
@@ -317,7 +317,7 @@ static std::vector<size_t> readAtFile(std::string const &path, std::vector<char>
 		} while (c != '\n' && c != EOF); // End if we reached EOL
 	}
 }
-/**
+/*
  * Parses an arg vector, modifying `options` as options are read.
  * The three booleans are for the "auto path" flags, since their processing must be deferred to the
  * end of option parsing.
@@ -785,7 +785,7 @@ void Palette::addColor(uint16_t color) {
 	}
 }
 
-/**
+/*
  * Returns the ID of the color in the palette, or `size()` if the color is not in
  */
 uint8_t Palette::indexOf(uint16_t color) const {

--- a/src/gfx/pal_packing.cpp
+++ b/src/gfx/pal_packing.cpp
@@ -39,12 +39,12 @@ namespace packing {
 //  Tile | Proto-palette
 //  Page | Palette
 
-/**
+/*
  * A reference to a proto-palette, and attached attributes for sorting purposes
  */
 struct ProtoPalAttrs {
 	size_t const protoPalIndex;
-	/**
+	/*
 	 * Pages from which we are banned (to prevent infinite loops)
 	 * This is dynamic because we wish not to hard-cap the amount of palettes
 	 */
@@ -62,7 +62,7 @@ struct ProtoPalAttrs {
 	}
 };
 
-/**
+/*
  * A collection of proto-palettes assigned to a palette
  * Does not contain the actual color indices because we need to be able to remove elements
  */
@@ -139,7 +139,7 @@ public:
 	}
 	const_iterator end() const { return const_iterator{&_assigned, _assigned.end()}; }
 
-	/**
+	/*
 	 * Assigns a new ProtoPalAttrs in a free slot, assuming there is one
 	 * Args are passed to the `ProtoPalAttrs`'s constructor
 	 */
@@ -198,7 +198,7 @@ private:
 		return colors;
 	}
 public:
-	/**
+	/*
 	 * Returns the number of distinct colors
 	 */
 	size_t volume() const { return uniqueColors().size(); }
@@ -208,7 +208,7 @@ public:
 		return colors.size() <= options.maxOpaqueColors();
 	}
 
-	/**
+	/*
 	 * Computes the "relative size" of a proto-palette on this palette
 	 */
 	double relSizeOf(ProtoPalette const &protoPal) const {
@@ -227,7 +227,7 @@ public:
 		return relSize;
 	}
 
-	/**
+	/*
 	 * Computes the "relative size" of a set of proto-palettes on this palette
 	 */
 	template<typename Iter>
@@ -237,7 +237,7 @@ public:
 		addUniqueColors(colors, std::forward<Iter>(begin), end, protoPals);
 		return colors.size();
 	}
-	/**
+	/*
 	 * Computes the "relative size" of a set of colors on this palette
 	 */
 	template<typename Iter>

--- a/src/gfx/pal_sorting.cpp
+++ b/src/gfx/pal_sorting.cpp
@@ -1,3 +1,10 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2022, Eldred Habert and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #include "gfx/pal_sorting.hpp"
 

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -165,7 +165,7 @@ void parseInlinePalSpec(char const * const rawArg) {
 	}
 }
 
-/**
+/*
  * Tries to read some magic bytes from the provided `file`.
  * Returns whether the magic was correctly read.
  */
@@ -191,7 +191,7 @@ static T readBE(U const *bytes) {
 	return val;
 }
 
-/**
+/*
  * **Appends** the first line read from `file` to the end of the provided `buffer`.
  */
 static void readLine(std::filebuf &file, std::string &buffer) {
@@ -214,7 +214,7 @@ static void readLine(std::filebuf &file, std::string &buffer) {
 }
 
 // FIXME: Normally we'd use `std::from_chars`, but that's not available with GCC 7
-/**
+/*
  * Parses the initial part of a string_view, advancing the "read index" as it does
  */
 static uint16_t parseDec(std::string const &str, std::string::size_type &n) {

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -42,7 +42,7 @@ class ImagePalette {
 public:
 	ImagePalette() = default;
 
-	/**
+	/*
 	 * Registers a color in the palette.
 	 * If the newly inserted color "conflicts" with another one (different color, but same CGB
 	 * color), then the other color is returned. Otherwise, `nullptr` is returned.
@@ -164,7 +164,7 @@ public:
 		return true;
 	}
 
-	/**
+	/*
 	 * Reads a PNG and notes all of its colors
 	 *
 	 * This code is more complicated than strictly necessary, but that's because of the API
@@ -466,7 +466,7 @@ public:
 };
 
 class RawTiles {
-	/**
+	/*
 	 * A tile which only contains indices into the image's global palette
 	 */
 	class RawTile {
@@ -481,7 +481,7 @@ private:
 	std::vector<RawTile> _tiles;
 
 public:
-	/**
+	/*
 	 * Creates a new raw tile, and returns a reference to it so it can be filled in
 	 */
 	RawTile &newTile() {
@@ -491,7 +491,7 @@ public:
 };
 
 struct AttrmapEntry {
-	/**
+	/*
 	 * This field can either be a proto-palette ID, or `transparent` to indicate that the
 	 * corresponding tile is fully transparent. If you are looking to get the palette ID for this
 	 * attrmap entry while correctly handling the above, use `getPalID`.
@@ -831,7 +831,7 @@ struct UniqueTiles {
 	UniqueTiles(UniqueTiles const &) = delete;
 	UniqueTiles(UniqueTiles &&) = default;
 
-	/**
+	/*
 	 * Adds a tile to the collection, and returns its ID
 	 */
 	std::tuple<uint16_t, TileData::MatchType> addTile(Png::TilesVisitor::Tile const &tile,
@@ -857,7 +857,7 @@ struct UniqueTiles {
 	auto end() const { return tiles.end(); }
 };
 
-/**
+/*
  * Generate tile data while deduplicating unique tiles (via mirroring if enabled)
  * Additionally, while we have the info handy, convert from the 16-bit "global" tile IDs to
  * 8-bit tile IDs + the bank bit; this will save the work when we output the data later (potentially
@@ -986,16 +986,17 @@ void process() {
 				protoPalettes[n] = tileColors; // Override them
 				// Remove any other proto-palettes that we encompass
 				// (Example [(0, 1), (0, 2)], inserting (0, 1, 2))
-				/* The following code does its job, except that references to the removed
+				/*
+				 * The following code does its job, except that references to the removed
 				 * proto-palettes are not updated, causing issues.
 				 * TODO: overlap might not be detrimental to the packing algorithm.
 				 * Investigation is necessary, especially if pathological cases are found.
-
-				for (size_t i = protoPalettes.size(); --i != n;) {
-				    if (tileColors.compare(protoPalettes[i]) == ProtoPalette::WE_BIGGER) {
-				        protoPalettes.erase(protoPalettes.begin() + i);
-				    }
-				}
+				 *
+				 * for (size_t i = protoPalettes.size(); --i != n;) {
+				 *     if (tileColors.compare(protoPalettes[i]) == ProtoPalette::WE_BIGGER) {
+				 *         protoPalettes.erase(protoPalettes.begin() + i);
+				 *     }
+				 * }
 				*/
 				[[fallthrough]];
 

--- a/src/gfx/rgba.cpp
+++ b/src/gfx/rgba.cpp
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2022, Eldred Habert and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "gfx/rgba.hpp"
 
 #include <assert.h>

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -15,10 +15,8 @@
 #include "error.h"
 #include "hashmap.h"
 
-/*
- * The lower half of the hash is used to index the "master" table,
- * the upper half is used to help resolve collisions more quickly
- */
+// The lower half of the hash is used to index the "master" table,
+// the upper half is used to help resolve collisions more quickly
 #define UINT_BITS_(NB_BITS) uint##NB_BITS##_t
 #define UINT_BITS(NB_BITS)  UINT_BITS_(NB_BITS)
 typedef UINT_BITS(HASH_NB_BITS) HashType;
@@ -34,7 +32,7 @@ struct HashMapEntry {
 #define FNV_OFFSET_BASIS 0x811c9dc5
 #define FNV_PRIME 16777619
 
-/* FNV-1a hash */
+// FNV-1a hash
 static HashType hash(char const *str)
 {
 	HashType hash = FNV_OFFSET_BASIS;

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -47,7 +47,7 @@ static struct {
 	} *banks;
 } sections[SECTTYPE_INVALID];
 
-/* Defines the order in which types are output to the sym and map files */
+// Defines the order in which types are output to the sym and map files
 static enum SectionType typeMap[SECTTYPE_INVALID] = {
 	SECTTYPE_ROM0,
 	SECTTYPE_ROMX,
@@ -124,7 +124,7 @@ struct Section const *out_OverlappingSection(struct Section const *section)
 	return NULL;
 }
 
-/**
+/*
  * Performs sanity checks on the overlay file.
  * @return The number of ROM banks in the overlay file
  */
@@ -140,7 +140,7 @@ static uint32_t checkOverlaySize(void)
 
 	long overlaySize = ftell(overlayFile);
 
-	/* Reset back to beginning */
+	// Reset back to beginning
 	fseek(overlayFile, 0, SEEK_SET);
 
 	if (overlaySize % BANK_SIZE)
@@ -157,7 +157,7 @@ static uint32_t checkOverlaySize(void)
 	return nbOverlayBanks;
 }
 
-/**
+/*
  * Expand sections[SECTTYPE_ROMX].banks to cover all the overlay banks.
  * This ensures that writeROM will output each bank, even if some are not
  * covered by any sections.
@@ -165,9 +165,9 @@ static uint32_t checkOverlaySize(void)
  */
 static void coverOverlayBanks(uint32_t nbOverlayBanks)
 {
-	/* 2 if is32kMode, 1 otherwise */
+	// 2 if is32kMode, 1 otherwise
 	uint32_t nbRom0Banks = sectionTypeInfo[SECTTYPE_ROM0].size / BANK_SIZE;
-	/* Discount ROM0 banks to avoid outputting too much */
+	// Discount ROM0 banks to avoid outputting too much
 	uint32_t nbUncoveredBanks = nbOverlayBanks - nbRom0Banks > sections[SECTTYPE_ROMX].nbBanks
 				    ? nbOverlayBanks - nbRom0Banks
 				    : 0;
@@ -186,7 +186,7 @@ static void coverOverlayBanks(uint32_t nbOverlayBanks)
 	}
 }
 
-/**
+/*
  * Write a ROM bank's sections to the output file.
  * @param bankSections The bank's sections, ordered by increasing address
  * @param baseOffset The address of the bank's first byte in GB address space
@@ -201,18 +201,18 @@ static void writeBank(struct SortedSection *bankSections, uint16_t baseOffset,
 		struct Section const *section = bankSections->section;
 
 		assert(section->offset == 0);
-		/* Output padding up to the next SECTION */
+		// Output padding up to the next SECTION
 		while (offset + baseOffset < section->org) {
 			putc(overlayFile ? getc(overlayFile) : padValue,
 			     outputFile);
 			offset++;
 		}
 
-		/* Output the section itself */
+		// Output the section itself
 		fwrite(section->data, sizeof(*section->data), section->size,
 		       outputFile);
 		if (overlayFile) {
-			/* Skip bytes even with pipes */
+			// Skip bytes even with pipes
 			for (uint16_t i = 0; i < section->size; i++)
 				getc(overlayFile);
 		}
@@ -231,9 +231,7 @@ static void writeBank(struct SortedSection *bankSections, uint16_t baseOffset,
 	}
 }
 
-/**
- * Writes a ROM file to the output.
- */
+// Writes a ROM file to the output.
 static void writeROM(void)
 {
 	outputFile = openFile(outputFileName, "wb");
@@ -258,7 +256,7 @@ static void writeROM(void)
 	closeFile(overlayFile);
 }
 
-/**
+/*
  * Get the lowest section by address out of the two
  * @param s1 One choice
  * @param s2 The other
@@ -275,10 +273,8 @@ static struct SortedSection const **nextSection(struct SortedSection const **s1,
 	return (*s1)->section->org < (*s2)->section->org ? s1 : s2;
 }
 
-/*
- * Comparator function for `qsort` to sort symbols
- * Symbols are ordered by address, or else by original index for a stable sort
- */
+// Comparator function for `qsort` to sort symbols
+// Symbols are ordered by address, or else by original index for a stable sort
 static int compareSymbols(void const *a, void const *b)
 {
 	struct SortedSymbol const *sym1 = (struct SortedSymbol const *)a;
@@ -290,7 +286,7 @@ static int compareSymbols(void const *a, void const *b)
 	return sym1->idx < sym2->idx ? -1 : sym1->idx > sym2->idx ? 1 : 0;
 }
 
-/**
+/*
  * Write a bank's contents to the sym file
  * @param bankSections The bank's sections
  */
@@ -357,7 +353,7 @@ static void writeSymBank(struct SortedSections const *bankSections,
 	free(symList);
 }
 
-/**
+/*
  * Write a bank's contents to the map file
  * @param bankSections The bank's sections
  * @return The bank's used space
@@ -445,7 +441,7 @@ static uint16_t writeMapBank(struct SortedSections const *sectList,
 	return used;
 }
 
-/**
+/*
  * Write the total used space by section type to the map file
  * @param usedMap The total used space by section type
  */
@@ -471,9 +467,7 @@ static void writeMapUsed(uint32_t usedMap[MIN_NB_ELMS(SECTTYPE_INVALID)])
 	}
 }
 
-/**
- * Writes the sym and/or map files, if applicable.
- */
+// Writes the sym and/or map files, if applicable.
 static void writeSymAndMap(void)
 {
 	if (!symFileName && !mapFileName)

--- a/src/link/patch.c
+++ b/src/link/patch.c
@@ -63,11 +63,9 @@ static void pushRPN(int32_t value, bool comesFromError)
 			realloc(stack.values, sizeof(*stack.values) * stack.capacity);
 		stack.errorFlags =
 			realloc(stack.errorFlags, sizeof(*stack.errorFlags) * stack.capacity);
-		/*
-		 * Static analysis tools complain that the capacity might become
-		 * zero due to overflow, but fail to realize that it's caught by
-		 * the overflow check above. Hence the stringent check below.
-		 */
+		// Static analysis tools complain that the capacity might become
+		// zero due to overflow, but fail to realize that it's caught by
+		// the overflow check above. Hence the stringent check below.
 		if (!stack.values || !stack.errorFlags || !stack.capacity)
 			err("Failed to resize RPN stack");
 	}
@@ -97,7 +95,7 @@ static void freeRPNStack(void)
 	free(stack.errorFlags);
 }
 
-/* RPN operators */
+// RPN operators
 
 static uint32_t getRPNByte(uint8_t const **expression, int32_t *size,
 			   struct FileStackNode const *node, uint32_t lineNo)
@@ -111,17 +109,17 @@ static uint32_t getRPNByte(uint8_t const **expression, int32_t *size,
 static struct Symbol const *getSymbol(struct Symbol const * const *symbolList,
 				      uint32_t index)
 {
-	assert(index != (uint32_t)-1); /* PC needs to be handled specially, not here */
+	assert(index != (uint32_t)-1); // PC needs to be handled specially, not here
 	struct Symbol const *symbol = symbolList[index];
 
-	/* If the symbol is defined elsewhere... */
+	// If the symbol is defined elsewhere...
 	if (symbol->type == SYMTYPE_IMPORT)
 		return sym_GetSymbol(symbol->name);
 
 	return symbol;
 }
 
-/**
+/*
  * Compute a patch's value from its RPN string.
  * @param patch The patch to compute the value of
  * @param section The section the patch is contained in
@@ -132,7 +130,7 @@ static struct Symbol const *getSymbol(struct Symbol const * const *symbolList,
 static int32_t computeRPNExpr(struct Patch const *patch,
 			      struct Symbol const * const *fileSymbols)
 {
-/* Small shortcut to avoid a lot of repetition */
+// Small shortcut to avoid a lot of repetition
 #define popRPN() popRPN(patch->src, patch->lineNo)
 
 	uint8_t const *expression = patch->rpnExpression;
@@ -147,13 +145,10 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 
 		isError = false;
 
-		/*
-		 * Friendly reminder:
-		 * Be VERY careful with two `popRPN` in the same expression.
-		 * C does not guarantee order of evaluation of operands!!
-		 * So, if there are two `popRPN` in the same expression, make
-		 * sure the operation is commutative.
-		 */
+		// Be VERY careful with two `popRPN` in the same expression.
+		// C does not guarantee order of evaluation of operands!!
+		// So, if there are two `popRPN` in the same expression, make
+		// sure the operation is commutative.
 		switch (command) {
 			struct Symbol const *symbol;
 			char const *name;
@@ -295,11 +290,9 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 			break;
 
 		case RPN_BANK_SECT:
-			/*
-			 * `expression` is not guaranteed to be '\0'-terminated. If it is not,
-			 * `getRPNByte` will have a fatal internal error.
-			 * In either case, `getRPNByte` will not free `expression`.
-			 */
+			// `expression` is not guaranteed to be '\0'-terminated. If it is not,
+			// `getRPNByte` will have a fatal internal error.
+			// In either case, `getRPNByte` will not free `expression`.
 			name = (char const *)expression;
 			while (getRPNByte(&expression, &size, patch->src, patch->lineNo))
 				;
@@ -329,7 +322,7 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 			break;
 
 		case RPN_SIZEOF_SECT:
-			/* This has assumptions commented in the `RPN_BANK_SECT` case above. */
+			// This has assumptions commented in the `RPN_BANK_SECT` case above.
 			name = (char const *)expression;
 			while (getRPNByte(&expression, &size, patch->src, patch->lineNo))
 				;
@@ -348,7 +341,7 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 			break;
 
 		case RPN_STARTOF_SECT:
-			/* This has assumptions commented in the `RPN_BANK_SECT` case above. */
+			// This has assumptions commented in the `RPN_BANK_SECT` case above.
 			name = (char const *)expression;
 			while (getRPNByte(&expression, &size, patch->src, patch->lineNo))
 				;
@@ -381,9 +374,8 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 
 		case RPN_RST:
 			value = popRPN();
-			/* Acceptable values are 0x00, 0x08, 0x10, ..., 0x38
-			 * They can be easily checked with a bitmask
-			 */
+			// Acceptable values are 0x00, 0x08, 0x10, ..., 0x38
+			// They can be easily checked with a bitmask
 			if (value & ~0x38) {
 				if (!isError)
 					error(patch->src, patch->lineNo,
@@ -406,7 +398,7 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 				value |= getRPNByte(&expression, &size,
 						    patch->src, patch->lineNo) << shift;
 
-			if (value == -1) { /* PC */
+			if (value == -1) { // PC
 				if (!patch->pcSection) {
 					error(patch->src, patch->lineNo,
 					      "PC has no value outside a section");
@@ -424,7 +416,7 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 					isError = true;
 				} else {
 					value = symbol->value;
-					/* Symbols attached to sections have offsets */
+					// Symbols attached to sections have offsets
 					if (symbol->section)
 						value += symbol->section->org;
 				}
@@ -461,8 +453,8 @@ void patch_CheckAssertions(struct Assertion *assert)
 				fatal(assert->patch.src, assert->patch.lineNo, "%s",
 				      assert->message[0] ? assert->message
 							 : "assert failure");
-				/* Not reached */
-				break; /* Here so checkpatch doesn't complain */
+				// Not reached
+				break; // Here so checkpatch doesn't complain
 			case ASSERT_ERROR:
 				error(assert->patch.src, assert->patch.lineNo, "%s",
 				      assert->message[0] ? assert->message
@@ -491,7 +483,7 @@ void patch_CheckAssertions(struct Assertion *assert)
 	freeRPNStack();
 }
 
-/**
+/*
  * Applies all of a section's patches
  * @param section The section to patch
  * @param arg Ignored callback arg
@@ -506,7 +498,7 @@ static void applyFilePatches(struct Section *section, struct Section *dataSectio
 							section->fileSymbols);
 		uint16_t offset = patch->offset + section->offset;
 
-		/* `jr` is quite unlike the others... */
+		// `jr` is quite unlike the others...
 		if (patch->type == PATCHTYPE_JR) {
 			// Offset is relative to the byte *after* the operand
 			// PC as operand to `jr` is lower than reference PC by 2
@@ -519,7 +511,7 @@ static void applyFilePatches(struct Section *section, struct Section *dataSectio
 				      jumpOffset);
 			dataSection->data[offset] = jumpOffset & 0xFF;
 		} else {
-			/* Patch a certain number of bytes */
+			// Patch a certain number of bytes
 			struct {
 				uint8_t size;
 				int32_t min;
@@ -544,7 +536,7 @@ static void applyFilePatches(struct Section *section, struct Section *dataSectio
 	}
 }
 
-/**
+/*
  * Applies all of a section's patches, iterating over "components" of
  * unionized sections
  * @param section The section to patch

--- a/src/link/sdas_obj.c
+++ b/src/link/sdas_obj.c
@@ -1,3 +1,10 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2022, Eldred Habert and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #include <assert.h>
 #include <ctype.h>

--- a/src/link/section.c
+++ b/src/link/section.c
@@ -166,7 +166,7 @@ static void mergeSections(struct Section *target, struct Section *other, enum Se
 		// `data` pointer, or a size of 0.
 		if (other->data) {
 			if (target->data) {
-				/* Ensure we're not allocating 0 bytes */
+				// Ensure we're not allocating 0 bytes
 				target->data = realloc(target->data,
 						       sizeof(*target->data) * target->size + 1);
 				if (!target->data)
@@ -177,7 +177,7 @@ static void mergeSections(struct Section *target, struct Section *other, enum Se
 				target->data = other->data;
 				other->data = NULL; // Prevent a double free()
 			}
-			/* Adjust patches' PC offsets */
+			// Adjust patches' PC offsets
 			for (uint32_t patchID = 0; patchID < other->nbPatches; patchID++)
 				other->patches[patchID].pcOffset += other->offset;
 		} else if (target->data) {
@@ -195,7 +195,7 @@ static void mergeSections(struct Section *target, struct Section *other, enum Se
 
 void sect_AddSection(struct Section *section)
 {
-	/* Check if the section already exists */
+	// Check if the section already exists
 	struct Section *other = hash_GetElement(sections, section->name);
 
 	if (other) {
@@ -210,7 +210,7 @@ void sect_AddSection(struct Section *section)
 		errx("Section \"%s\" is of type %s, which cannot be unionized",
 		     section->name, sectionTypeInfo[section->type].name);
 	} else {
-		/* If not, add it */
+		// If not, add it
 		hash_AddElement(sections, section->name, section);
 	}
 }
@@ -229,7 +229,7 @@ static void doSanityChecks(struct Section *section, void *ptr)
 {
 	(void)ptr;
 
-	/* Sanity check the section's type */
+	// Sanity check the section's type
 
 	if (section->type < 0 || section->type >= SECTTYPE_INVALID) {
 		error(NULL, 0, "Section \"%s\" has an invalid type", section->name);
@@ -254,14 +254,12 @@ static void doSanityChecks(struct Section *section, void *ptr)
 		error(NULL, 0, "%s: VRAM bank 1 can't be used with option -d",
 		     section->name);
 
-	/*
-	 * Check if alignment is reasonable, this is important to avoid UB
-	 * An alignment of zero is equivalent to no alignment, basically
-	 */
+	// Check if alignment is reasonable, this is important to avoid UB
+	// An alignment of zero is equivalent to no alignment, basically
 	if (section->isAlignFixed && section->alignMask == 0)
 		section->isAlignFixed = false;
 
-	/* Too large an alignment may not be satisfiable */
+	// Too large an alignment may not be satisfiable
 	if (section->isAlignFixed && (section->alignMask & sectionTypeInfo[section->type].startAddr))
 		error(NULL, 0, "%s: %s sections cannot be aligned to $%04x bytes",
 		     section->name, sectionTypeInfo[section->type].name, section->alignMask + 1);
@@ -274,12 +272,12 @@ static void doSanityChecks(struct Section *section, void *ptr)
 			: "Cannot place section \"%s\" in bank %" PRIu32 ", it must be between %" PRIu32 " and %" PRIu32,
 		     section->name, section->bank, minbank, maxbank);
 
-	/* Check if section has a chance to be placed */
+	// Check if section has a chance to be placed
 	if (section->size > sectionTypeInfo[section->type].size)
 		error(NULL, 0, "Section \"%s\" is bigger than the max size for that type: %#" PRIx16 " > %#" PRIx16,
 		     section->name, section->size, sectionTypeInfo[section->type].size);
 
-	/* Translate loose constraints to strong ones when they're equivalent */
+	// Translate loose constraints to strong ones when they're equivalent
 
 	if (minbank == maxbank) {
 		section->bank = minbank;
@@ -287,7 +285,7 @@ static void doSanityChecks(struct Section *section, void *ptr)
 	}
 
 	if (section->isAddressFixed) {
-		/* It doesn't make sense to have both org and alignment set */
+		// It doesn't make sense to have both org and alignment set
 		if (section->isAlignFixed) {
 			if ((section->org & section->alignMask) != section->alignOfs)
 				error(NULL, 0, "Section \"%s\"'s fixed address doesn't match its alignment",
@@ -295,7 +293,7 @@ static void doSanityChecks(struct Section *section, void *ptr)
 			section->isAlignFixed = false;
 		}
 
-		/* Ensure the target address is valid */
+		// Ensure the target address is valid
 		if (section->org < sectionTypeInfo[section->type].startAddr
 		 || section->org > endaddr(section->type))
 			error(NULL, 0, "Section \"%s\"'s fixed address %#" PRIx16 " is outside of range [%#"

--- a/src/link/symbol.c
+++ b/src/link/symbol.c
@@ -40,7 +40,7 @@ void sym_ForEach(void (*callback)(struct Symbol *, void *), void *arg)
 
 void sym_AddSymbol(struct Symbol *symbol)
 {
-	/* Check if the symbol already exists */
+	// Check if the symbol already exists
 	struct Symbol *other = hash_GetElement(symbols, symbol->name);
 
 	if (other) {
@@ -53,7 +53,7 @@ void sym_AddSymbol(struct Symbol *symbol)
 		exit(1);
 	}
 
-	/* If not, add it */
+	// If not, add it
 	hash_AddElement(symbols, symbol->name, symbol);
 }
 

--- a/src/linkdefs.c
+++ b/src/linkdefs.c
@@ -1,3 +1,10 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2022, RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #include "linkdefs.h"
 

--- a/src/opmath.c
+++ b/src/opmath.c
@@ -6,9 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-/*
- * Mathematical operators that don't reuse C's behavior
- */
+// Mathematical operators that don't reuse C's behavior
 
 #include <stdint.h>
 

--- a/test/gfx/rgbgfx_test.cpp
+++ b/test/gfx/rgbgfx_test.cpp
@@ -1,3 +1,10 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2022, Eldred Habert and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 // For `execProg` (Windows is its special little snowflake again)
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
@@ -125,7 +132,7 @@ public:
 
 	Rgba const &pixel(uint32_t x, uint32_t y) const { return pixels[y * width + x]; }
 
-	/**
+	/*
 	 * Reads a PNG and notes all of its colors
 	 *
 	 * This code is more complicated than strictly necessary, but that's because of the API
@@ -298,7 +305,7 @@ static char *execProg(char const *name, char * const *argv) {
 		fatal("%s returned with status %d", name, info.si_status);
 	}
 
-#else /* defined(_MSC_VER) || defined(__MINGW32__) */
+#else // defined(_MSC_VER) || defined(__MINGW32__)
 
 	auto winStrerror = [](DWORD errnum) {
 		LPTSTR buf;


### PR DESCRIPTION
Fixes #1037

- Changes most `/* comments */` to `// comments`
- Changes `/**` block comments consistently to `/*`
- Adds consistent license comments to all files

Also renames `T_POP_SET` to `T_Z80_SET`