### PR TITLE
Only warn about unmapped characters in non-empty charmaps

### DIFF
--- a/contrib/zsh_compl/_rgbasm
+++ b/contrib/zsh_compl/_rgbasm
@@ -29,7 +29,7 @@ _rgbasm_warnings() {
 		'user:Warn when executing the WARN built-in'
 	)
 	# TODO: handle `no-` and `error=` somehow?
-	# TODO: handle `=0|1|2` levels for `numeric-string` and `truncation`?
+	# TODO: handle `=0|1|2` levels for `numeric-string`, `truncation`, and `unmapped-char`?
 	_describe warning warnings
 }
 

--- a/include/asm/charmap.h
+++ b/include/asm/charmap.h
@@ -11,6 +11,8 @@
 
 #include <stdint.h>
 
+#define DEFAULT_CHARMAP_NAME "main"
+
 struct Charmap *charmap_New(char const *name, char const *baseName);
 void charmap_Delete(struct Charmap *charmap);
 void charmap_Set(char const *name);

--- a/include/asm/warning.h
+++ b/include/asm/warning.h
@@ -36,7 +36,6 @@ enum WarningID {
 	WARNING_OBSOLETE,	      // Obsolete things
 	WARNING_SHIFT,		      // Shifting undefined behavior
 	WARNING_SHIFT_AMOUNT,	      // Strange shift amount
-	WARNING_UNMAPPED_CHAR,	      // Character without charmap entry
 	WARNING_USER,		      // User warnings
 
 	NB_PLAIN_WARNINGS,
@@ -49,6 +48,9 @@ enum WarningID {
 	// Implicit truncation loses some bits
 	WARNING_TRUNCATION_1,
 	WARNING_TRUNCATION_2,
+	// Character without charmap entry
+	WARNING_UNMAPPED_CHAR_1,
+	WARNING_UNMAPPED_CHAR_2,
 
 	NB_PLAIN_AND_PARAM_WARNINGS,
 #define NB_PARAM_WARNINGS (NB_PLAIN_AND_PARAM_WARNINGS - PARAM_WARNINGS_START)

--- a/man/rgbasm.1
+++ b/man/rgbasm.1
@@ -320,12 +320,19 @@ warns when an N-bit value's absolute value is 2**N or greater.
 or just
 .Fl Wtruncation
 also warns when an N-bit value is less than -2**(N-1), which will not fit in two's complement encoding.
-.It Fl Wunmapped-char
+.It Fl Wunmapped-char=
 Warn when a character goes through charmap conversion but has no defined mapping.
-This warning is always disabled if the active charmap is empty, and/or is the default charmap
+.Fl Wunmapped-char=0
+or
+.Fl Wunmapped-char
+disables this warning.
+.Fl Wunmapped-char=1
+or just
+.Fl Wunmapped-char
+only warns if the active charmap is not empty.
+.Fl Wunmapped-char=2
+warns if the active charmap is empty, and/or is not the default charmap
 .Sq main .
-This warning is enabled by
-.Fl Wall .
 .It Fl Wno-user
 Warn when the
 .Ic WARN

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -251,8 +251,12 @@ size_t charmap_ConvertNext(char const **input, uint8_t **output)
 
 				// Warn if this character is not mapped but any others are
 				if (charmap->usedNodes > 1)
-					warning(WARNING_UNMAPPED_CHAR,
+					warning(WARNING_UNMAPPED_CHAR_1,
 						"Unmapped character %s\n", printChar(firstChar));
+				else if (strcmp(charmap->name, DEFAULT_CHARMAP_NAME))
+					warning(WARNING_UNMAPPED_CHAR_2,
+						"Unmapped character %s not in " DEFAULT_CHARMAP_NAME
+						" charmap\n", printChar(firstChar));
 
 				return codepointLen;
 

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -249,9 +249,8 @@ size_t charmap_ConvertNext(char const **input, uint8_t **output)
 				if (output)
 					*output += codepointLen;
 
-				// Check if the character map is not the default "main" one, or if
-				// it has any mappings defined
-				if (strcmp(charmap->name, "main") || charmap->usedNodes > 1)
+				// Warn if this character is not mapped but any others are
+				if (charmap->usedNodes > 1)
 					warning(WARNING_UNMAPPED_CHAR,
 						"Unmapped character %s\n", printChar(firstChar));
 

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -378,7 +378,7 @@ int main(int argc, char *argv[])
 		fprintf(dependfile, "%s: %s\n", targetFileName, mainFileName);
 	}
 
-	charmap_New("main", NULL);
+	charmap_New(DEFAULT_CHARMAP_NAME, NULL);
 
 	// Init lexer and file stack, providing file info
 	lexer_Init();

--- a/src/asm/warning.c
+++ b/src/asm/warning.c
@@ -38,13 +38,14 @@ static const enum WarningState defaultWarnings[ARRAY_SIZE(warningStates)] = {
 	[WARNING_OBSOLETE]		= WARNING_ENABLED,
 	[WARNING_SHIFT]			= WARNING_DISABLED,
 	[WARNING_SHIFT_AMOUNT]		= WARNING_DISABLED,
-	[WARNING_UNMAPPED_CHAR]		= WARNING_ENABLED,
 	[WARNING_USER]			= WARNING_ENABLED,
 
 	[WARNING_NUMERIC_STRING_1]	= WARNING_ENABLED,
 	[WARNING_NUMERIC_STRING_2]	= WARNING_DISABLED,
 	[WARNING_TRUNCATION_1]		= WARNING_ENABLED,
 	[WARNING_TRUNCATION_2]		= WARNING_DISABLED,
+	[WARNING_UNMAPPED_CHAR_1]	= WARNING_ENABLED,
+	[WARNING_UNMAPPED_CHAR_2]	= WARNING_DISABLED,
 };
 
 enum WarningState warningStates[ARRAY_SIZE(warningStates)];
@@ -86,7 +87,6 @@ static const char * const warningFlags[NB_WARNINGS] = {
 	"obsolete",
 	"shift",
 	"shift-amount",
-	"unmapped-char",
 	"user",
 
 	// Parametric warnings
@@ -94,6 +94,8 @@ static const char * const warningFlags[NB_WARNINGS] = {
 	"numeric-string",
 	"truncation",
 	"truncation",
+	"unmapped-char",
+	"unmapped-char",
 
 	// Meta warnings
 	"all",
@@ -108,6 +110,7 @@ static const struct {
 } paramWarnings[] = {
 	{ "numeric-string", 2, 1 },
 	{ "truncation", 2, 2 },
+	{ "unmapped-char", 2, 1 },
 };
 
 static bool tryProcessParamWarning(char const *flag, uint8_t param, enum WarningState state)
@@ -162,8 +165,8 @@ static uint8_t const _wallCommands[] = {
 	WARNING_LONG_STR,
 	WARNING_NESTED_COMMENT,
 	WARNING_OBSOLETE,
-	WARNING_UNMAPPED_CHAR,
 	WARNING_NUMERIC_STRING_1,
+	WARNING_UNMAPPED_CHAR_1,
 	META_WARNING_DONE
 };
 
@@ -176,6 +179,8 @@ static uint8_t const _wextraCommands[] = {
 	WARNING_NUMERIC_STRING_2,
 	WARNING_TRUNCATION_1,
 	WARNING_TRUNCATION_2,
+	WARNING_UNMAPPED_CHAR_1,
+	WARNING_UNMAPPED_CHAR_2,
 	META_WARNING_DONE
 };
 
@@ -194,11 +199,12 @@ static uint8_t const _weverythingCommands[] = {
 	WARNING_OBSOLETE,
 	WARNING_SHIFT,
 	WARNING_SHIFT_AMOUNT,
-	WARNING_UNMAPPED_CHAR,
 	WARNING_NUMERIC_STRING_1,
 	WARNING_NUMERIC_STRING_2,
 	WARNING_TRUNCATION_1,
 	WARNING_TRUNCATION_2,
+	WARNING_UNMAPPED_CHAR_1,
+	WARNING_UNMAPPED_CHAR_2,
 	// WARNING_USER,
 	META_WARNING_DONE
 };

--- a/test/asm/unmapped-char.asm
+++ b/test/asm/unmapped-char.asm
@@ -4,7 +4,9 @@ SECTION "test", ROM0
 
 	pushc
 	newcharmap custom
-	db "A" ; unmapped in non-default charmap
+	db "A" ; OK, unmapped in non-default empty charmap
+	charmap "C", $99
+	db "A" ; unmapped in non-empty charmap
 	popc
 
 	db "A" ; OK, default empty charmap again

--- a/test/asm/unmapped-char.asm
+++ b/test/asm/unmapped-char.asm
@@ -1,3 +1,5 @@
+opt Wunmapped-char=1 ; non-default empty charmaps can have unmapped chars
+
 SECTION "test", ROM0
 
 	db "A" ; OK, default empty charmap
@@ -5,6 +7,10 @@ SECTION "test", ROM0
 	pushc
 	newcharmap custom
 	db "A" ; OK, unmapped in non-default empty charmap
+		pusho
+		opt Wunmapped-char=2
+		db "A" ; unmapped in non-default empty charmap
+		popo
 	charmap "C", $99
 	db "A" ; unmapped in non-empty charmap
 	popc

--- a/test/asm/unmapped-char.err
+++ b/test/asm/unmapped-char.err
@@ -1,4 +1,4 @@
-warning: unmapped-char.asm(7): [-Wunmapped-char]
+warning: unmapped-char.asm(9): [-Wunmapped-char]
     Unmapped character 'A'
-warning: unmapped-char.asm(13): [-Wunmapped-char]
+warning: unmapped-char.asm(15): [-Wunmapped-char]
     Unmapped character 'A'

--- a/test/asm/unmapped-char.err
+++ b/test/asm/unmapped-char.err
@@ -1,4 +1,6 @@
-warning: unmapped-char.asm(9): [-Wunmapped-char]
-    Unmapped character 'A'
+warning: unmapped-char.asm(12): [-Wunmapped-char]
+    Unmapped character 'A' not in main charmap
 warning: unmapped-char.asm(15): [-Wunmapped-char]
+    Unmapped character 'A'
+warning: unmapped-char.asm(21): [-Wunmapped-char]
     Unmapped character 'A'

--- a/test/asm/unmapped-char.out.bin
+++ b/test/asm/unmapped-char.out.bin
@@ -1,1 +1,1 @@
-AAAAA
+AAAAAAA


### PR DESCRIPTION
Fixes #1058