### PR TITLE
Remove legacy support for generating a palette with unused colors

### DIFF
--- a/src/gfx/pal_sorting.cpp
+++ b/src/gfx/pal_sorting.cpp
@@ -28,31 +28,6 @@ void indexed(std::vector<Palette> &palettes, int palSize, png_color const *palRG
 		return Rgba(c.red, c.green, c.blue, palAlpha ? palAlpha[index] : 0xFF);
 	};
 
-	// HACK: for compatibility with old versions, add unused colors if:
-	// - there is only one palette, and
-	// - only some of the first N colors are being used
-	if (palettes.size() == 1) {
-		Palette &palette = palettes[0];
-		// Build our candidate array of colors
-		decltype(palette.colors) colors{UINT16_MAX, UINT16_MAX, UINT16_MAX, UINT16_MAX};
-		for (int i = 0; i < options.maxOpaqueColors(); ++i) {
-			colors[i + options.hasTransparentPixels] = pngToRgb(i).cgbColor();
-		}
-
-		// Check that the palette only uses those colors
-		if (std::all_of(palette.begin(), palette.end(), [&colors](uint16_t color) {
-			    return std::find(colors.begin(), colors.end(), color) != colors.end();
-		    })) {
-			if (palette.size() != options.maxOpaqueColors()) {
-				warning("Unused color in PNG embedded palette was re-added; please use `-c "
-				        "embedded` to get this in future versions");
-			}
-			// Overwrite the palette, and return with that (it's already sorted)
-			palette.colors = colors;
-			return;
-		}
-	}
-
 	for (Palette &pal : palettes) {
 		std::sort(pal.begin(), pal.end(), [&](uint16_t lhs, uint16_t rhs) {
 			// Iterate through the PNG's palette, looking for either of the two

--- a/test/patches/pokecrystal.patch
+++ b/test/patches/pokecrystal.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 387c2cca1..856968189 100644
+index bf54eb4ce..d75f86aae 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -104,7 +104,7 @@ tools:
@@ -11,6 +11,20 @@ index 387c2cca1..856968189 100644
  # Create a sym/map for debug purposes if `make` run with `DEBUG=1`
  ifeq ($(DEBUG),1)
  RGBASMFLAGS += -E
+@@ -208,9 +208,11 @@ gfx/pokemon/girafarig/front.animated.tilemap: gfx/pokemon/girafarig/front.2bpp g
+ 
+ ### Misc file-specific graphics rules
+ 
+-gfx/pokemon/%/back.2bpp: rgbgfx += -h
++gfx/pokemon/%/back.2bpp: rgbgfx += -h -c embedded
++gfx/pokemon/%/front.2bpp: rgbgfx += -c embedded
++gfx/pokemon/unown_%/front.2bpp: rgbgfx =
+ 
+-gfx/trainers/%.2bpp: rgbgfx += -h
++gfx/trainers/%.2bpp: rgbgfx += -h -c embedded
+ 
+ gfx/pokemon/egg/unused_front.2bpp: rgbgfx += -h
+ 
 diff --git a/macros/data.asm b/macros/data.asm
 index c2686c9f4..4dac70f3a 100644
 --- a/macros/data.asm

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -39,6 +39,6 @@ test_downstream() { # owner/repo shallow-since commit make-target
 	popd
 }
 
-test_downstream pret/pokecrystal 2022-09-26 a9869f18962353b056559dc14dfc00fef0df5978 compare
-test_downstream pret/pokered     2022-09-25 22859c4bb70dba17994c9b47b07f657ea082875d compare
+test_downstream pret/pokecrystal 2022-09-29 70a3ec1accb6de1c1c273470af0ddfa2edc1b0a9 compare
+test_downstream pret/pokered     2022-09-29 2b52ceb718b55dce038db24d177715ae4281d065 compare
 test_downstream AntonioND/ucity  2022-04-20 d8878233da7a6569f09f87b144cb5bf140146a0f ''


### PR DESCRIPTION
If you need an explicit set of colors, possibly including unused ones, use `-c`.

Fixes #1062