### PR TITLE
Comply with sym file spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ develop:
 		-fsanitize=signed-integer-overflow -fsanitize=bounds \
 		-fsanitize=object-size -fsanitize=bool -fsanitize=enum \
 		-fsanitize=alignment -fsanitize=null -fsanitize=address" \
-		CFLAGS="-ggdb3 -O0 -fno-omit-frame-pointer -fno-optimize-sibling-calls" \
+		CFLAGS="-ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls" \
 		CXXFLAGS="-ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls"
 
 # Targets for the project maintainer to easily create Windows exes.

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ rgblink_obj := \
 	src/link/section.o \
 	src/link/symbol.o \
 	src/extern/getopt.o \
+	src/extern/utf8decoder.o \
 	src/error.o \
 	src/hashmap.o \
 	src/linkdefs.o \
@@ -246,7 +247,7 @@ develop:
 		-fsanitize=signed-integer-overflow -fsanitize=bounds \
 		-fsanitize=object-size -fsanitize=bool -fsanitize=enum \
 		-fsanitize=alignment -fsanitize=null -fsanitize=address" \
-		CFLAGS="-ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls" \
+		CFLAGS="-ggdb3 -O0 -fno-omit-frame-pointer -fno-optimize-sibling-calls" \
 		CXXFLAGS="-ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls"
 
 # Targets for the project maintainer to easily create Windows exes.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,7 @@ set(rgblink_src
     "link/sdas_obj.c"
     "link/section.c"
     "link/symbol.c"
+    "extern/utf8decoder.c"
     "hashmap.c"
     "linkdefs.c"
     "opmath.c"

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -273,6 +273,12 @@ static struct SortedSection const **nextSection(struct SortedSection const **s1,
 	return (*s1)->section->org < (*s2)->section->org ? s1 : s2;
 }
 
+// Checks whether a symbol is
+static bool canStartSymName(char c)
+{
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
+}
+
 // Comparator function for `qsort` to sort symbols
 // Symbols are ordered by address, or else by original index for a stable sort
 static int compareSymbols(void const *a, void const *b)
@@ -315,29 +321,32 @@ static void writeSymBank(struct SortedSections const *bankSections,
 	if (!symList)
 		err("Failed to allocate symbol list");
 
-	uint32_t idx = 0;
+	nbSymbols = 0;
 
 	for (struct SortedSection const *ptr = bankSections->zeroLenSections; ptr; ptr = ptr->next) {
 		for (struct Section const *sect = ptr->section; sect; sect = sect->nextu) {
 			for (uint32_t i = 0; i < sect->nbSymbols; i++) {
-				symList[idx].idx = idx;
-				symList[idx].sym = sect->symbols[i];
-				symList[idx].addr = symList[idx].sym->offset + sect->org;
-				idx++;
+				if (!canStartSymName(sect->symbols[i]->name[0]))
+					continue;
+				symList[nbSymbols].idx = nbSymbols;
+				symList[nbSymbols].sym = sect->symbols[i];
+				symList[nbSymbols].addr = symList[nbSymbols].sym->offset + sect->org;
+				nbSymbols++;
 			}
 		}
 	}
 	for (struct SortedSection const *ptr = bankSections->sections; ptr; ptr = ptr->next) {
 		for (struct Section const *sect = ptr->section; sect; sect = sect->nextu) {
 			for (uint32_t i = 0; i < sect->nbSymbols; i++) {
-				symList[idx].idx = idx;
-				symList[idx].sym = sect->symbols[i];
-				symList[idx].addr = symList[idx].sym->offset + sect->org;
-				idx++;
+				if (!canStartSymName(sect->symbols[i]->name[0]))
+					continue;
+				symList[nbSymbols].idx = nbSymbols;
+				symList[nbSymbols].sym = sect->symbols[i];
+				symList[nbSymbols].addr = symList[nbSymbols].sym->offset + sect->org;
+				nbSymbols++;
 			}
 		}
 	}
-	assert(idx == nbSymbols);
 
 	qsort(symList, nbSymbols, sizeof(*symList), compareSymbols);
 


### PR DESCRIPTION
- Avoid printing symbols that begin with an illegal character
- Print illegal characters using Unicode escapes instead

Fixes #1076.

Should the former behaviour be documented?