### PR TITLE
Parse GPL palettes, and fixes PSP palette parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@
 .SUFFIXES:
 .SUFFIXES: .h .y .c .cpp .o
 
+.PHONY: all clean install checkcodebase checkpatch checkdiff develop debug mingw32 mingw64 wine-shim dist
+
 # User-defined variables
 
 Q		:= @
@@ -246,6 +248,13 @@ develop:
 		-fsanitize=signed-integer-overflow -fsanitize=bounds \
 		-fsanitize=object-size -fsanitize=bool -fsanitize=enum \
 		-fsanitize=alignment -fsanitize=null -fsanitize=address" \
+		CFLAGS="-ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls" \
+		CXXFLAGS="-ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls"
+
+# This target is used during development in order to more easily debug with gdb.
+
+debug:
+	$Qenv ${MAKE} \
 		CFLAGS="-ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls" \
 		CXXFLAGS="-ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls"
 

--- a/man/rgbgfx.1
+++ b/man/rgbgfx.1
@@ -380,6 +380,8 @@ The following formats are supported:
 .Lk https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577411_pgfId-1055819 Adobe Photoshop color swatch .
 .It Sy psp
 .Lk https://www.selapa.net/swatches/colors/fileformats.php#psp_pal Paint Shop Pro palette .
+.It Sy gpl
+.Lk https://docs.gimp.org/2.10/en/gimp-concepts-palettes.html GIMP palette .
 .El
 .Pp
 If you wish for another format to be supported, please open an issue (see

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -240,7 +240,8 @@ static std::optional<U> parseDec(std::string const &str, std::string::size_type 
 	return n > start ? std::optional<U>{value} : std::nullopt;
 }
 
-static std::optional<Rgba> parseColor(std::string const &str, std::string::size_type &n, uint16_t i) {
+static std::optional<Rgba> parseColor(std::string const &str, std::string::size_type &n,
+                                      uint16_t i) {
 	std::optional<uint8_t> r = parseDec<uint8_t>(str, n);
 	if (!r) {
 		error("Failed to parse color #%" PRIu16 " (\"%s\"): invalid red component", i + 1,
@@ -509,8 +510,8 @@ static void parseGBCFile(std::filebuf &file) {
 			break;
 		} else if (len != sizeof(buf)) {
 			error("GBC palette dump contains %zu 8-byte palette%s, plus %zu byte%s",
-			      options.palSpec.size(), options.palSpec.size() == 1 ? "" : "s",
-			      len, len == 1 ? "" : "s");
+			      options.palSpec.size(), options.palSpec.size() == 1 ? "" : "s", len,
+			      len == 1 ? "" : "s");
 			break;
 		}
 

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -338,6 +338,7 @@ static void parseGPLFile(std::filebuf &file) {
 
 	std::string line;
 	readLine(file, line);
+	// C++20 will allow `!line.starts_with("GIMP Palette")`
 	if (line.rfind("GIMP Palette", 0)) {
 		error("Palette file does not appear to be a GPL palette file");
 		return;

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -228,16 +228,16 @@ static void readLine(std::filebuf &file, std::string &buffer) {
 /*
  * Parses the initial part of a string_view, advancing the "read index" as it does
  */
-template<typename T>
-static std::optional<T> parseDec(std::string const &str, std::string::size_type &n) {
+template<typename U> // Should be uint*_t
+static std::optional<U> parseDec(std::string const &str, std::string::size_type &n) {
 	std::string::size_type start = n;
 
 	uintmax_t value = 0; // Use a larger type to handle overflow more easily
 	for (auto end = std::min(str.length(), str.find_first_not_of("0123456789", n)); n < end; ++n) {
-		value = std::min(value * 10 + (str[n] - '0'), (uintmax_t)std::numeric_limits<T>::max);
+		value = std::min(value * 10 + (str[n] - '0'), (uintmax_t)std::numeric_limits<U>::max);
 	}
 
-	return n > start ? std::optional<T>{value} : std::nullopt;
+	return n > start ? std::optional<U>{value} : std::nullopt;
 }
 
 static std::optional<Rgba> parseColor(std::string const &str, std::string::size_type &n, uint16_t i) {
@@ -338,7 +338,7 @@ static void parseGPLFile(std::filebuf &file) {
 
 	std::string line;
 	readLine(file, line);
-	// C++20 will allow `!line.starts_with("GIMP Palette")`
+	// FIXME: C++20 will allow `!line.starts_with` instead of `line.rfind` with 0
 	if (line.rfind("GIMP Palette", 0)) {
 		error("Palette file does not appear to be a GPL palette file");
 		return;
@@ -354,6 +354,7 @@ static void parseGPLFile(std::filebuf &file) {
 			break;
 		}
 
+		// FIXME: C++20 will allow `line.starts_with` instead of `!line.rfind` with 0
 		if (!line.rfind("#", 0) | !line.rfind("Name:", 0) || !line.rfind("Column:", 0)) {
 			continue;
 		}


### PR DESCRIPTION
Addresses one item of #1065

This changes how PSP palette files are parsed. If parsing a single number fails, i.e. there weren't any digits to parse, it will report that. Previously a blank "number of colors" line would count as 0 colors, and a missing blue value could not be reported.

Note that the use of `std::optional` with `parseDec` is closer to how `std::from_chars` would work if we could use that (returning a combined parsed value and parsing error flag).