### PR TITLE
Parse HEX palettes

### DIFF
--- a/man/rgbgfx.1
+++ b/man/rgbgfx.1
@@ -384,6 +384,10 @@ A GBC palette memory dump, as emitted by
 Useful to force several images to share the same palette.
 .It Cm gpl
 .Lk https://docs.gimp.org/2.10/en/gimp-concepts-palettes.html GIMP palette .
+.It Cm hex
+Plaintext lines of hexadecimal colors in
+.Ql rrggbb
+format.
 .It Cm psp
 .Lk https://www.selapa.net/swatches/colors/fileformats.php#psp_pal Paint Shop Pro palette .
 .El


### PR DESCRIPTION
Addresses one item of #1065

Fixes #1065, since the remaining suggested palette formats are redundant (TXT) or complex (JSON).

The same test case as #1080 works here, reformatted as tree.hex:

```
b5ff52
3a3a3a
63ce08
297300
d8f8d8
3a3a3a
a8a8a8
686868
d8f8d8
3a3a3a
f898c0
f05030
bdbdff
3a3a3a
9098f8
6860f8
```