### PR TITLE
Build macOS binaries on releases as well

### DIFF
--- a/.github/actions/install.sh
+++ b/.github/actions/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+install -d /usr/local/bin/ /usr/local/share/man/man1/ /usr/local/share/man/man5/ /usr/local/share/man/man7/
+install -s -m 755 rgbasm rgblink rgbfix rgbgfx /usr/local/bin/
+install -m 644 rgbasm.1 rgblink.1 rgbfix.1 rgbgfx.1 /usr/local/share/man/man1/
+install -m 644 rgbds.5 rgbasm.5 rgblink.5 /usr/local/share/man/man5/
+install -m 644 rgbds.7 gbz80.7 /usr/local/share/man/man7/

--- a/.github/workflows/create-release-artifacts.yaml
+++ b/.github/workflows/create-release-artifacts.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get version from tag
         shell: bash
-        run: | # Turn "refs/tags/vX.Y.Z" into "X.Y.Z"
+        run: | # Turn "vX.Y.Z" into "X.Y.Z"
           VERSION="${{ github.ref_name }}"
           echo "version=${VERSION#v}" >> $GITHUB_ENV
       - uses: actions/checkout@v2

--- a/.github/workflows/create-release-artifacts.yaml
+++ b/.github/workflows/create-release-artifacts.yaml
@@ -7,15 +7,26 @@ on:
 jobs:
   windows:
     runs-on: windows-2022
+    strategy:
+      matrix:
+        bits: [32, 64]
+        include:
+          - bits: 32
+            arch: x86
+            platform: Win32
+          - bits: 64
+            arch: x86_x64
+            platform: x64
+      fail-fast: false
     steps:
-      - uses: actions/checkout@v2
       - name: Get version from tag
         shell: bash
         run: | # Turn "refs/tags/vX.Y.Z" into "X.Y.Z"
-          VERSION="${{ github.ref }}"
-          echo "version=${VERSION##*/v}" >> $GITHUB_ENV
+          VERSION="${{ github.ref_name }}"
+          echo "version=${VERSION#v}" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
       - name: Get zlib, libpng and bison
-        run: | # TODO: use an array
+        run: | # TODO: use an array; remember to update the versions being downloaded, *and* the paths being extracted! (`Move-Item`)
           $wc = New-Object System.Net.WebClient
           $wc.DownloadFile('https://www.zlib.net/zlib1212.zip', 'zlib.zip')
           $hash = (Get-FileHash "zlib.zip" -Algorithm SHA256).Hash
@@ -39,45 +50,85 @@ jobs:
           Expand-Archive -DestinationPath install_dir "winflexbison.zip"
           Move-Item zlib-1.2.12 zlib
           Move-Item lpng1637 libpng
-      - name: Build 32-bit zlib
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            zbuild
+            pngbuild
+          key: ${{ matrix.arch }}-${{ hashFiles('zlib/**', 'libpng/**') }}
+      - name: Build zlib
         run: | # BUILD_SHARED_LIBS causes the output DLL to be correctly called `zlib1.dll`
-          cmake -S zlib -B zbuild32 -A Win32 -DCMAKE_INSTALL_PREFIX=install_dir -DBUILD_SHARED_LIBS=ON
-          cmake --build zbuild32 --config Release
-          cmake --install zbuild32
-      - name: Build 32-bit libpng
+          cmake -S zlib -B zbuild -A ${{ matrix.platform }} -DCMAKE_INSTALL_PREFIX=install_dir -DBUILD_SHARED_LIBS=ON
+          cmake --build zbuild --config Release -j
+        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Install zlib
         run: |
-          cmake -S libpng -B pngbuild32 -A Win32 -DCMAKE_INSTALL_PREFIX=install_dir -DPNG_SHARED=ON -DPNG_STATIC=ON -DPNG_TESTS=OFF
-          cmake --build pngbuild32 --config Release
-          cmake --install pngbuild32
-      - name: Build 32-bit Windows binaries
+          cmake --install zbuild
+      - name: Build libpng
         run: |
-          cmake -S . -B build32 -A Win32 -DCMAKE_INSTALL_PREFIX=install_dir -DCMAKE_BUILD_TYPE=Release
-          cmake --build build32 --config Release
-          cmake --install build32
-      - name: Package 32-bit binaries
+          cmake -S libpng -B pngbuild -A ${{ matrix.platform }} -DCMAKE_INSTALL_PREFIX=install_dir -DPNG_SHARED=ON -DPNG_STATIC=ON -DPNG_TESTS=OFF
+          cmake --build pngbuild --config Release -j
+        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Install libpng
         run: |
-          Compress-Archive -LiteralPath @("install_dir/bin/rgbasm.exe", "install_dir/bin/rgblink.exe", "install_dir/bin/rgbfix.exe", "install_dir/bin/rgbgfx.exe", "install_dir/bin/zlib1.dll", "install_dir/bin/libpng16.dll") "rgbds-${{ env.version }}-win32.zip"
-      - name: Build 64-bit zlib
-        run: | # BUILD_SHARED_LIBS causes the output DLL to be correctly called `zlib1.dll`
-          cmake -S zlib -B zbuild64 -A x64 -DCMAKE_INSTALL_PREFIX=install_dir -DBUILD_SHARED_LIBS=ON
-          cmake --build zbuild64 --config Release
-          cmake --install zbuild64
-      - name: Build 64-bit libpng
+          cmake --install pngbuild
+      - name: Build Windows binaries
         run: |
-          cmake -S libpng -B pngbuild64 -A x64 -DCMAKE_INSTALL_PREFIX=install_dir -DPNG_SHARED=ON -DPNG_STATIC=ON -DPNG_TESTS=OFF
-          cmake --build pngbuild64 --config Release
-          cmake --install pngbuild64
-      - name: Build 64-bit Windows binaries
+          cmake -S . -B build -A ${{ matrix.platform }} -DCMAKE_INSTALL_PREFIX=install_dir -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --config Release -j --verbose
+          cmake --install build --verbose --prefix install_dir --strip
+      - name: Package binaries
         run: |
-          cmake -S . -B build64 -A x64 -DCMAKE_INSTALL_PREFIX=install_dir -DCMAKE_BUILD_TYPE=Release
-          cmake --build build64 --config Release
-          cmake --install build64
-      - name: Package 64-bit binaries
+          Compress-Archive -LiteralPath @("install_dir/bin/rgbasm.exe", "install_dir/bin/rgblink.exe", "install_dir/bin/rgbfix.exe", "install_dir/bin/rgbgfx.exe", "install_dir/bin/zlib1.dll", "install_dir/bin/libpng16.dll") "rgbds-${{ env.version }}-win${{ matrix.bits }}.zip"
+      - name: Upload Windows binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: win${{ matrix.bits }}
+          path: rgbds-${{ env.version }}-win${{ matrix.bits }}.zip
+
+  macos:
+    runs-on: macos-12
+    steps:
+      - name: Get version from tag
+        shell: bash
+        run: | # Turn "refs/tags/vX.Y.Z" into "X.Y.Z"
+          VERSION="${{ github.ref_name }}"
+          echo "version=${VERSION#v}" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - name: Install deps
+        shell: bash
         run: |
-          Compress-Archive -LiteralPath @("install_dir/bin/rgbasm.exe", "install_dir/bin/rgblink.exe", "install_dir/bin/rgbfix.exe", "install_dir/bin/rgbgfx.exe", "install_dir/bin/zlib1.dll", "install_dir/bin/libpng16.dll") "rgbds-${{ env.version }}-win64.zip"
+          ./.github/actions/install_deps.sh macos-latest
+      # We force linking libpng statically; the other libs are provided by macOS itself
+      - name: Build binaries
+        run: |
+          export PATH="/usr/local/opt/bison/bin:$PATH"
+          make -j WARNFLAGS="-Wall -Wextra -mmacosx-version-min=10.9" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
+      - name: Package binaries
+        run: |
+          zip --junk-paths rgbds-${{ env.version }}-macos-x86-64.zip rgb{asm,link,fix,gfx} man/* .github/actions/install.sh
+      - name: Upload macOS binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos
+          path: rgbds-${{ env.version }}-macos-x86-64.zip
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [windows, macos]
+    steps:
+      - name: Get version from tag
+        shell: bash
+        run: | # Turn "refs/tags/vX.Y.Z" into "X.Y.Z"
+          VERSION="${{ github.ref_name }}"
+          echo "version=${VERSION#v}" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
       - name: Package sources
         run: |
-          make dist
+          make dist Q=
+          ls
+      - uses: actions/download-artifact@v3
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
@@ -88,8 +139,9 @@ jobs:
           draft: true # Don't publish the release quite yet...
           prerelease: ${{ contains(github.ref, '-rc') }}
           files: |
-            rgbds-${{ env.version }}-win32.zip
-            rgbds-${{ env.version }}-win64.zip
+            win32/rgbds-${{ env.version }}-win32.zip
+            win64/rgbds-${{ env.version }}-win64.zip
+            macos/rgbds-${{ env.version }}-macos-x86-64.zip
             rgbds-${{ env.version }}.tar.gz
           fail_on_unmatched_files: true
         env:

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ rgbfix: ${rgbfix_obj}
 	$Q${CC} ${REALLDFLAGS} -o $@ ${rgbfix_obj} ${REALCFLAGS} src/version.c
 
 rgbgfx: ${rgbgfx_obj}
-	$Q${CXX} ${REALLDFLAGS} ${PNGLDFLAGS} -o $@ ${rgbgfx_obj} ${REALCXXFLAGS} -x c++ src/version.c ${PNGLDLIBS}
+	$Q${CXX} ${REALLDFLAGS} ${PNGLDFLAGS} -o $@ ${rgbgfx_obj} ${REALCXXFLAGS} ${PNGLDLIBS} -x c++ src/version.c
 
 test/gfx/randtilegen: test/gfx/randtilegen.c
 	$Q${CC} ${REALLDFLAGS} ${PNGLDFLAGS} -o $@ $^ ${REALCFLAGS} ${PNGCFLAGS} ${PNGLDLIBS}

--- a/Makefile
+++ b/Makefile
@@ -183,21 +183,11 @@ clean:
 # Target used to install the binaries and man pages.
 
 install: all
-	$Qmkdir -p ${DESTDIR}${bindir}
-	$Qinstall ${STRIP} -m ${BINMODE} rgbasm ${DESTDIR}${bindir}/rgbasm
-	$Qinstall ${STRIP} -m ${BINMODE} rgbfix ${DESTDIR}${bindir}/rgbfix
-	$Qinstall ${STRIP} -m ${BINMODE} rgblink ${DESTDIR}${bindir}/rgblink
-	$Qinstall ${STRIP} -m ${BINMODE} rgbgfx ${DESTDIR}${bindir}/rgbgfx
-	$Qmkdir -p ${DESTDIR}${mandir}/man1 ${DESTDIR}${mandir}/man5 ${DESTDIR}${mandir}/man7
-	$Qinstall -m ${MANMODE} man/rgbds.7 ${DESTDIR}${mandir}/man7/rgbds.7
-	$Qinstall -m ${MANMODE} man/gbz80.7 ${DESTDIR}${mandir}/man7/gbz80.7
-	$Qinstall -m ${MANMODE} man/rgbds.5 ${DESTDIR}${mandir}/man5/rgbds.5
-	$Qinstall -m ${MANMODE} man/rgbasm.1 ${DESTDIR}${mandir}/man1/rgbasm.1
-	$Qinstall -m ${MANMODE} man/rgbasm.5 ${DESTDIR}${mandir}/man5/rgbasm.5
-	$Qinstall -m ${MANMODE} man/rgbfix.1 ${DESTDIR}${mandir}/man1/rgbfix.1
-	$Qinstall -m ${MANMODE} man/rgblink.1 ${DESTDIR}${mandir}/man1/rgblink.1
-	$Qinstall -m ${MANMODE} man/rgblink.5 ${DESTDIR}${mandir}/man5/rgblink.5
-	$Qinstall -m ${MANMODE} man/rgbgfx.1 ${DESTDIR}${mandir}/man1/rgbgfx.1
+	$Qinstall -d ${DESTDIR}${bindir}/ ${DESTDIR}${mandir}/man1/ ${DESTDIR}${mandir}/man5/ ${DESTDIR}${mandir}/man7/
+	$Qinstall ${STRIP} -m ${BINMODE} rgbasm rgblink rgbfix rgbgfx ${DESTDIR}${bindir}/
+	$Qinstall -m ${MANMODE} man/rgbasm.1 man/rgblink.1 man/rgbfix.1 man/rgbgfx.1 ${DESTDIR}${mandir}/man1/
+	$Qinstall -m ${MANMODE} man/rgbds.5 man/rgbasm.5 man/rgblink.5 ${DESTDIR}${mandir}/man5/
+	$Qinstall -m ${MANMODE} man/rgbds.7 man/gbz80.7 ${DESTDIR}${mandir}/man7/
 
 # Target used to check the coding style of the whole codebase.
 # `extern/` is excluded, as it contains external code that should not be patched


### PR DESCRIPTION
This is actually an old branch, which for some reason has not been PR'd... Build steps provided by @LIJI32, yes there's some cursed stuff in there, but [binaries built that way](https://github.com/ISSOtm/rgbds/releases/tag/v0.6.1) are confirmed to work all the way back on macOS 10.9.

Anyway, if this is merged, I'd like to retroactively publish some binaries for v0.6.0 (cherry-picking these two commits onto a new branch, and running CI on my fork.