### PR TITLE
Enable GLIBCXX_ASSERTIONS in `make develop`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ else()
                   -fsanitize=alignment -fsanitize=null -fsanitize=address)
     add_compile_options(${SAN_FLAGS})
     add_link_options(${SAN_FLAGS})
+    add_definitions(-D_GLIBCXX_ASSERTIONS)
     # A non-zero optimization level is desired in debug mode, but allow overriding it nonetheless
     # TODO: this overrides anything previously set... that's a bit sloppy!
     set(CMAKE_C_FLAGS_DEBUG "-g -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls" CACHE STRING "" FORCE)

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,7 @@ develop:
 		-Wno-type-limits -Wno-tautological-constant-out-of-range-compare \
 		-Wvla \
 		-Wno-unknown-warning-option \
+		-D_GLIBCXX_ASSERTIONS \
 		-fsanitize=shift -fsanitize=integer-divide-by-zero \
 		-fsanitize=unreachable -fsanitize=vla-bound \
 		-fsanitize=signed-integer-overflow -fsanitize=bounds \


### PR DESCRIPTION
Not sure it's very portable, but this is only the dev config