### PR TITLE
Print "; Next union/fragment" between "pieces" in .map file

### DIFF
--- a/src/link/output.c
+++ b/src/link/output.c
@@ -460,15 +460,19 @@ static uint16_t writeMapBank(struct SortedSections const *sectList,
 			uint16_t org = sect->org;
 
 			while (sect) {
-				if (sect->modifier == SECTION_UNION)
-					fprintf(mapFile, "\t\t; New union\n");
-				else if (sect->modifier == SECTION_FRAGMENT)
-					fprintf(mapFile, "\t\t; New fragment\n");
 				for (size_t i = 0; i < sect->nbSymbols; i++)
-					//               "\tSECTION: $xxxx ..."
+					// Space matches "\tSECTION: $xxxx ..."
 					fprintf(mapFile, "\t         $%04" PRIx32 " = %s\n",
 						sect->symbols[i]->offset + org,
 						sect->symbols[i]->name);
+
+				if (sect->nextu) {
+					// Announce the following "piece"
+					if (sect->nextu->modifier == SECTION_UNION)
+						fprintf(mapFile, "\t\t; Next union\n");
+					else if (sect->nextu->modifier == SECTION_FRAGMENT)
+						fprintf(mapFile, "\t\t; Next fragment\n");
+				}
 
 				sect = sect->nextu; // Also print symbols in the following "pieces"
 			}

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -469,9 +469,11 @@ static uint16_t writeMapBank(struct SortedSections const *sectList,
 				if (sect->nextu) {
 					// Announce the following "piece"
 					if (sect->nextu->modifier == SECTION_UNION)
-						fprintf(mapFile, "\t\t; Next union\n");
+						fprintf(mapFile,
+							"\t         ; Next union\n");
 					else if (sect->nextu->modifier == SECTION_FRAGMENT)
-						fprintf(mapFile, "\t\t; Next fragment\n");
+						fprintf(mapFile,
+							"\t         ; Next fragment\n");
 				}
 
 				sect = sect->nextu; // Also print symbols in the following "pieces"


### PR DESCRIPTION
Resolves #1099

As discussed in the comments, instead of printing "`; New union/fragment`" before each piece (which can be confusing when rgbasm has already combined them into one piece), this prints "`; Next union/fragment`" between the pieces.

I also added a commit to change the two-tab indent to spaces. I can undo this if preferred, but it looks weird to me to have the "heading" comments indented without any content indented at the same level or greater:

![image](https://user-images.githubusercontent.com/35663410/200198952-4fe6cb99-8765-472e-ba59-ca566e2040f5.png)

And in the (unlikely) case of tabs longer than 8 spaces, they don't even look related to the symbols:

![image](https://user-images.githubusercontent.com/35663410/200198998-3b81c922-dace-4be6-a36e-d10adf0503ef.png)
