### PR TITLE
Add contrib/rgbenv as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "contrib/rgbenv"]
+	path = contrib/rgbenv
+	url = https://github.com/ZoomTen/rgbenv
+	branch = master


### PR DESCRIPTION
This is a RGBDS version manager written in Bash, which at the moment assumes a Linux/BSD styled environment + GNU coreutils.

@ISSOtm (via the Discord server) suggested to put rgbenv in the repo somehow, feel free to object or to make suggestions.