### PR TITLE
Fix SRL [HL] Flags link

### DIFF
--- a/man/gbz80.7
+++ b/man/gbz80.7
@@ -1748,7 +1748,7 @@ Cycles: 4
 Bytes: 2
 .Pp
 Flags: See
-.Sx SRA r8
+.Sx SRL r8
 .Ss STOP
 Enter CPU very low power mode.
 Also used to switch between double and normal speed CPU modes in GBC.


### PR DESCRIPTION
It should point to `SRL r8` instead of `SRA r8`