### PR TITLE
allow defining local labels for another scope

### DIFF
--- a/.github/scripts/get_win_deps.ps1
+++ b/.github/scripts/get_win_deps.ps1
@@ -15,9 +15,9 @@ function getlibrary ([string] $URI, [string] $filename, [string] $hash, [string]
 	Expand-Archive -DestinationPath $destdir $filename
 }
 
-getlibrary 'https://www.zlib.net/zlib1213.zip' 'zlib.zip' 'd233fca7cf68db4c16dc5287af61f3cd01ab62495224c66639ca3da537701e42' .
+getlibrary 'https://www.zlib.net/zlib13.zip' 'zlib.zip' 'c561d09347f674f0d72692e7c75d9898919326c532aab7f8c07bb43b07efeb38' .
 getlibrary 'https://download.sourceforge.net/libpng/lpng1637.zip' 'libpng.zip'  '3b4b1cbd0bae6822f749d39b1ccadd6297f05e2b85a83dd2ce6ecd7d09eabdf2' .
 getlibrary 'https://github.com/lexxmark/winflexbison/releases/download/v2.5.24/win_flex_bison-2.5.24.zip' 'winflexbison.zip'  '39c6086ce211d5415500acc5ed2d8939861ca1696aee48909c7f6daf5122b505' install_dir
 
-Move-Item zlib-1.2.13 zlib
+Move-Item zlib-1.3 zlib
 Move-Item lpng1637 libpng

--- a/test/asm/local-without-parent.err
+++ b/test/asm/local-without-parent.err
@@ -1,3 +1,3 @@
 error: local-without-parent.asm(2):
-    Local label '.test' in main scope
+    Unqualified local label '.test' in main scope
 error: Assembly aborted (1 error)!

--- a/test/asm/local-wrong-parent.asm
+++ b/test/asm/local-wrong-parent.asm
@@ -1,6 +1,0 @@
-SECTION "sec", ROM0
-
-Parent:
-	db 0
-WrongParent.child
-	db 0

--- a/test/asm/local-wrong-parent.err
+++ b/test/asm/local-wrong-parent.err
@@ -1,3 +1,0 @@
-error: local-wrong-parent.asm(5):
-    Not currently in the scope of 'WrongParent'
-error: Assembly aborted (1 error)!

--- a/test/asm/sym-scope.asm
+++ b/test/asm/sym-scope.asm
@@ -1,8 +1,9 @@
 SECTION "Scopes", ROM0
 
-; Neither of these should be created
-.tooSoon
-Nice.try
+; Tests of injecting local labels into another label's scope.
+; This construction is useful to define a subroutine's local variables
+; in WRAM or HRAM.
+Valid.syntax
 
 Parent:
 .loc
@@ -11,8 +12,8 @@ Parent.explicit
 	dw .explicit ; This should expand to the above
 
 
-; None of the two locals below should manage to be created, being in the wrong scopes
-; Note however that `Parentheses` begins with `Parent`, which string checks may fail to handle
+; Note that `Parentheses` begins with `Parent`,
+; which string checks may fail to handle
 
 Parentheses.check
 

--- a/test/asm/sym-scope.err
+++ b/test/asm/sym-scope.err
@@ -1,9 +1,0 @@
-error: sym-scope.asm(4):
-    Local label '.tooSoon' in main scope
-error: sym-scope.asm(5):
-    Local label 'Nice.try' in main scope
-error: sym-scope.asm(17):
-    Not currently in the scope of 'Parentheses'
-error: sym-scope.asm(21):
-    Not currently in the scope of 'Parent'
-error: Assembly aborted (4 errors)!


### PR DESCRIPTION
fix #1157 for the following source code
```
section "hSAVE_locals",HRAM
func3.hSpam: ds 1  ; no longer produces an error
;.hEggs: ds 1      ; uncomment this to see the new error

section "demo",ROM0
func3:
  ldh a, [.hSpam]
  ret
```

Remove two errors:
- `Not currently in the scope of 'func3'`
- `Local label 'func3.hSpam' in main scope`

Add one error:
- `Relative local label '.hSpam' in main scope`

Add a switch to restore previous behavior in `include/asm/symbol.h`