### PR TITLE
add `--only-free` and `--help` options to tests

### DIFF
--- a/test/fetch-test-deps.sh
+++ b/test/fetch-test-deps.sh
@@ -1,10 +1,45 @@
 #!/usr/bin/env bash
-
 set -e
 
 cd "$(dirname "$0")"
 
-case "$1" in
+usage() {
+	echo "Downloads source code of Game Boy programs used as RGBDS test cases."
+	echo "Options:"
+	echo "    -h, --help      show this help message"
+	echo "    --only-free     download only freely licensed codebases"
+	echo "    --get-hash      print programs' commit hashes instead of downloading them"
+	echo "    --get-paths     print programs' GitHub paths instead of downloading them"
+}
+
+# Parse options in pure Bash because macOS `getopt` is stuck
+# in what util-linux `getopt` calls `GETOPT_COMPATIBLE` mode
+nonfree=true
+actionname=
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-h|--help)
+			usage
+			exit 0
+			;;
+		--only-free)
+			nonfree=false
+			;;
+		--get-hash|--get-paths)
+			actionname="$1"
+			;;
+		--)
+			break
+			;;
+		*)
+			echo "$(basename $0): unknown option "$1""
+			exit 1
+			;;
+	esac
+	shift
+done
+
+case "$actionname" in
 	--get-hash)
 		action() { # owner/repo shallow-since commit
 			printf "%s@%s-" "${1##*/}" "$3"
@@ -33,6 +68,8 @@ case "$1" in
 		}
 esac
 
-action pret/pokecrystal 2022-09-29 70a3ec1accb6de1c1c273470af0ddfa2edc1b0a9
-action pret/pokered     2022-09-29 2b52ceb718b55dce038db24d177715ae4281d065
-action AntonioND/ucity  2022-04-20 d8878233da7a6569f09f87b144cb5bf140146a0f
+if "$nonfree"; then
+	action pret/pokecrystal 2022-09-29 70a3ec1accb6de1c1c273470af0ddfa2edc1b0a9
+	action pret/pokered     2022-09-29 2b52ceb718b55dce038db24d177715ae4281d065
+fi
+action         AntonioND/ucity  2022-04-20 d8878233da7a6569f09f87b144cb5bf140146a0f

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,10 +1,39 @@
 #!/usr/bin/env bash
-
-# Return failure as soon as a command fails to execute
-
 set -e
 
 cd "$(dirname "$0")"
+
+usage() {
+	echo "Runs regression tests on RGBDS."
+	echo "Options:"
+	echo "    -h, --help      show this help message"
+	echo "    --only-free     skip tests that build nonfree codebases"
+}
+
+# Parse options in pure Bash because macOS `getopt` is stuck
+# in what util-linux `getopt` calls `GETOPT_COMPATIBLE` mode
+nonfree=true
+FETCH_TEST_DEPS="fetch-test-deps.sh"
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-h|--help)
+			usage
+			exit 0
+			;;
+		--only-free)
+			nonfree=false
+			FETCH_TEST_DEPS="fetch-test-deps.sh --only-free"
+			;;
+		--)
+			break
+			;;
+		*)
+			echo "$(basename $0): internal error"
+			exit 1
+			;;
+	esac
+	shift
+done
 
 # Refuse to run if RGBDS isn't present
 if [[ ! ( -x ../rgbasm && -x ../rgblink && -x ../rgbfix && -x ../rgbgfx ) ]]; then
@@ -27,7 +56,7 @@ done
 
 test_downstream() { # owner/repo make-target
 	if ! pushd ${1##*/}; then
-		echo >&2 'Please run `fetch-test-deps.sh` before running the test suite'
+		echo >&2 'Please run `'"$FETCH_TEST_DEPS"'` before running the test suite'
 		return 1
 	fi
 	make clean
@@ -35,6 +64,8 @@ test_downstream() { # owner/repo make-target
 	popd
 }
 
-test_downstream pret/pokecrystal compare
-test_downstream pret/pokered     compare
+if "$nonfree"; then
+	test_downstream pret/pokecrystal compare
+	test_downstream pret/pokered     compare
+fi
 test_downstream AntonioND/ucity  ''


### PR DESCRIPTION
Use [`getopt(1)`](https://www.man7.org/linux/man-pages/man1/getopt.1.html) to provide `-h`, `--help`, and `--dfsg` options in `test/fetch-test-deps.sh` and `test/run-tests.sh`

- `-h` or `--help` prints a usage message
- `--dfsg` (which stands for Debian Free Software Guidelines) skips repositories with non-free licenses (`pokecrystal` and `pokered`) in favor of `ucity` to support packaging RGBDS for Debian
- `--dfsg` can be combined with `--get-hash` or `--get-paths`

Fix #1160