### PR TITLE
Add dockerfile to build (and possibly run) RGBDS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM debian:11-slim
+LABEL org.opencontainers.image.source=https://github.com/gbdev/rgbds
 ARG version=0.6.1
+WORKDIR /rgbds
 
-COPY ./rgbds .
+COPY . .
 
 RUN apt-get update && \
     apt-get install sudo make cmake gcc build-essential -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,12 @@
-# This file is part of RGBDS.
-#
-# Copyright (c) 2018-2019, Phil Smith and RGBDS contributors.
-#
-# SPDX-License-Identifier: MIT
-# docker build -t rgbds:vX.X.X-alpine
-FROM alpine:latest
-RUN apk add --update \
-      build-base \
-      bison \
-      libpng-dev
-COPY . /rgbds
-WORKDIR /rgbds
-RUN make Q='' all
+FROM debian:11-slim
+ARG version=0.6.1
 
-FROM alpine:latest
-RUN apk add --update \
-      libpng
-COPY --from=0 \
-  /rgbds/rgbasm \
-  /rgbds/rgbfix \
-  /rgbds/rgblink \
-  /rgbds/rgbgfx \
-  /bin/
+COPY ./rgbds .
+
+RUN apt-get update && \
+    apt-get install sudo make cmake gcc build-essential -y
+
+RUN ./.github/scripts/install_deps.sh ubuntu-20.04
+RUN make -j WARNFLAGS="-Wall -Wextra -pedantic  -static" PKG_CONFIG="pkg-config --static" Q=
+
+RUN tar caf rgbds-${version}-linux-x86_64.tar.xz --transform='s#.*/##' rgbasm rgblink rgbfix rgbgfx man/* .github/scripts/install.sh


### PR DESCRIPTION
This basically follows https://github.com/gbdev/rgbds/blob/master/.github/workflows/create-release-artifacts.yaml#L96 and prepares a system to build (and run) RGBDS.

Why:

- It allows generating Linux executables of RGBDS in a one-liner, not requiring root or the user to install the build dependencies. Choose a commit hash (or a tag), run the image, get your RGBDS release.
- GH Actions pipelines are not _really_ reproducible, as the runners are not OSS. This would provide a more future-proof way of testing what is necessary to get a build of RGBDS
 - There are a lot of RGBDS docker images around. It would be nice to provide official ones