### PR TITLE
Implement order-independent purge

### DIFF
--- a/include/asm/lexer.h
+++ b/include/asm/lexer.h
@@ -97,4 +97,11 @@ struct DsArgList {
 	struct Expression *args;
 };
 
+#define INITIAL_PURGE_ARG_SIZE 2
+struct PurgeArgList {
+	size_t nbArgs;
+	size_t capacity;
+	char **args;
+};
+
 #endif // RGBDS_ASM_LEXER_H

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -135,6 +135,7 @@ struct Symbol *sym_Ref(char const *symName);
 struct Symbol *sym_AddString(char const *symName, char const *value);
 struct Symbol *sym_RedefString(char const *symName, char const *value);
 void sym_Purge(char const *symName);
+void sym_FlushPurged(void);
 void sym_Init(time_t now);
 
 // Functions to save and restore the current symbol scope.

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -135,7 +135,6 @@ struct Symbol *sym_Ref(char const *symName);
 struct Symbol *sym_AddString(char const *symName, char const *value);
 struct Symbol *sym_RedefString(char const *symName, char const *value);
 void sym_Purge(char const *symName);
-void sym_FlushPurged(void);
 void sym_Init(time_t now);
 
 // Functions to save and restore the current symbol scope.

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -1201,6 +1201,7 @@ purge		: T_POP_PURGE {
 			lexer_ToggleStringExpansion(false);
 		} purge_list trailing_comma {
 			lexer_ToggleStringExpansion(true);
+			sym_FlushPurged();
 		}
 ;
 

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -276,13 +276,6 @@ static bool isReferenced(struct Symbol const *sym)
 	return sym->ID != (uint32_t)-1;
 }
 
-struct SymbolListNode {
-	struct Symbol *sym;
-	struct SymbolListNode *next;
-};
-
-static struct SymbolListNode *purgeList = NULL;
-
 // Purge a symbol
 void sym_Purge(char const *symName)
 {
@@ -295,25 +288,6 @@ void sym_Purge(char const *symName)
 	} else if (isReferenced(sym)) {
 		error("Symbol \"%s\" is referenced and thus cannot be purged\n", symName);
 	} else {
-		struct SymbolListNode *node = malloc(sizeof(*node));
-
-		node->sym = sym;
-		node->next = purgeList;
-		purgeList = node;
-	}
-}
-
-// Remove purged symbols
-void sym_FlushPurged(void)
-{
-	while (purgeList) {
-		struct SymbolListNode *next = purgeList->next;
-		struct Symbol *sym = purgeList->sym;
-
-		free(purgeList);
-		purgeList = next;
-
-		assert(sym);
 		// Do not keep a reference to the label's name after purging it
 		if (sym->name == labelScope)
 			sym_SetCurrentSymbolScope(NULL);

--- a/test/asm/purge-deferred.asm
+++ b/test/asm/purge-deferred.asm
@@ -1,0 +1,10 @@
+DEF prefix EQUS "cool"
+DEF {prefix}banana EQU 1
+
+ASSERT DEF(prefix)
+ASSERT DEF(coolbanana)
+
+PURGE prefix, {prefix}banana
+
+ASSERT !DEF(prefix)
+ASSERT !DEF(coolbanana)

--- a/test/asm/purge-deferred.asm
+++ b/test/asm/purge-deferred.asm
@@ -4,6 +4,7 @@ DEF {prefix}banana EQU 1
 ASSERT DEF(prefix)
 ASSERT DEF(coolbanana)
 
+; purging `prefix` should not prevent expanding it to purge `coolbanana`
 PURGE prefix, {prefix}banana
 
 ASSERT !DEF(prefix)


### PR DESCRIPTION
This changes how purge works:
- `sym_Purge` collects the symbols in a list instead of removing them
- `sym_FlushPurged` removes/frees all of the symbols at once (it gets called after the purge list is processed)

I haven't written C for quite a long time, so if something looks like an obvious mistake, it surely is.

This fixes #1152. It implements the solution described in the [comment](https://github.com/gbdev/rgbds/issues/1152#issuecomment-1719016000) on that issue.

I wasn't sure about adding a test case -- is it as simple as something like:

```
; test/asm/purge-deferred.asm

DEF prefix EQUS "cool"
DEF {prefix}banana EQU 1

PURGE prefix, {prefix}banana

ASSERT !DEF(prefix)
ASSERT !DEF(coolbanana)
```
