### PR TITLE
Document STRUPR/STRLWR as ASCII-only

### DIFF
--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -414,8 +414,8 @@ Most of them return a string, however some of these functions actually return an
 .It Fn STRIN str1 str2 Ta Returns the first position of Ar str2 No in Ar str1 No or zero if it's not present Pq first character is position 1 .
 .It Fn STRRIN str1 str2 Ta Returns the last position of Ar str2 No in Ar str1 No or zero if it's not present Pq first character is position 1 .
 .It Fn STRSUB str pos len Ta Returns a substring from Ar str No starting at Ar pos No (first character is position 1, last is position -1) and Ar len No characters long. If Ar len No is not specified the substring continues to the end of Ar str .
-.It Fn STRUPR str Ta Returns Ar str No with all letters in uppercase.
-.It Fn STRLWR str Ta Returns Ar str No with all letters in lowercase.
+.It Fn STRUPR str Ta Returns Ar str No with all ASCII letters (`a-z`) in uppercase.
+.It Fn STRLWR str Ta Returns Ar str No with all ASCII letters (`A-Z`) in lowercase.
 .It Fn STRRPL str old new Ta Returns Ar str No with each non-overlapping occurrence of the substring Ar old No replaced with Ar new .
 .It Fn STRFMT fmt args... Ta Returns the string Ar fmt No with each
 .Ql %spec

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -1945,7 +1945,7 @@ z80_ldio	: T_Z80_LDH T_MODE_A T_COMMA op_mem_ind {
 
 c_ind		: T_LBRACK T_MODE_C T_RBRACK
 		| T_LBRACK relocexpr T_OP_ADD T_MODE_C T_RBRACK {
-			if (!rpn_isKnown(&$2) || $2.val != 0xff00)
+			if (!rpn_isKnown(&$2) || $2.val != 0xFF00)
 				error("Expected constant expression equal to $FF00 for \"$ff00+c\"\n");
 		}
 ;

--- a/src/asm/section.c
+++ b/src/asm/section.c
@@ -161,7 +161,7 @@ static unsigned int mergeSectUnion(struct Section *sect, enum SectionType type, 
 			   != (sect->alignOfs & mask(alignment))) {
 			fail("Section already declared with incompatible %u"
 			     "-byte alignment (offset %" PRIu16 ")\n",
-			     1u << sect->align, sect->alignOfs);
+			     1U << sect->align, sect->alignOfs);
 		} else if (alignment > sect->align) {
 			// If the section is not fixed, its alignment is the largest of both
 			sect->align = alignment;
@@ -212,7 +212,7 @@ static unsigned int mergeFragments(struct Section *sect, enum SectionType type, 
 		} else if ((curOfs & mask(sect->align)) != (sect->alignOfs & mask(alignment))) {
 			fail("Section already declared with incompatible %u"
 			     "-byte alignment (offset %" PRIu16 ")\n",
-			     1u << sect->align, sect->alignOfs);
+			     1U << sect->align, sect->alignOfs);
 		} else if (alignment > sect->align) {
 			// If the section is not fixed, its alignment is the largest of both
 			sect->align = alignment;

--- a/src/extern/getopt.c
+++ b/src/extern/getopt.c
@@ -82,7 +82,7 @@ static int getopt(int argc, char *argv[], char const *optstring)
 	k = mbtowc(&c, argv[musl_optind] + musl_optpos, MB_LEN_MAX);
 	if (k < 0) {
 		k = 1;
-		c = 0xfffd; /* replacement char */
+		c = 0xFFFD; /* replacement char */
 	}
 	optchar = argv[musl_optind] + musl_optpos;
 	musl_optpos += k;

--- a/src/extern/utf8decoder.c
+++ b/src/extern/utf8decoder.c
@@ -43,8 +43,8 @@ uint32_t decode(uint32_t *state, uint32_t *codep, uint8_t byte)
 	uint32_t type = utf8d[byte];
 
 	*codep = (*state != 0) ?
-			(byte & 0x3fu) | (*codep << 6) :
-			(0xff >> type) & (byte);
+			(byte & 0x3FU) | (*codep << 6) :
+			(0xFF >> type) & (byte);
 
 	*state = utf8d[256 + *state * 16 + type];
 	return *state;

--- a/src/gfx/reverse.cpp
+++ b/src/gfx/reverse.cpp
@@ -144,7 +144,7 @@ void reverse() {
 	// TODO: -U
 
 	std::vector<std::array<Rgba, 4>> palettes{
-	    {Rgba(0xffffffff), Rgba(0xaaaaaaff), Rgba(0x555555ff), Rgba(0x000000ff)}
+	    {Rgba(0xFFFFFFFF), Rgba(0xAAAAAAFF), Rgba(0x555555FF), Rgba(0x000000FF)}
     };
 	if (!options.palettes.empty()) {
 		File file;

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -29,7 +29,7 @@ struct HashMapEntry {
 	struct HashMapEntry *next;
 };
 
-#define FNV_OFFSET_BASIS 0x811c9dc5
+#define FNV_OFFSET_BASIS 0x811C9DC5
 #define FNV_PRIME 16777619
 
 // FNV-1a hash

--- a/test/gfx/randtilegen.c
+++ b/test/gfx/randtilegen.c
@@ -53,7 +53,7 @@ static unsigned long long getRandomBits(unsigned count) {
 		randbits |= (unsigned long long)data << randcount;
 		randcount += 8;
 	}
-	unsigned long long result = randbits & ((1ull << count) - 1);
+	unsigned long long result = randbits & ((1ULL << count) - 1);
 	randbits >>= count;
 	randcount -= count;
 	return result;


### PR DESCRIPTION
Fixes #639

This has two commits, one for some unrelated hex style, so don't squash it.