### PR TITLE
Make some changes noticed while porting to C++

### DIFF
--- a/include/asm/fstack.h
+++ b/include/asm/fstack.h
@@ -11,6 +11,11 @@
 
 #include "asm/lexer.h"
 
+enum FileStackNodeType {
+	NODE_REPT,
+	NODE_FILE,
+	NODE_MACRO,
+};
 
 struct FileStackNode {
 	struct FileStackNode *parent; // Pointer to parent node, for error reporting
@@ -21,11 +26,7 @@ struct FileStackNode {
 	bool referenced; // If referenced, don't free!
 	uint32_t ID; // Set only if referenced: ID within the object file, -1 if not output yet
 
-	enum {
-		NODE_REPT,
-		NODE_FILE,
-		NODE_MACRO,
-	} type;
+	enum FileStackNodeType type;
 };
 
 struct FileStackReptNode { // NODE_REPT

--- a/include/asm/fstack.h
+++ b/include/asm/fstack.h
@@ -11,11 +11,7 @@
 
 #include "asm/lexer.h"
 
-enum FileStackNodeType {
-	NODE_REPT,
-	NODE_FILE,
-	NODE_MACRO,
-};
+#include "linkdefs.h"
 
 struct FileStackNode {
 	struct FileStackNode *parent; // Pointer to parent node, for error reporting

--- a/include/asm/opt.h
+++ b/include/asm/opt.h
@@ -11,8 +11,8 @@ void opt_G(char const chars[4]);
 void opt_P(uint8_t padByte);
 void opt_Q(uint8_t precision);
 void opt_L(bool optimize);
-void opt_W(char const *flag);
-void opt_Parse(char const *option);
+void opt_W(char *flag);
+void opt_Parse(char *option);
 
 void opt_Push(void);
 void opt_Pop(void);

--- a/include/asm/section.h
+++ b/include/asm/section.h
@@ -38,9 +38,9 @@ struct SectionSpec {
 extern struct Section *currentSection;
 
 struct Section *sect_FindSectionByName(char const *name);
-void sect_NewSection(char const *name, uint32_t secttype, uint32_t org,
+void sect_NewSection(char const *name, enum SectionType type, uint32_t org,
 		     struct SectionSpec const *attributes, enum SectionModifier mod);
-void sect_SetLoadSection(char const *name, uint32_t secttype, uint32_t org,
+void sect_SetLoadSection(char const *name, enum SectionType type, uint32_t org,
 			 struct SectionSpec const *attributes, enum SectionModifier mod);
 void sect_EndLoadSection(void);
 

--- a/include/itertools.hpp
+++ b/include/itertools.hpp
@@ -6,6 +6,8 @@
 #include <tuple>
 #include <utility>
 
+#include "platform.h" // __PRETTY_FUNCTION__
+
 template<typename... Ts>
 static inline void report() {
 	puts(__PRETTY_FUNCTION__);

--- a/include/link/main.h
+++ b/include/link/main.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 
 #include "helpers.h"
+#include "linkdefs.h"
 
 // Variables related to CLI options
 extern bool isDmgMode;
@@ -26,12 +27,6 @@ extern bool is32kMode;
 extern bool beVerbose;
 extern bool isWRA0Mode;
 extern bool disablePadding;
-
-enum FileStackNodeType {
-	NODE_REPT,
-	NODE_FILE,
-	NODE_MACRO,
-};
 
 struct FileStackNode {
 	struct FileStackNode *parent;

--- a/include/link/main.h
+++ b/include/link/main.h
@@ -27,16 +27,18 @@ extern bool beVerbose;
 extern bool isWRA0Mode;
 extern bool disablePadding;
 
+enum FileStackNodeType {
+	NODE_REPT,
+	NODE_FILE,
+	NODE_MACRO,
+};
+
 struct FileStackNode {
 	struct FileStackNode *parent;
 	// Line at which the parent context was exited; meaningless for the root level
 	uint32_t lineNo;
 
-	enum {
-		NODE_REPT,
-		NODE_FILE,
-		NODE_MACRO,
-	} type;
+	enum FileStackNodeType type;
 	union {
 		char *name; // NODE_FILE, NODE_MACRO
 		struct { // NODE_REPT

--- a/include/link/script.h
+++ b/include/link/script.h
@@ -5,6 +5,7 @@
 #define RGBDS_LINK_SCRIPT_H
 
 #include <stdint.h>
+
 #include "linkdefs.h"
 
 extern FILE * linkerScript;

--- a/include/linkdefs.h
+++ b/include/linkdefs.h
@@ -75,6 +75,12 @@ enum SectionType {
 	SECTTYPE_INVALID
 };
 
+enum FileStackNodeType {
+	NODE_REPT,
+	NODE_FILE,
+	NODE_MACRO,
+};
+
 // Nont-`const` members may be patched in RGBLINK depending on CLI flags
 extern struct SectionTypeInfo {
 	char const *const name;

--- a/include/platform.h
+++ b/include/platform.h
@@ -27,6 +27,15 @@
 # define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
 #endif
 
+// gcc has __PRETTY_FUNCTION__, MSVC has __FUNCSIG__, __func__ is standard
+#ifndef __PRETTY_FUNCTION__
+# ifdef __FUNCSIG__
+#  define __PRETTY_FUNCTION__ __FUNCSIG__
+# else
+#  define __PRETTY_FUNCTION__ __func__
+# endif
+#endif
+
 // MSVC doesn't use POSIX types or defines for `read`
 #ifdef _MSC_VER
 # include <io.h>

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -122,9 +122,8 @@ void charmap_Set(char const *name)
 
 void charmap_Push(void)
 {
-	struct CharmapStackEntry *stackEntry;
+	struct CharmapStackEntry *stackEntry = malloc(sizeof(*stackEntry));
 
-	stackEntry = malloc(sizeof(*stackEntry));
 	if (stackEntry == NULL)
 		fatalerror("Failed to alloc charmap stack entry: %s\n", strerror(errno));
 

--- a/src/asm/section.c
+++ b/src/asm/section.c
@@ -386,7 +386,7 @@ static void changeSection(void)
 }
 
 // Set the current section by name and type
-void sect_NewSection(char const *name, uint32_t type, uint32_t org,
+void sect_NewSection(char const *name, enum SectionType type, uint32_t org,
 		     struct SectionSpec const *attribs, enum SectionModifier mod)
 {
 	if (currentLoadSection)
@@ -406,7 +406,7 @@ void sect_NewSection(char const *name, uint32_t type, uint32_t org,
 }
 
 // Set the current section by name and type
-void sect_SetLoadSection(char const *name, uint32_t type, uint32_t org,
+void sect_SetLoadSection(char const *name, enum SectionType type, uint32_t org,
 			 struct SectionSpec const *attribs, enum SectionModifier mod)
 {
 	// Important info: currently, UNION and LOAD cannot interact, since UNION is prohibited in

--- a/src/asm/warning.c
+++ b/src/asm/warning.c
@@ -260,7 +260,7 @@ void processWarningFlag(char *flag)
 				  // Not an error, then check if this is a negation
 				  strncmp(flag, "no-", strlen("no-")) ? WARNING_ENABLED
 								      : WARNING_DISABLED;
-	char const *rootFlag = state == WARNING_DISABLED ? flag + strlen("no-") : flag;
+	char *rootFlag = state == WARNING_DISABLED ? flag + strlen("no-") : flag;
 
 	// Is this a "parametric" warning?
 	if (state != WARNING_DISABLED) { // The `no-` form cannot be parametrized

--- a/src/fix/main.c
+++ b/src/fix/main.c
@@ -325,7 +325,7 @@ do { \
 				tryReadSlice("MA5");
 				mbc = BANDAI_TAMA5;
 				break;
-			case 'P':
+			case 'P': {
 				tryReadSlice("P1");
 				// Parse version
 				while (*ptr == ' ' || *ptr == '_')
@@ -359,6 +359,7 @@ do { \
 				tpp1Rev[1] = val;
 				mbc = TPP1;
 				break;
+			}
 			default:
 				return MBC_BAD;
 			}
@@ -1376,7 +1377,7 @@ do { \
 			sgb = true;
 			break;
 
-		case 't':
+		case 't': {
 			title = musl_optarg;
 			len = strlen(title);
 			uint8_t maxLen = maxTitleLen();
@@ -1388,6 +1389,7 @@ do { \
 			}
 			titleLen = len;
 			break;
+		}
 
 		case 'V':
 			printf("rgbfix %s\n", get_package_version_string());

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -419,7 +419,7 @@ static void parseHEXFile(std::filebuf &file) {
 static void parseACTFile(std::filebuf &file) {
 	// https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577411_pgfId-1070626
 
-	std::array<char, 772> buf;
+	std::array<char, 772> buf{};
 	auto len = file.sgetn(buf.data(), buf.size());
 
 	uint16_t nbColors = 256;

--- a/src/link/object.c
+++ b/src/link/object.c
@@ -28,7 +28,7 @@ static struct SymbolList {
 } *symbolLists;
 
 unsigned int nbObjFiles;
-static struct {
+static struct FileStackNodes {
 	struct FileStackNode *nodes;
 	uint32_t nbNodes;
 } *nodes;
@@ -92,19 +92,6 @@ static int64_t readlong(FILE *file)
 
 /*
  * Helper macro for reading bytes from a file, and errors out if it fails to.
- * Differs from `tryGetc` in that the backing function is fgetc(1).
- * Not as a function to avoid overhead in the general case.
- * @param var The variable to stash the number into
- * @param file The file to read from. Its position will be advanced
- * @param ... A format string and related arguments; note that an extra string
- *            argument is provided, the reason for failure
- */
-#define tryFgetc(var, file, ...) \
-	tryRead(fgetc, int, EOF, var, file, __VA_ARGS__)
-
-/*
- * Helper macro for reading bytes from a file, and errors out if it fails to.
- * Differs from `tryGetc` in that the backing function is fgetc(1).
  * Not as a function to avoid overhead in the general case.
  * @param var The variable to stash the number into
  * @param file The file to read from. Its position will be advanced

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -36,12 +36,14 @@ struct SortedSymbol {
 	uint16_t addr;
 };
 
+struct SortedSections {
+	struct SortedSection *sections;
+	struct SortedSection *zeroLenSections;
+};
+
 static struct {
 	uint32_t nbBanks; // Size of the array below (which may be NULL if this is 0)
-	struct SortedSections {
-		struct SortedSection *sections;
-		struct SortedSection *zeroLenSections;
-	} *banks;
+	struct SortedSections *banks;
 } sections[SECTTYPE_INVALID];
 
 // Defines the order in which types are output to the sym and map files

--- a/src/link/script.c
+++ b/src/link/script.c
@@ -19,7 +19,7 @@ char *includeFileName;
 
 static uint32_t lineNo;
 
-static struct {
+static struct FileNode {
 	FILE *file;
 	uint32_t lineNo;
 	char *name;
@@ -153,14 +153,16 @@ enum LinkerScriptCommand {
 	COMMAND_INVALID
 };
 
+union LinkerScriptTokenAttr {
+	enum LinkerScriptCommand command;
+	enum SectionType secttype;
+	uint32_t number;
+	char *string;
+};
+
 struct LinkerScriptToken {
 	enum LinkerScriptTokenType type;
-	union LinkerScriptTokenAttr {
-		enum LinkerScriptCommand command;
-		enum SectionType secttype;
-		uint32_t number;
-		char *string;
-	} attr;
+	union LinkerScriptTokenAttr attr;
 };
 
 static char const * const commands[] = {

--- a/src/link/section.c
+++ b/src/link/section.c
@@ -15,21 +15,21 @@
 
 HashMap sections;
 
-struct ForEachArg {
+struct ForEachSectionArg {
 	void (*callback)(struct Section *section, void *arg);
 	void *arg;
 };
 
 static void forEach(void *section, void *arg)
 {
-	struct ForEachArg *callbackArg = (struct ForEachArg *)arg;
+	struct ForEachSectionArg *callbackArg = (struct ForEachSectionArg *)arg;
 
 	callbackArg->callback((struct Section *)section, callbackArg->arg);
 }
 
 void sect_ForEach(void (*callback)(struct Section *, void *), void *arg)
 {
-	struct ForEachArg callbackArg = { .callback = callback, .arg = arg};
+	struct ForEachSectionArg callbackArg = { .callback = callback, .arg = arg};
 
 	hash_ForEach(sections, forEach, &callbackArg);
 }

--- a/src/link/symbol.c
+++ b/src/link/symbol.c
@@ -13,21 +13,21 @@
 
 HashMap symbols;
 
-struct ForEachArg {
+struct ForEachSymbolArg {
 	void (*callback)(struct Symbol *symbol, void *arg);
 	void *arg;
 };
 
 static void forEach(void *symbol, void *arg)
 {
-	struct ForEachArg *callbackArg = (struct ForEachArg *)arg;
+	struct ForEachSymbolArg *callbackArg = (struct ForEachSymbolArg *)arg;
 
 	callbackArg->callback((struct Symbol *)symbol, callbackArg->arg);
 }
 
 void sym_ForEach(void (*callback)(struct Symbol *, void *), void *arg)
 {
-	struct ForEachArg callbackArg = { .callback = callback, .arg = arg};
+	struct ForEachSymbolArg callbackArg = { .callback = callback, .arg = arg};
 
 	hash_ForEach(symbols, forEach, &callbackArg);
 }

--- a/test/gfx/randtilegen.c
+++ b/test/gfx/randtilegen.c
@@ -32,7 +32,7 @@ struct Attributes {
 static unsigned long long randbits = 0;
 static unsigned char randcount = 0;
 
-static _Noreturn void fatal(char const *error) {
+_Noreturn static void fatal(char const *error) {
 	fprintf(stderr, "FATAL: %s\n", error);
 	exit(1);
 }


### PR DESCRIPTION
Some of these changes, like moving nested `enum`s and `struct`s out, are things that C++ requires and C doesn't, but I think are worth doing here anyway.

One thing I notably didn't do in that vein is casting `void *` pointers like all the `malloc` calls (and also `hash_GetElement`).