### PR TITLE
Build a code coverage report with gcov and lcov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,13 @@
 /rgbfix
 /rgbgfx
 /rgbshim.sh
+/coverage/
 *.o
 *.exe
 *.dll
+*.gcno
+*.gcda
+*.gcov
 .checkpatch-camelcase.*
 CMakeCache.txt
 CMakeFiles/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@
 .SUFFIXES:
 .SUFFIXES: .cpp .y .o
 
-.PHONY: all clean install checkcodebase checkpatch checkdiff develop debug mingw32 mingw64 wine-shim dist
+.PHONY: all clean install checkcodebase checkpatch checkdiff \
+	develop debug coverage mingw32 mingw64 wine-shim dist
 
 # User-defined variables
 
@@ -188,6 +189,7 @@ clean:
 	$Q${RM} rgbfix rgbfix.exe
 	$Q${RM} rgbgfx rgbgfx.exe
 	$Qfind src/ -name "*.o" -exec rm {} \;
+	$Qfind . -type f \( -name "*.gcno" -o -name "*.gcda" -o -name "*.gcov" \) -exec rm {} \;
 	$Q${RM} rgbshim.sh
 	$Q${RM} src/asm/parser.cpp src/asm/parser.hpp
 	$Q${RM} test/gfx/randtilegen test/gfx/rgbgfx_test
@@ -258,6 +260,12 @@ develop:
 debug:
 	$Qenv ${MAKE} \
 		CXXFLAGS="-ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls"
+
+# This target is used during development in order to inspect code coverage with gcov.
+
+coverage:
+	$Qenv ${MAKE} \
+		CXXFLAGS="-ggdb3 -Og --coverage -fno-omit-frame-pointer -fno-optimize-sibling-calls"
 
 # Targets for the project maintainer to easily create Windows exes.
 # This is not for Windows users!

--- a/contrib/coverage.bash
+++ b/contrib/coverage.bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+# Build RGBDS with gcov support
+make coverage -j
+
+# Run the tests
+for dir in asm link fix gfx; do
+	pushd test/$dir
+	./test.sh
+	popd
+done
+
+# Generate coverage logs
+gcov src/**/*.{c,cpp}
+mkdir -p coverage
+
+# Generate coverage report
+lcov -c --no-external -d . -o coverage/coverage.info
+genhtml -f -s -o coverage/ coverage/coverage.info
+
+# Open report in web browser
+if [ "$(uname)" == "Darwin" ]; then
+  open coverage/index.html
+else
+  xdg-open coverage/index.html
+fi


### PR DESCRIPTION
Fixes #996

This is a fairly manual process that I don't foresee adding to CI. You run `./contrib/coverage.bash`, which will build RGBDS with gcov support, run all the tests, generate a coverage report with gcov and lcov, and open it in your web browser.

I'm in the process of reading this report for ideas for new tests. Note that many of the zero-coverage lines are error conditions we don't need to test (e.g. malloc failure), or verbose output that is likewise just a dev convenience not a testable feature.

![image](https://github.com/gbdev/rgbds/assets/35663410/fffc6ae8-45b4-44e5-98b5-93bd5b3dd5c5)

![image](https://github.com/gbdev/rgbds/assets/35663410/802e0f2a-bf5a-4766-b667-96de8c598569)
