### PR TITLE
Have the `eqn` preprocessor run on rgbasm(5) and rgbgfx(1)

### DIFF
--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -1,3 +1,5 @@
+'\" e
+.\"
 .\" SPDX-License-Identifier: MIT
 .\"
 .Dd March 28, 2021

--- a/man/rgbgfx.1
+++ b/man/rgbgfx.1
@@ -1,3 +1,5 @@
+'\" e
+.\"
 .\" SPDX-License-Identifier: MIT
 .\"
 .Dd March 28, 2021


### PR DESCRIPTION
I removed these by mistake when shortening the license headers in #1217.