### PR TITLE
Use some more C++20 features

### DIFF
--- a/src/fix/main.cpp
+++ b/src/fix/main.cpp
@@ -1197,7 +1197,7 @@ static bool processFilename(char const *name)
 
 		if (fstat(input, &stat) == -1) {
 			report("FATAL: Failed to stat \"%s\": %s\n", name, strerror(errno));
-		} else if (!S_ISREG(stat.st_mode)) { // FIXME: Do we want to support other types?
+		} else if (!S_ISREG(stat.st_mode)) { // TODO: Do we want to support other types?
 			report("FATAL: \"%s\" is not a regular file, and thus cannot be modified in-place\n",
 				name);
 		} else if (stat.st_size < 0x150) {

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -402,7 +402,7 @@ int main(int argc, char *argv[])
 			parseScrambleSpec(musl_optarg);
 			break;
 		case 's':
-			// FIXME: nobody knows what this does, figure it out
+			// TODO: implement "smart linking" with `-s`
 			(void)musl_optarg;
 			warning(NULL, 0, "Nobody has any idea what `-s` does");
 			break;

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -330,8 +330,8 @@ static int compareSymbols(void const *a, void const *b)
 
 	char const *sym1_name = sym1->sym->name;
 	char const *sym2_name = sym2->sym->name;
-	bool sym1_local = !!strchr(sym1_name, '.');
-	bool sym2_local = !!strchr(sym2_name, '.');
+	bool sym1_local = strchr(sym1_name, '.');
+	bool sym2_local = strchr(sym2_name, '.');
 
 	if (sym1_local != sym2_local) {
 		size_t sym1_len = strlen(sym1_name);


### PR DESCRIPTION
We were not using `std::from_chars` in RGBGFX because we supported gcc 7, which didn't have it; but now we require at least gcc 8 for C++20 support, which does have it.

We were likewise not using `std::string.starts_with`, but now we can.