### PR TITLE
Switch to using `std::filesystem`

### DIFF
--- a/include/file.hpp
+++ b/include/file.hpp
@@ -7,11 +7,11 @@
 #include <assert.h>
 #include <cassert>
 #include <fcntl.h>
+#include <filesystem>
 #include <fstream>
 #include <ios>
 #include <iostream>
 #include <streambuf>
-#include <string>
 #include <string.h>
 #include <string_view>
 #include <variant>
@@ -41,7 +41,7 @@ public:
 	 * This should only be called once, and before doing any `->` operations.
 	 * Returns `nullptr` on error, and a non-null pointer otherwise.
 	 */
-	File *open(std::string const &path, std::ios_base::openmode mode) {
+	File *open(std::filesystem::path const &path, std::ios_base::openmode mode) {
 		if (path != "-") {
 			return _file.emplace<std::filebuf>().open(path, mode) ? this : nullptr;
 		} else if (mode & std::ios_base::in) {
@@ -85,7 +85,7 @@ public:
 		           : nullptr;
 	}
 
-	char const *c_str(std::string const &path) const {
+	char const *c_str(std::filesystem::path const &path) const {
 		return std::visit(Visitor{[&path](std::filebuf const &) { return path.c_str(); },
 		                          [](std::streambuf const *buf) {
 			                          return buf == std::cin.rdbuf() ? "<stdin>" : "<stdout>";

--- a/include/gfx/main.hpp
+++ b/include/gfx/main.hpp
@@ -4,7 +4,9 @@
 #define RGBDS_GFX_MAIN_HPP
 
 #include <array>
+#include <filesystem>
 #include <limits.h>
+#include <optional>
 #include <stdint.h>
 #include <string>
 #include <utility>
@@ -24,7 +26,7 @@ struct Options {
 	bool columnMajor = false; // -Z, previously -h
 	uint8_t verbosity = 0; // -v
 
-	std::string attrmap{}; // -a, -A
+	std::optional<std::filesystem::path> attrmap{}; // -a, -A
 	std::array<uint8_t, 2> baseTileIDs{0, 0}; // -b
 	enum {
 		NO_SPEC,
@@ -41,14 +43,14 @@ struct Options {
 	} inputSlice{0, 0, 0, 0}; // -L (margins in clockwise order, like CSS)
 	std::array<uint16_t, 2> maxNbTiles{UINT16_MAX, 0}; // -N
 	uint8_t nbPalettes = 8; // -n
-	std::string output{}; // -o
-	std::string palettes{}; // -p, -P
-	std::string palmap{}; // -q, -Q
+	std::optional<std::filesystem::path> output{}; // -o
+	std::optional<std::filesystem::path> palettes{}; // -p, -P
+	std::optional<std::filesystem::path> palmap{}; // -q, -Q
 	uint8_t nbColorsPerPal = 0; // -s; 0 means "auto" = 1 << bitDepth;
-	std::string tilemap{}; // -t, -T
+	std::optional<std::filesystem::path> tilemap{}; // -t, -T
 	uint64_t trim = 0; // -x
 
-	std::string input{}; // positional arg
+	std::optional<std::filesystem::path> input{}; // positional arg
 
 	static constexpr uint8_t VERB_NONE = 0; // Normal, no extra output
 	static constexpr uint8_t VERB_CFG = 1; // Print configuration after parsing options

--- a/src/gfx/reverse.cpp
+++ b/src/gfx/reverse.cpp
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <cinttypes>
 #include <errno.h>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <png.h>
@@ -21,7 +22,7 @@
 
 #include "gfx/main.hpp"
 
-static DefaultInitVec<uint8_t> readInto(std::string path) {
+static DefaultInitVec<uint8_t> readInto(std::filesystem::path path) {
 	File file;
 	if (!file.open(path, std::ios::in | std::ios::binary)) {
 		fatal("Failed to open \"%s\": %s", file.c_str(path), strerror(errno));
@@ -77,11 +78,11 @@ void reverse() {
 
 	// Check for weird flag combinations
 
-	if (options.output.empty()) {
+	if (!options.output.has_value()) {
 		fatal("Tile data must be provided when reversing an image!");
 	}
 
-	if (options.allowDedup && options.tilemap.empty()) {
+	if (options.allowDedup && !options.tilemap.has_value()) {
 		warning("Tile deduplication is enabled, but no tilemap is provided?");
 	}
 
@@ -100,7 +101,7 @@ void reverse() {
 	}
 
 	options.verbosePrint(Options::VERB_LOG_ACT, "Reading tiles...\n");
-	auto const tiles = readInto(options.output);
+	auto const tiles = readInto(*options.output);
 	uint8_t tileSize = 8 * options.bitDepth;
 	if (tiles.size() % tileSize != 0) {
 		fatal("Tile data size (%zu bytes) is not a multiple of %" PRIu8 " bytes",
@@ -111,8 +112,8 @@ void reverse() {
 	size_t nbTileInstances = tiles.size() / tileSize + options.trim; // Image size in tiles
 	options.verbosePrint(Options::VERB_INTERM, "Read %zu tiles.\n", nbTileInstances);
 	std::optional<DefaultInitVec<uint8_t>> tilemap;
-	if (!options.tilemap.empty()) {
-		tilemap = readInto(options.tilemap);
+	if (options.tilemap.has_value()) {
+		tilemap = readInto(*options.tilemap);
 		nbTileInstances = tilemap->size();
 		options.verbosePrint(Options::VERB_INTERM, "Read %zu tilemap entries.\n", nbTileInstances);
 	}
@@ -140,10 +141,10 @@ void reverse() {
 	std::vector<std::array<Rgba, 4>> palettes{
 	    {Rgba(0xFFFFFFFF), Rgba(0xAAAAAAFF), Rgba(0x555555FF), Rgba(0x000000FF)}
     };
-	if (!options.palettes.empty()) {
+	if (options.palettes.has_value()) {
 		File file;
-		if (!file.open(options.palettes, std::ios::in | std::ios::binary)) {
-			fatal("Failed to open \"%s\": %s", file.c_str(options.palettes), strerror(errno));
+		if (!file.open(*options.palettes, std::ios::in | std::ios::binary)) {
+			fatal("Failed to open \"%s\": %s", file.c_str(*options.palettes), strerror(errno));
 		}
 
 		palettes.clear();
@@ -172,8 +173,8 @@ void reverse() {
 	}
 
 	std::optional<DefaultInitVec<uint8_t>> attrmap;
-	if (!options.attrmap.empty()) {
-		attrmap = readInto(options.attrmap);
+	if (options.attrmap.has_value()) {
+		attrmap = readInto(*options.attrmap);
 		if (attrmap->size() != nbTileInstances) {
 			fatal("Attribute map size (%zu tiles) doesn't match image's (%zu)", attrmap->size(),
 			      nbTileInstances);
@@ -219,8 +220,8 @@ void reverse() {
 	}
 
 	std::optional<DefaultInitVec<uint8_t>> palmap;
-	if (!options.palmap.empty()) {
-		palmap = readInto(options.palmap);
+	if (options.palmap.has_value()) {
+		palmap = readInto(*options.palmap);
 		if (palmap->size() != nbTileInstances) {
 			fatal("Palette map size (%zu tiles) doesn't match image's (%zu)", palmap->size(),
 			      nbTileInstances);
@@ -229,12 +230,12 @@ void reverse() {
 
 	options.verbosePrint(Options::VERB_LOG_ACT, "Writing image...\n");
 	File pngFile;
-	if (!pngFile.open(options.input, std::ios::out | std::ios::binary)) {
-		fatal("Failed to create \"%s\": %s", pngFile.c_str(options.input), strerror(errno));
+	if (!pngFile.open(*options.input, std::ios::out | std::ios::binary)) {
+		fatal("Failed to create \"%s\": %s", pngFile.c_str(*options.input), strerror(errno));
 	}
 	png_structp png = png_create_write_struct(
 	    PNG_LIBPNG_VER_STRING,
-	    const_cast<png_voidp>(static_cast<void const *>(pngFile.c_str(options.input))), pngError,
+	    const_cast<png_voidp>(static_cast<void const *>(pngFile.c_str(*options.input))), pngError,
 	    pngWarning);
 	if (!png) {
 		fatal("Couldn't create PNG write struct: %s", strerror(errno));


### PR DESCRIPTION
Allows better platform-agnostic path manipulation. Also, using `std::optional` rather than empty strings allows correctly handling empty arguments (treating them as such, instead of acting as they were never passed).

This is based on https://github.com/ISSOtm/rgbds/commit/874cd4c38a0e481ef08d46ceb7deff74ca60c239 and https://github.com/gbdev/rgbds/commit/7eb4ecea8bd4494fb384b24179973ab09b39058c. We previously avoided using `std::filesystem` due to CI support, but now we require C++20 and gcc 9+ so it should be okay.