### PR TITLE
Some RGBGFX cleanup observed during #1235

### DIFF
--- a/src/gfx/main.cpp
+++ b/src/gfx/main.cpp
@@ -316,6 +316,7 @@ static std::vector<size_t> readAtFile(std::string const &path, std::vector<char>
 		} while (c != '\n' && c != EOF); // End if we reached EOL
 	}
 }
+
 /*
  * Parses an arg vector, modifying `options` as options are read.
  * The three booleans are for the "auto path" flags, since their processing must be deferred to the
@@ -644,6 +645,11 @@ int main(int argc, char *argv[]) {
 
 	auto autoOutPath = [](bool autoOptEnabled, std::string &path, char const *extension) {
 		if (autoOptEnabled) {
+			if (options.input.empty()) {
+				fputs("FATAL: No input image specified\n", stderr);
+				printUsage();
+				exit(1);
+			}
 			constexpr std::string_view chars =
 // Both must start with a dot!
 #if defined(_MSC_VER) || defined(__MINGW32__)

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -804,27 +804,18 @@ static void outputTileData(Png const &png, DefaultInitVec<AttrmapEntry> const &a
 static void outputMaps(DefaultInitVec<AttrmapEntry> const &attrmap,
                        DefaultInitVec<size_t> const &mappings) {
 	std::optional<File> tilemapOutput, attrmapOutput, palmapOutput;
-	if (!options.tilemap.empty()) {
-		tilemapOutput.emplace();
-		if (!tilemapOutput->open(options.tilemap, std::ios_base::out | std::ios_base::binary)) {
-			fatal("Failed to open \"%s\": %s", tilemapOutput->c_str(options.tilemap),
-			      strerror(errno));
+	auto autoOpenPath = [](std::string &path, std::optional<File> &file) {
+		if (!path.empty()) {
+			file.emplace();
+			if (!file->open(path, std::ios_base::out | std::ios_base::binary)) {
+				fatal("Failed to open \"%s\": %s", file->c_str(path),
+				      strerror(errno));
+			}
 		}
-	}
-	if (!options.attrmap.empty()) {
-		attrmapOutput.emplace();
-		if (!attrmapOutput->open(options.attrmap, std::ios_base::out | std::ios_base::binary)) {
-			fatal("Failed to open \"%s\": %s", attrmapOutput->c_str(options.attrmap),
-			      strerror(errno));
-		}
-	}
-	if (!options.palmap.empty()) {
-		palmapOutput.emplace();
-		if (!palmapOutput->open(options.palmap, std::ios_base::out | std::ios_base::binary)) {
-			fatal("Failed to open \"%s\": %s", palmapOutput->c_str(options.palmap),
-			      strerror(errno));
-		}
-	}
+	};
+	autoOpenPath(options.tilemap, tilemapOutput);
+	autoOpenPath(options.attrmap, attrmapOutput);
+	autoOpenPath(options.palmap, palmapOutput);
 
 	uint8_t tileID = 0;
 	uint8_t bank = 0;


### PR DESCRIPTION
This adds an error check for if RGBGFX was run with an option to automatically derive an output path from the input path (`-A -T -P`) but the input image is not specified.

It also factors out another anonymous function for common tilemap/attrmap/palmap behavior.