### PR TITLE
Fix spurious truncation warning

### DIFF
--- a/man/rgbasm.1
+++ b/man/rgbasm.1
@@ -298,7 +298,7 @@ or
 .Fl Wno-truncation
 disables this warning.
 .Fl Wtruncation=1
-warns when an N-bit value's absolute value is 2**N or greater.
+warns when an N-bit value is 2**N or greater, or less than -2**N.
 .Fl Wtruncation=2
 or just
 .Fl Wtruncation

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -292,7 +292,7 @@ void rpn_CheckNBit(struct Expression const *expr, uint8_t n)
 	if (rpn_isKnown(expr)) {
 		int32_t val = expr->val;
 
-		if (val <= -(1 << n) || val >= 1 << n)
+		if (val < -(1 << n) || val >= 1 << n)
 			warning(WARNING_TRUNCATION_1, "Expression must be %u-bit\n", n);
 		else if (val < -(1 << (n - 1)))
 			warning(WARNING_TRUNCATION_2, "Expression must be %u-bit\n", n);

--- a/test/asm/warn-truncation.asm
+++ b/test/asm/warn-truncation.asm
@@ -27,6 +27,8 @@ MACRO try
 	; warn at level 2
 	db ~(1 << BAR_F)
 	dw -wLabel
+	db ~$ff
+	dw ~$ffff
 ENDM
 
 	try Wno-truncation

--- a/test/asm/warn-truncation.err
+++ b/test/asm/warn-truncation.err
@@ -1,15 +1,3 @@
-warning: warn-truncation.asm(33) -> warn-truncation.asm::try(23): [-Wtruncation]
-    Expression must be 8-bit
-warning: warn-truncation.asm(33) -> warn-truncation.asm::try(24): [-Wtruncation]
-    Expression must be 8-bit
-warning: warn-truncation.asm(33) -> warn-truncation.asm::try(25): [-Wtruncation]
-    Expression must be 16-bit
-warning: warn-truncation.asm(33) -> warn-truncation.asm::try(26): [-Wtruncation]
-    Expression must be 16-bit
-warning: warn-truncation.asm(33) -> warn-truncation.asm::try(28): [-Wtruncation]
-    Expression must be 8-bit
-warning: warn-truncation.asm(33) -> warn-truncation.asm::try(29): [-Wtruncation]
-    Expression must be 16-bit
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(23): [-Wtruncation]
     Expression must be 8-bit
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(24): [-Wtruncation]
@@ -18,35 +6,59 @@ warning: warn-truncation.asm(35) -> warn-truncation.asm::try(25): [-Wtruncation]
     Expression must be 16-bit
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(26): [-Wtruncation]
     Expression must be 16-bit
-warning: warn-truncation.asm(36) -> warn-truncation.asm::try(23): [-Wtruncation]
+warning: warn-truncation.asm(35) -> warn-truncation.asm::try(28): [-Wtruncation]
     Expression must be 8-bit
-warning: warn-truncation.asm(36) -> warn-truncation.asm::try(24): [-Wtruncation]
-    Expression must be 8-bit
-warning: warn-truncation.asm(36) -> warn-truncation.asm::try(25): [-Wtruncation]
+warning: warn-truncation.asm(35) -> warn-truncation.asm::try(29): [-Wtruncation]
     Expression must be 16-bit
-warning: warn-truncation.asm(36) -> warn-truncation.asm::try(26): [-Wtruncation]
-    Expression must be 16-bit
-warning: warn-truncation.asm(36) -> warn-truncation.asm::try(28): [-Wtruncation]
+warning: warn-truncation.asm(35) -> warn-truncation.asm::try(30): [-Wtruncation]
     Expression must be 8-bit
-warning: warn-truncation.asm(36) -> warn-truncation.asm::try(29): [-Wtruncation]
+warning: warn-truncation.asm(35) -> warn-truncation.asm::try(31): [-Wtruncation]
     Expression must be 16-bit
-error: warn-truncation.asm(37) -> warn-truncation.asm::try(23): [-Werror=truncation]
+warning: warn-truncation.asm(37) -> warn-truncation.asm::try(23): [-Wtruncation]
     Expression must be 8-bit
-error: warn-truncation.asm(37) -> warn-truncation.asm::try(24): [-Werror=truncation]
+warning: warn-truncation.asm(37) -> warn-truncation.asm::try(24): [-Wtruncation]
     Expression must be 8-bit
-error: warn-truncation.asm(37) -> warn-truncation.asm::try(25): [-Werror=truncation]
+warning: warn-truncation.asm(37) -> warn-truncation.asm::try(25): [-Wtruncation]
     Expression must be 16-bit
-error: warn-truncation.asm(37) -> warn-truncation.asm::try(26): [-Werror=truncation]
+warning: warn-truncation.asm(37) -> warn-truncation.asm::try(26): [-Wtruncation]
     Expression must be 16-bit
-error: warn-truncation.asm(38) -> warn-truncation.asm::try(23): [-Werror=truncation]
+warning: warn-truncation.asm(38) -> warn-truncation.asm::try(23): [-Wtruncation]
     Expression must be 8-bit
-error: warn-truncation.asm(38) -> warn-truncation.asm::try(24): [-Werror=truncation]
+warning: warn-truncation.asm(38) -> warn-truncation.asm::try(24): [-Wtruncation]
     Expression must be 8-bit
-error: warn-truncation.asm(38) -> warn-truncation.asm::try(25): [-Werror=truncation]
+warning: warn-truncation.asm(38) -> warn-truncation.asm::try(25): [-Wtruncation]
     Expression must be 16-bit
-error: warn-truncation.asm(38) -> warn-truncation.asm::try(26): [-Werror=truncation]
+warning: warn-truncation.asm(38) -> warn-truncation.asm::try(26): [-Wtruncation]
     Expression must be 16-bit
-error: warn-truncation.asm(38) -> warn-truncation.asm::try(28): [-Werror=truncation]
+warning: warn-truncation.asm(38) -> warn-truncation.asm::try(28): [-Wtruncation]
     Expression must be 8-bit
-error: warn-truncation.asm(38) -> warn-truncation.asm::try(29): [-Werror=truncation]
+warning: warn-truncation.asm(38) -> warn-truncation.asm::try(29): [-Wtruncation]
+    Expression must be 16-bit
+warning: warn-truncation.asm(38) -> warn-truncation.asm::try(30): [-Wtruncation]
+    Expression must be 8-bit
+warning: warn-truncation.asm(38) -> warn-truncation.asm::try(31): [-Wtruncation]
+    Expression must be 16-bit
+error: warn-truncation.asm(39) -> warn-truncation.asm::try(23): [-Werror=truncation]
+    Expression must be 8-bit
+error: warn-truncation.asm(39) -> warn-truncation.asm::try(24): [-Werror=truncation]
+    Expression must be 8-bit
+error: warn-truncation.asm(39) -> warn-truncation.asm::try(25): [-Werror=truncation]
+    Expression must be 16-bit
+error: warn-truncation.asm(39) -> warn-truncation.asm::try(26): [-Werror=truncation]
+    Expression must be 16-bit
+error: warn-truncation.asm(40) -> warn-truncation.asm::try(23): [-Werror=truncation]
+    Expression must be 8-bit
+error: warn-truncation.asm(40) -> warn-truncation.asm::try(24): [-Werror=truncation]
+    Expression must be 8-bit
+error: warn-truncation.asm(40) -> warn-truncation.asm::try(25): [-Werror=truncation]
+    Expression must be 16-bit
+error: warn-truncation.asm(40) -> warn-truncation.asm::try(26): [-Werror=truncation]
+    Expression must be 16-bit
+error: warn-truncation.asm(40) -> warn-truncation.asm::try(28): [-Werror=truncation]
+    Expression must be 8-bit
+error: warn-truncation.asm(40) -> warn-truncation.asm::try(29): [-Werror=truncation]
+    Expression must be 16-bit
+error: warn-truncation.asm(40) -> warn-truncation.asm::try(30): [-Werror=truncation]
+    Expression must be 8-bit
+error: warn-truncation.asm(40) -> warn-truncation.asm::try(31): [-Werror=truncation]
     Expression must be 16-bit


### PR DESCRIPTION
Fixes #1237

The line number changes obscure the test result, but compared to the previous RGBASM, it will only warn about `db ~$ff` and `dw ~$ffff` with `-Wtruncation=2`.