### PR TITLE
Avoid building test support programs by default with CMake

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -123,6 +123,7 @@ jobs:
           cmake -S . -B build -A ${{ matrix.platform }} -DCMAKE_INSTALL_PREFIX=install_dir -DCMAKE_BUILD_TYPE=Release -DZLIB_LIBRARY="$PWD"/install_dir/lib/zlib.lib -DZLIB_INCLUDE_DIR="$PWD"/install_dir/include -DPNG_LIBRARY="$PWD"/install_dir/lib/libpng16.lib -DPNG_INCLUDE_DIR="$PWD"/install_dir/include
           cmake --build build --config Release -j --verbose
           cmake --install build --verbose --prefix install_dir
+          cmake --install build --verbose --component "Test support programs"
       - name: Package binaries
         shell: bash
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,6 +41,7 @@ jobs:
           cmake --build build -j --verbose
           cp build/src/rgb{asm,link,fix,gfx} .
           sudo cmake --install build --verbose
+          cmake --install build --verbose --component "Test support programs"
       - name: Package binaries
         run: |
           mkdir bins

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(randtilegen gfx/randtilegen.cpp)
 
 add_executable(rgbgfx_test gfx/rgbgfx_test.cpp)
 
-install(TARGETS randtilegen rgbgfx_test DESTINATION ${rgbds_SOURCE_DIR}/test/gfx)
+install(TARGETS randtilegen rgbgfx_test DESTINATION ${rgbds_SOURCE_DIR}/test/gfx COMPONENT "Test support programs" EXCLUDE_FROM_ALL)
 
 foreach(TARGET randtilegen rgbgfx_test)
   if(LIBPNG_FOUND) # pkg-config


### PR DESCRIPTION
This was reported by @Robbi-Blechdose to cause problems with Debian packaging; he confirmed this patch fixes his problems, so let's upstream it for 0.7.0.