### PR TITLE
Refactor alignment spec parsing

### DIFF
--- a/include/asm/lexer.hpp
+++ b/include/asm/lexer.hpp
@@ -84,7 +84,7 @@ int yylex(void);
 bool lexer_CaptureRept(struct CaptureBody *capture);
 bool lexer_CaptureMacroBody(struct CaptureBody *capture);
 
-struct DsAlignment {
+struct AlignmentSpec {
 	uint8_t alignment;
 	uint16_t alignOfs;
 };


### PR DESCRIPTION
This is a prerequisite for #1248, but is useful on its own to avoid repeating the same alignment-checking code three times.