### PR TITLE
Add LADX disassembly to test suite

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,3 +1,4 @@
+/LADX-Disassembly/
 /libbet/
 /pokecrystal/
 /pokered/

--- a/test/fetch-test-deps.sh
+++ b/test/fetch-test-deps.sh
@@ -95,8 +95,9 @@ case "$actionname" in
 esac
 
 if "$nonfree"; then
-	action pret/pokecrystal 2023-11-22 9a917e35760210a1f34057ecada2148f1fefc390
-	action pret/pokered     2023-11-21 d4d7b91aecf651b06d1f466ecc22b65da234a299
+	action pret/pokecrystal       2023-11-22 9a917e35760210a1f34057ecada2148f1fefc390
+	action pret/pokered           2023-12-05 f6017ddbfd7e14ea39b81ce3393de9117e7310d9
+	action zladx/LADX-Disassembly 2023-12-10 e08773051fa75f0c02a85434196fd598642d2c2c
 fi
 action AntonioND/ucity  2023-11-02 c781ae20c0b319262b19b51e5067a2c93cf3b362
 action pinobatch/libbet 2023-11-30 9f56cf94883c58517c2cd41a752cfee5a5800e8d

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -65,8 +65,9 @@ test_downstream() { # owner/repo make-target
 }
 
 if "$nonfree"; then
-	test_downstream pret/pokecrystal compare
-	test_downstream pret/pokered     compare
+	test_downstream pret/pokecrystal       compare
+	test_downstream pret/pokered           compare
+	test_downstream zladx/LADX-Disassembly ''
 fi
 test_downstream AntonioND/ucity  ''
 test_downstream pinobatch/libbet all


### PR DESCRIPTION
The testing.yml script has `if: false` to disable the "Check test dependency repositories cache" step because it needs to be patched. That will no longer be the case after https://github.com/zladx/LADX-Disassembly/pull/554 merges, and we can remove the .patch file from this PR. (The patch fixes LADX's Makefile and tools/\*.sh scripts so they'll work in CI, even on Windows.)