### PR TITLE
Use `RANGE` macro to abbreviate `begin`/`end` pairs

### DIFF
--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -82,4 +82,7 @@
 // (Having two instances of `arr` is OK because the contents of `sizeof` are not evaluated.)
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof *(arr))
 
+// For lack of <ranges>, this adds some more brevity
+#define RANGE(s) std::begin(s), std::end(s)
+
 #endif // HELPERS_H

--- a/src/gfx/pal_sorting.cpp
+++ b/src/gfx/pal_sorting.cpp
@@ -23,7 +23,7 @@ void indexed(std::vector<Palette> &palettes, int palSize, png_color const *palRG
 	};
 
 	for (Palette &pal : palettes) {
-		std::sort(pal.begin(), pal.end(), [&](uint16_t lhs, uint16_t rhs) {
+		std::sort(RANGE(pal), [&](uint16_t lhs, uint16_t rhs) {
 			// Iterate through the PNG's palette, looking for either of the two
 			for (int i = 0; i < palSize; ++i) {
 				uint16_t color = pngToRgb(i).cgbColor();
@@ -52,7 +52,7 @@ void grayscale(std::vector<Palette> &palettes,
 	assert(palettes.size() == 1);
 
 	Palette &palette = palettes[0];
-	std::fill(palette.colors.begin(), palette.colors.end(), Rgba::transparent);
+	std::fill(RANGE(palette.colors), Rgba::transparent);
 	for (auto const &slot : colors) {
 		if (!slot.has_value() || slot->isTransparent()) {
 			continue;
@@ -72,7 +72,7 @@ void rgb(std::vector<Palette> &palettes) {
 	options.verbosePrint(Options::VERB_LOG_ACT, "Sorting palettes by \"\"\"luminance\"\"\"...\n");
 
 	for (Palette &pal : palettes) {
-		std::sort(pal.begin(), pal.end(), [](uint16_t lhs, uint16_t rhs) {
+		std::sort(RANGE(pal), [](uint16_t lhs, uint16_t rhs) {
 			return legacyLuminance(lhs) > legacyLuminance(rhs);
 		});
 	}

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -572,7 +572,7 @@ void parseExternalPalSpec(char const *arg) {
 	    std::tuple{"GBC", &parseGBCFile, std::ios::binary},
 	};
 
-	auto iter = std::find_if(parsers.begin(), parsers.end(),
+	auto iter = std::find_if(RANGE(parsers),
 	                         [&arg, &ptr](decltype(parsers)::value_type const &parser) {
 		                         return strncasecmp(arg, std::get<0>(parser), ptr - arg) == 0;
 	                         });

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -60,7 +60,7 @@ public:
 	}
 
 	size_t size() const {
-		return std::count_if(_colors.begin(), _colors.end(),
+		return std::count_if(RANGE(_colors),
 		                     [](decltype(_colors)::value_type const &slot) {
 			                     return slot.has_value() && !slot->isTransparent();
 		                     });
@@ -333,7 +333,7 @@ public:
 		                                                       Rgba &&color) {
 			if (!color.isTransparent() && !color.isOpaque()) {
 				uint32_t css = color.toCSS();
-				if (std::find(indeterminates.begin(), indeterminates.end(), css)
+				if (std::find(RANGE(indeterminates), css)
 				    == indeterminates.end()) {
 					error("Color #%08x is neither transparent (alpha < %u) nor opaque (alpha >= "
 					      "%u) [first seen at x: %" PRIu32 ", y: %" PRIu32 "]",
@@ -343,7 +343,7 @@ public:
 			} else if (Rgba const *other = colors.registerColor(color); other) {
 				std::tuple conflicting{color.toCSS(), other->toCSS()};
 				// Do not report combinations twice
-				if (std::find(conflicts.begin(), conflicts.end(), conflicting) == conflicts.end()) {
+				if (std::find(RANGE(conflicts), conflicting) == conflicts.end()) {
 					warning("Fusing colors #%08x and #%08x into Game Boy color $%04x [first seen "
 					        "at x: %" PRIu32 ", y: %" PRIu32 "]",
 					        std::get<0>(conflicting), std::get<1>(conflicting), color.cgbColor(), x,
@@ -597,10 +597,10 @@ static std::tuple<DefaultInitVec<size_t>, std::vector<Palette>>
 	for (size_t i = 0; i < protoPalettes.size(); ++i) {
 		ProtoPalette const &protoPal = protoPalettes[i];
 		// Find the palette...
-		auto iter = std::find_if(palettes.begin(), palettes.end(), [&protoPal](Palette const &pal) {
+		auto iter = std::find_if(RANGE(palettes), [&protoPal](Palette const &pal) {
 			// ...which contains all colors in this proto-pal
-			return std::all_of(protoPal.begin(), protoPal.end(), [&pal](uint16_t color) {
-				return std::find(pal.begin(), pal.end(), color) != pal.end();
+			return std::all_of(RANGE(protoPal), [&pal](uint16_t color) {
+				return std::find(RANGE(pal), color) != pal.end();
 			});
 		});
 
@@ -731,7 +731,7 @@ public:
 		}
 
 		// Check if we have horizontal mirroring, which scans the array forward again
-		if (std::equal(_data.begin(), _data.end(), other._data.begin(),
+		if (std::equal(RANGE(_data), other._data.begin(),
 		               [](uint8_t lhs, uint8_t rhs) { return lhs == flipTable[rhs]; })) {
 			return MatchType::HFLIP;
 		}

--- a/src/gfx/proto_palette.cpp
+++ b/src/gfx/proto_palette.cpp
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 
+#include "helpers.hpp"
+
 #include "gfx/proto_palette.hpp"
 
 #include <algorithm>
@@ -42,8 +44,8 @@ bool ProtoPalette::add(uint16_t color) {
 
 ProtoPalette::ComparisonResult ProtoPalette::compare(ProtoPalette const &other) const {
 	// This works because the sets are sorted numerically
-	assert(std::is_sorted(_colorIndices.begin(), _colorIndices.end()));
-	assert(std::is_sorted(other._colorIndices.begin(), other._colorIndices.end()));
+	assert(std::is_sorted(RANGE(_colorIndices)));
+	assert(std::is_sorted(RANGE(other._colorIndices)));
 
 	auto ours = _colorIndices.begin(), theirs = other._colorIndices.begin();
 	bool weBigger = true, theyBigger = true;
@@ -67,7 +69,7 @@ ProtoPalette::ComparisonResult ProtoPalette::compare(ProtoPalette const &other) 
 }
 
 size_t ProtoPalette::size() const {
-	return std::distance(begin(), end());
+	return std::distance(RANGE(*this));
 }
 
 bool ProtoPalette::empty() const {
@@ -78,5 +80,5 @@ auto ProtoPalette::begin() const -> decltype(_colorIndices)::const_iterator {
 	return _colorIndices.begin();
 }
 auto ProtoPalette::end() const -> decltype(_colorIndices)::const_iterator {
-	return std::find(_colorIndices.begin(), _colorIndices.end(), UINT16_MAX);
+	return std::find(RANGE(_colorIndices), UINT16_MAX);
 }

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -281,17 +281,13 @@ try_again: // Can't use a `do {} while(0)` loop, otherwise compilers (wrongly) t
 		}
 
 		for (SectionType type : EnumSeq(SECTTYPE_INVALID)) {
-			if (std::equal(ident.begin(), ident.end(),
-			               sectionTypeInfo[type].name.begin(), sectionTypeInfo[type].name.end(),
-			               strUpperCmp)) {
+			if (std::equal(RANGE(ident), RANGE(sectionTypeInfo[type].name), strUpperCmp)) {
 				return yy::parser::make_section_type(type);
 			}
 		}
 
 		for (Keyword const &keyword : keywords) {
-			if (std::equal(ident.begin(), ident.end(),
-			               keyword.name.begin(), keyword.name.end(),
-			               strUpperCmp)) {
+			if (std::equal(RANGE(ident), RANGE(keyword.name), strUpperCmp)) {
 				return keyword.tokenGen();
 			}
 		}


### PR DESCRIPTION
Fixes #1267