### PR TITLE
Linker scripts can align to offsets, and require valid alignments

### DIFF
--- a/man/rgblink.5
+++ b/man/rgblink.5
@@ -68,15 +68,25 @@ and
 .Ic DS :
 .Bl -bullet
 .It
-.Ic ORG
-sets the address in which new sections will be placed.
+.Ic ORG Ar addr
+sets the address in which new sections will be placed to
+.Ar addr .
 It can not be lower than the current address.
 .It
-.Ic ALIGN
+.Ic ALIGN Ar addr
+or
+.Ic ALIGN Ar addr , Ar offset
 will increase the address until it is aligned to the specified boundary
-.Po it tries to set to 0 the number of bits specified after the directive:
+.Po it tries to set to
+.Ar offset
+the number of bits specified by
+.Ar align :
+for example,
 .Ql ALIGN 8
-will align to $100
+will align to $100 ,
+and
+.Ql ALIGN 8 , 10
+will align to $10A
 .Pc .
 .It
 .Ic DS

--- a/test/link/section-attributes-mismatch.out
+++ b/test/link/section-attributes-mismatch.out
@@ -1,2 +1,2 @@
-error: ./section-attributes-mismatch.link(3): The linker script assigns section "sec" to address $0018, but that would be ALIGN[4, 8] instead of the requested ALIGN[4, 0]
+error: ./section-attributes-mismatch.link(3): The linker script assigns section "sec" to address $0018, but that would be ALIGN[4, 8] instead of the requested ALIGN[4, 2]
 Linking failed with 1 error

--- a/test/link/section-attributes.asm
+++ b/test/link/section-attributes.asm
@@ -1,3 +1,3 @@
-SECTION "sec",ROM0,ALIGN[4]
-	ds 8, $42
+SECTION "sec",ROM0,ALIGN[4,2]
+	ds 6, $42
 SECTION "secfix",ROM0[$20]

--- a/test/link/section-attributes.link
+++ b/test/link/section-attributes.link
@@ -1,6 +1,7 @@
 ROM0
-	align 4
+	align 4, 2
 	"sec"
 	ds $18
 	org $20
+	align 5
 	"secfix"


### PR DESCRIPTION
Fixes #1268
Fixes #1270