### PR TITLE
Scramble banks from the end of the ROM

### DIFF
--- a/test/asm/test.sh
+++ b/test/asm/test.sh
@@ -122,7 +122,7 @@ for i in *.asm; do
 		desired_binname=${i%.asm}.out.bin
 		if [ -f "$desired_binname" ]; then
 			"$RGBLINK" -o "$gb" "$o"
-			rom_size=$(wc -c < "$desired_binname")
+			rom_size=$(printf %s $(wc -c <"$desired_binname"))
 			dd if="$gb" count=1 bs="$rom_size" >"$output" 2>/dev/null
 			tryCmp "$desired_binname" "$output" gb
 			(( our_rc = our_rc || $? ))

--- a/test/link/scramble-romx/a.asm
+++ b/test/link/scramble-romx/a.asm
@@ -1,0 +1,5 @@
+SECTION "fixed", ROMX, BANK[3]
+ds $4000, 1
+
+SECTION "floating", ROMX
+db 2

--- a/test/link/test.sh
+++ b/test/link/test.sh
@@ -41,7 +41,7 @@ tryCmp () {
 	fi
 }
 tryCmpRom () {
-	# `printf` lets us keep only the first returned word.
+	# `printf` lets us keep only the first returned word from `wc`.
 	rom_size=$(printf %s $(wc -c <"$1"))
 	dd if="$gbtemp" count=1 bs="$rom_size" >"$otemp" 2>/dev/null
 	tryCmp "$1" "$otemp"
@@ -144,6 +144,17 @@ tryDiff overlay/out.err "$outtemp"
 (( rc = rc || $? ))
 # This test does not trim its output with 'dd' because it needs to verify the correct output size
 tryCmp overlay/out.gb "$gbtemp"
+(( rc = rc || $? ))
+
+i="scramble-romx.asm"
+startTest
+"$RGBASM" -o "$otemp" scramble-romx/a.asm
+rgblinkQuiet -o "$gbtemp" -S romx=3 "$otemp" >"$outtemp" 2>&1
+tryDiff scramble-romx/out.err "$outtemp"
+(( rc = rc || $? ))
+# This test does not compare its exact output with 'tryCmpRom' because no scrambling order is guaranteed
+rom_size=$(printf %s $(wc -c <"$gbtemp"))
+test "$rom_size" = 65536 # Check for exactly 3 ROMX banks
 (( rc = rc || $? ))
 
 i="section-fragment/jr-offset.asm"


### PR DESCRIPTION
This is more likely to test edge cases, such as having content in banks with their highest bit set.

Fixes #1036.

#1149 proposes allocating sections from the *end* of their individual banks. This is a similar approach, allocating section banks from the end of their overall ROM space.