### PR TITLE
Improve linker scripts a little

### DIFF
--- a/man/rgblink.5
+++ b/man/rgblink.5
@@ -69,7 +69,7 @@ The possible types are:
 .Ic ROM0 , ROMX , VRAM , SRAM , WRAM0 , WRAMX , OAM ,
 and
 .Ic HRAM .
-However, if the type only contains a single bank, then the number can be omitted.
+If the type only contains a single bank, then the number can be omitted.
 The applicable types are:
 .Ic ROM0 ,
 .Ic ROMX No if Fl t No is passed to Xr rgblink 1 ,
@@ -96,7 +96,9 @@ sets the
 .Dq current address
 to
 .Ar addr .
-The new address cannot be less than the old one.
+THis directive cannot be used to move the address backwards:
+.Ar addr
+must be greater than or equal to the current address.
 .Pp
 .Ql Ic FLOATING
 causes all sections between it and the next
@@ -116,17 +118,18 @@ If
 is omitted, it is implied to be 0.
 For example, if the
 .Dq current address
-is $007,
+is $0007,
 .Ql ALIGN 8
-would set it to $100, and
+would set it to $0100, and
 .Ql ALIGN 8 , 10
-would set it to $00A.
+would set it to $000A.
 .Pp
 .Ql Ic DS Ar size
 increases the
 .Dq current address
 by
 .Ar size .
+The gap is not allocated, thus smaller floating sections can later be placed there.
 .El
 .Ss Section placement
 A section can be placed simply by naming it (with a string).

--- a/man/rgblink.5
+++ b/man/rgblink.5
@@ -69,8 +69,7 @@ The possible types are:
 .Ic ROM0 , ROMX , VRAM , SRAM , WRAM0 , WRAMX , OAM ,
 and
 .Ic HRAM .
-If the type only contains a single bank, then the number can be omitted.
-The applicable types are:
+The bank number can be omitted from the types that only contain a single bank, which are:
 .Ic ROM0 ,
 .Ic ROMX No if Fl t No is passed to Xr rgblink 1 ,
 .Ic VRAM No if Fl d No is passed to Xr rgblink 1 ,
@@ -96,7 +95,7 @@ sets the
 .Dq current address
 to
 .Ar addr .
-THis directive cannot be used to move the address backwards:
+This directive cannot be used to move the address backwards:
 .Ar addr
 must be greater than or equal to the current address.
 .Pp
@@ -135,7 +134,8 @@ The gap is not allocated, thus smaller floating sections can later be placed the
 A section can be placed simply by naming it (with a string).
 Its bank is set to the active bank, and its address to the
 .Dq current address .
-Any properties the section already possesses (whether from the linker script or the object files being linked) must be consistent with what the linker script specifies: the section's type must match, the section's bank number (if set) must match the active bank, etc.
+Any constraints the section already possesses (whether from the linker script or the object files being linked) must be consistent with what the linker script specifies: the section's type must match, the section's bank number (if set) must match the active bank, etc.
+In particular, if the section has an alignment constraint, the address at which it is placed by the linker script must obey that constraint; otherwise, an error will occur.
 .Pp
 Afterwards, the
 .Dq current address

--- a/man/rgblink.5
+++ b/man/rgblink.5
@@ -97,7 +97,8 @@ to
 .Ar addr .
 This directive cannot be used to move the address backwards:
 .Ar addr
-must be greater than or equal to the current address.
+must be greater than or equal to the
+.Dq current address .
 .Pp
 .Ql Ic FLOATING
 causes all sections between it and the next
@@ -128,16 +129,16 @@ increases the
 .Dq current address
 by
 .Ar size .
-The gap is not allocated, thus smaller floating sections can later be placed there.
+The gap is not allocated, so smaller floating sections can later be placed there.
 .El
 .Ss Section placement
 A section can be placed simply by naming it (with a string).
 Its bank is set to the active bank, and its address to the
 .Dq current address .
-Any constraints the section already possesses (whether from the linker script or the object files being linked) must be consistent with what the linker script specifies: the section's type must match, the section's bank number (if set) must match the active bank, etc.
+Any constraints the section already possesses (whether from earlier in the linker script, or from the object files being linked) must be consistent with what the linker script specifies: the section's type must match, the section's bank number (if set) must match the active bank, etc.
 In particular, if the section has an alignment constraint, the address at which it is placed by the linker script must obey that constraint; otherwise, an error will occur.
 .Pp
-Afterwards, the
+After a section is placed, the
 .Dq current address
 is increased by the section's size.
 This must not increase it past the end of the active memory region.

--- a/man/rgblink.5
+++ b/man/rgblink.5
@@ -1,53 +1,37 @@
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd March 28, 2021
+.Dd December 22, 2023
 .Dt RGBLINK 5
 .Os
 .Sh NAME
 .Nm rgblink
 .Nd linker script file format
 .Sh DESCRIPTION
-The linker script is an external file that allows the user to specify the order of sections at link time and in a centralized manner.
+The linker script is a self-contained file that allows specifying attributes for sections at link time, and in a centralized manner.
+There can only be one linker script per invocation of
+.Nm ,
+but it can be split into several files
+.Pq using the Ic INCLUDE No directive .
+.Ss Basic syntax
+A linker script follows a very line-oriented format: each line can contain up to one directive or section name, and up to one comment.
+Whitespace (space and tab characters) is used to separate elements, but is otherwise ignored.
 .Pp
-A linker script consists of a series of bank declarations, each optionally followed by a list of section names (in double quotes) or directives.
-All reserved keywords (bank types and directive names) are case-insensitive; all section names are case-sensitive.
-.Pp
-Any line can contain a comment starting with
+Comments begin with a semicolon
 .Ql \&;
-that ends at the end of the line.
-.Bd -literal -offset indent
-; This line is a comment
-ROMX $F            ; start a bank
-  "Some functions" ; a section name
-  ALIGN 8          ; a directive
-  "Some array"
-
-WRAMX 2            ; start another bank
-  org $d123        ; another directive
-  "Some variables"
-.Ed
+character, until the end of the line; they are simply ignored.
 .Pp
-Numbers can be in decimal or hexadecimal format
-.Pq the prefix is Ql $ .
-It is an error if any section name or directive is found before setting a bank.
+Keywords are composed of letters and digits (but they can't start with a digit); they are all case-insensitive.
 .Pp
-Files can be included by using the
-.Ic INCLUDE
-keyword, followed by a string with the path of the file that has to be included.
+Numbers can be written in the usual decimal format, or in binary using the
+.Ql %
+prefix, or in hexadecimal using the
+.Ql $
+prefix (both uppercase and lowercase letters are accepted).
 .Pp
-The possible bank types are:
-.Cm ROM0 , ROMX , VRAM , SRAM , WRAM0 , WRAMX , OAM
-and
-.Cm HRAM .
-Unless there is a single bank, which can occur with types
-.Cm ROMX , VRAM , SRAM
-and
-.Cm WRAMX ,
-it is mandatory to specify a bank number after the type.
-.Pp
-Section names in double quotes support the same character escape sequences as strings in
-.Xr rgbasm 5 ,
-specifically
+Strings begin with a double quote, and end at the next (non-escaped) double quote.
+Most of the same character escapes as
+.Xr rgbasm 5
+are supported, specifically
 .Ql \e\e ,
 .Ql \e" ,
 .Ql \en ,
@@ -56,55 +40,105 @@ and
 .Ql \et .
 Other backslash escape sequences in
 .Xr rgbasm 5
-are only relevant to assembly code and do not apply in section names.
-.Pp
-When a new bank statement is found, sections found after it will be placed right from the beginning of that bank.
-If the linker script switches to a different bank and then comes back to a previous one, it will continue from the last address that was used.
-.Pp
-The only three directives are
-.Ic ORG ,
-.Ic ALIGN ,
+are only relevant to assembly code and do not apply in linker scripts.
+.Ss Directives
+.Bl -tag -width Ds
+.It Including other files
+.Ql Ic INCLUDE Ar path
+acts as if the contents of the file at
+.Ar path
+were copy-pasted in place of the
+.Ic INCLUDE
+directive.
+.Ar path
+must be a string.
+.It Bank specification
+.Tg region
+The active bank can be set by specifying its type (memory region) and number.
+The possible types are:
+.Ic ROM0 , ROMX , VRAM , SRAM , WRAM0 , WRAMX , OAM ,
 and
-.Ic DS :
-.Bl -bullet
-.It
-.Ic ORG Ar addr
-sets the address in which new sections will be placed to
+.Ic HRAM .
+However, if the type only contains a single bank
+.Pq Ic ROM0, Ic ROMX No if Fl t No is passed to Xr rgblink 1 , Ic VRAM No if Fl d No is passed to Xr rgblink 1 , Ic WRAM0 , Ic WRAMX No if Fl w No is passed to Xr rgblink 1 , Ic OAM , Ic HRAM ,
+then the number can be omitted.
+.Pp
+After a bank specification, the
+.Dq current address
+is set to the last value it had for that bank.
+If the bank has never been active thus far, the
+.Dq current address
+defaults to the beginning of the bank
+.Pq e.g. Ad $4000 No for Ic ROMX No sections .
+.It Changing the Dq current address
+A bank must be active for any of these directives to be used.
+.Pp
+.Ql Ic ORG Ar addr
+sets the
+.Dq current address
+to
 .Ar addr .
-It can not be lower than the current address.
-.It
-.Ic ALIGN Ar addr
-or
-.Ic ALIGN Ar addr , Ar offset
-will increase the address until it is aligned to the specified boundary
-.Po it tries to set to
-.Ar offset
-the number of bits specified by
-.Ar align :
-for example,
-.Ql ALIGN 8
-will align to $100 ,
-and
-.Ql ALIGN 8 , 10
-will align to $10A
-.Pc .
-.It
-.Ic DS
-will increase the address by the specified non-negative amount.
-.El
+The new address cannot be less than the old one.
 .Pp
-.Sy Note :
-The bank, alignment, address and type of sections can be specified both in the source code and in the linker script.
-For a section to be able to be placed with the linker script, the bank, address and alignment must be left unassigned in the source code or be compatible with what is specified in the linker script.
-For example,
-.Ql ALIGN[8]
-in the source code is compatible with
-.Ql ORG $F00
-in the linker script.
+.Ql Ic FLOATING :
+All sections between
+.Ic FLOATING
+and the next
+.Ic ORG
+or bank specification, will be placed at addresses automatically determined by
+.Nm .
+.Pp
+.Ql Ic ALIGN Ar addr , Ar offset
+increases the
+.Dq current address
+until it is aligned to the specified boundary (i.e. the
+.Ar align
+lowest bits of the address are equal to
+.Ar offset ) .
+If
+.Ar offset
+is omitted, it is implied to be 0.
+For example, if the
+.Dq current address
+is $007,
+.Ql ALIGN 8
+would set it to $100, and
+.Ql ALIGN 8 , 10
+would set it to $00A.
+.Pp
+.Ql Ic DS Ar size
+increases the
+.Dq current address
+by
+.Ar size .
+.El
+.Ss Section placement
+A section can be placed simply by naming it (with a string).
+Its bank is set to the active bank, and its address to the
+.Dq current address .
+Any properties the section already possesses must be consistent with what the linker script specifies: the section's type must match, (if set) the section's bank number must match the active bank's, etc.
+.Pp
+Afterwards, the
+.Dq current address
+is increased by the section's size.
+This must not make it go past the end of the active memory region.
+.Sh EXAMPLES
+.Bd -literal -offset indent
+; This line contains only a comment
+ROMX $F            ; start a bank
+  "Some functions" ; a section name
+  ALIGN 8          ; a directive
+  "Some \e"array\e""
+
+WRAMX 2            ; start another bank
+  org $d123        ; another directive
+  "Some variables"
+.Ed
 .Sh SEE ALSO
 .Xr rgbasm 1 ,
 .Xr rgblink 1 ,
 .Xr rgbfix 1 ,
+.Xr rgbasm 5 ,
 .Xr rgbds 5 ,
 .Xr rgbds 7
 .Sh HISTORY

--- a/man/rgblink.5
+++ b/man/rgblink.5
@@ -7,28 +7,38 @@
 .Nm rgblink
 .Nd linker script file format
 .Sh DESCRIPTION
-The linker script is a self-contained file that allows specifying attributes for sections at link time, and in a centralized manner.
+The linker script is a file that allows specifying attributes for sections at link time, and in a centralized manner.
 There can only be one linker script per invocation of
 .Nm ,
 but it can be split into several files
 .Pq using the Ic INCLUDE No directive .
 .Ss Basic syntax
-A linker script follows a very line-oriented format: each line can contain up to one directive or section name, and up to one comment.
-Whitespace (space and tab characters) is used to separate elements, but is otherwise ignored.
+The linker script syntax is line-based.
+Each line may have a directive or section name, a comment, both, or neither.
+Whitespace (space and tab characters) is used to separate syntax elements, but is otherwise ignored.
 .Pp
 Comments begin with a semicolon
 .Ql \&;
-character, until the end of the line; they are simply ignored.
+character, until the end of the line.
+They are simply ignored.
 .Pp
 Keywords are composed of letters and digits (but they can't start with a digit); they are all case-insensitive.
 .Pp
-Numbers can be written in the usual decimal format, or in binary using the
+Numbers can be written in decimal format, or in binary using the
 .Ql %
 prefix, or in hexadecimal using the
 .Ql $
-prefix (both uppercase and lowercase letters are accepted).
+prefix (hexadecimal digits are case-insensitive).
+Note that unlike
+.Xr rgbasm 5 ,
+an octal
+.Ql &
+prefix is not supported, nor are
+.Ql _
+digit separators.
 .Pp
 Strings begin with a double quote, and end at the next (non-escaped) double quote.
+Strings must not contain literal newline characters.
 Most of the same character escapes as
 .Xr rgbasm 5
 are supported, specifically
@@ -52,16 +62,24 @@ were copy-pasted in place of the
 directive.
 .Ar path
 must be a string.
-.It Bank specification
+.It Specifying the active bank
 .Tg region
 The active bank can be set by specifying its type (memory region) and number.
 The possible types are:
 .Ic ROM0 , ROMX , VRAM , SRAM , WRAM0 , WRAMX , OAM ,
 and
 .Ic HRAM .
-However, if the type only contains a single bank
-.Pq Ic ROM0, Ic ROMX No if Fl t No is passed to Xr rgblink 1 , Ic VRAM No if Fl d No is passed to Xr rgblink 1 , Ic WRAM0 , Ic WRAMX No if Fl w No is passed to Xr rgblink 1 , Ic OAM , Ic HRAM ,
-then the number can be omitted.
+However, if the type only contains a single bank, then the number can be omitted.
+The applicable types are:
+.Ic ROM0 ,
+.Ic ROMX No if Fl t No is passed to Xr rgblink 1 ,
+.Ic VRAM No if Fl d No is passed to Xr rgblink 1 ,
+.Ic WRAM0 ,
+.Ic WRAMX No if Fl w No is passed to Xr rgblink 1 ,
+.Ic OAM ,
+and
+.Ic HRAM .
+.Pq Ic SRAM No is the only type that can never have its bank number omitted.
 .Pp
 After a bank specification, the
 .Dq current address
@@ -70,7 +88,7 @@ If the bank has never been active thus far, the
 .Dq current address
 defaults to the beginning of the bank
 .Pq e.g. Ad $4000 No for Ic ROMX No sections .
-.It Changing the Dq current address
+.It Changing the current address
 A bank must be active for any of these directives to be used.
 .Pp
 .Ql Ic ORG Ar addr
@@ -80,12 +98,10 @@ to
 .Ar addr .
 The new address cannot be less than the old one.
 .Pp
-.Ql Ic FLOATING :
-All sections between
-.Ic FLOATING
-and the next
+.Ql Ic FLOATING
+causes all sections between it and the next
 .Ic ORG
-or bank specification, will be placed at addresses automatically determined by
+or bank specification to be placed at addresses automatically determined by
 .Nm .
 .Pp
 .Ql Ic ALIGN Ar addr , Ar offset
@@ -116,12 +132,15 @@ by
 A section can be placed simply by naming it (with a string).
 Its bank is set to the active bank, and its address to the
 .Dq current address .
-Any properties the section already possesses must be consistent with what the linker script specifies: the section's type must match, (if set) the section's bank number must match the active bank's, etc.
+Any properties the section already possesses (whether from the linker script or the object files being linked) must be consistent with what the linker script specifies: the section's type must match, the section's bank number (if set) must match the active bank, etc.
 .Pp
 Afterwards, the
 .Dq current address
 is increased by the section's size.
-This must not make it go past the end of the active memory region.
+This must not increase it past the end of the active memory region.
+.Pp
+The section must have been defined in the object files being linked, unless the section name is followed by the keyword
+.Ic OPTIONAL .
 .Sh EXAMPLES
 .Bd -literal -offset indent
 ; This line contains only a comment

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -365,6 +365,11 @@ static void setSectionType(SectionType type, uint32_t bank) {
 
 static void setAddr(uint32_t addr) {
 	auto const &context = lexerStack.back();
+	if (activeType == SECTTYPE_INVALID) {
+		scriptError(context, "Cannot set PC because no memory region is active");
+		return;
+	}
+
 	auto &pc = curAddr[activeType][activeBankIdx];
 	auto const &typeInfo = sectionTypeInfo[activeType];
 
@@ -381,6 +386,11 @@ static void setAddr(uint32_t addr) {
 
 static void alignTo(uint32_t alignment, uint32_t alignOfs) {
 	auto const &context = lexerStack.back();
+	if (activeType == SECTTYPE_INVALID) {
+		scriptError(context, "Cannot modify PC because no memory region is active");
+		return;
+	}
+
 	auto const &typeInfo = sectionTypeInfo[activeType];
 	auto &pc = curAddr[activeType][activeBankIdx];
 
@@ -419,6 +429,11 @@ static void alignTo(uint32_t alignment, uint32_t alignOfs) {
 
 static void pad(uint32_t length) {
 	auto const &context = lexerStack.back();
+	if (activeType == SECTTYPE_INVALID) {
+		scriptError(context, "Cannot modify PC because no memory region is active");
+		return;
+	}
+
 	auto const &typeInfo = sectionTypeInfo[activeType];
 	auto &pc = curAddr[activeType][activeBankIdx];
 
@@ -433,9 +448,6 @@ static void pad(uint32_t length) {
 
 static void placeSection(std::string const &name, bool isOptional) {
 	auto const &context = lexerStack.back();
-	auto const &typeInfo = sectionTypeInfo[activeType];
-
-	// A type *must* be active.
 	if (activeType == SECTTYPE_INVALID) {
 		scriptError(context, "No memory region has been specified to place section \"%s\" in",
 		            name.c_str());
@@ -450,6 +462,7 @@ static void placeSection(std::string const &name, bool isOptional) {
 		return;
 	}
 
+	auto const &typeInfo = sectionTypeInfo[activeType];
 	assert(section->offset == 0);
 	// Check that the linker script doesn't contradict what the code says.
 	if (section->type == SECTTYPE_INVALID) {

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -360,11 +360,11 @@ static void setSectionType(SectionType type, uint32_t bank) {
 	auto const &typeInfo = sectionTypeInfo[type];
 
 	if (bank < typeInfo.firstBank) {
-		scriptError(context, "%s bank %" PRIu32 " doesn't exist, the minimum is %" PRIu32,
+		scriptError(context, "%s bank %" PRIu32 " doesn't exist (the minimum is %" PRIu32 ")",
 		            typeInfo.name.c_str(), bank, typeInfo.firstBank);
 		bank = typeInfo.firstBank;
 	} else if (bank > typeInfo.lastBank) {
-		scriptError(context, "%s bank %" PRIu32 " doesn't exist, the maximum is %" PRIu32,
+		scriptError(context, "%s bank %" PRIu32 " doesn't exist (the maximum is %" PRIu32 ")",
 		            typeInfo.name.c_str(), bank, typeInfo.lastBank);
 	}
 
@@ -374,7 +374,7 @@ static void setSectionType(SectionType type, uint32_t bank) {
 static void setAddr(uint32_t addr) {
 	auto const &context = lexerStack.back();
 	if (activeType == SECTTYPE_INVALID) {
-		scriptError(context, "Cannot set PC because no memory region is active");
+		scriptError(context, "Cannot set the current address: no memory region is active");
 		return;
 	}
 
@@ -382,9 +382,9 @@ static void setAddr(uint32_t addr) {
 	auto const &typeInfo = sectionTypeInfo[activeType];
 
 	if (addr < pc) {
-		scriptError(context, "ORG cannot be used to go backwards (from $%04x to $%04x)", pc, addr);
+		scriptError(context, "Cannot decrease the current address (from $%04x to $%04x)", pc, addr);
 	} else if (addr > endaddr(activeType)) { // Allow "one past the end" sections.
-		scriptError(context, "Cannot go to $%04" PRIx32 ": %s ends at $%04" PRIx16 "",
+		scriptError(context, "Cannot set the current address to $%04" PRIx32 ": %s ends at $%04" PRIx16 "",
 		            addr, typeInfo.name.c_str(), endaddr(activeType));
 		pc = endaddr(activeType);
 	} else {
@@ -396,7 +396,7 @@ static void setAddr(uint32_t addr) {
 static void makeAddrFloating(void) {
 	auto const &context = lexerStack.back();
 	if (activeType == SECTTYPE_INVALID) {
-		scriptError(context, "Cannot make PC floating because no memory region is active");
+		scriptError(context, "Cannot make the current address floating: no memory region is active");
 		return;
 	}
 
@@ -408,7 +408,7 @@ static void makeAddrFloating(void) {
 static void alignTo(uint32_t alignment, uint32_t alignOfs) {
 	auto const &context = lexerStack.back();
 	if (activeType == SECTTYPE_INVALID) {
-		scriptError(context, "Cannot modify PC because no memory region is active");
+		scriptError(context, "Cannot align: no memory region is active");
 		return;
 	}
 
@@ -470,7 +470,7 @@ static void alignTo(uint32_t alignment, uint32_t alignOfs) {
 static void pad(uint32_t length) {
 	auto const &context = lexerStack.back();
 	if (activeType == SECTTYPE_INVALID) {
-		scriptError(context, "Cannot modify PC because no memory region is active");
+		scriptError(context, "Cannot pad: no memory region is active");
 		return;
 	}
 

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -416,8 +416,17 @@ static void alignTo(uint32_t alignment, uint32_t alignOfs) {
 		if (alignment >= 16) {
 			setAddr(alignOffset);
 		} else {
-			alignMask = UINT16_C(1) << alignment;
-			alignOffset = alignOfs % alignMask; // TODO: maybe warn if truncating?
+			uint32_t alignSize = 1u << alignment;
+
+			if (alignOfs >= alignSize) {
+				scriptError(context, "Cannot align: The alignment offset (%" PRIu32
+						      ") must be less than alignment size (%" PRIu32 ")\n",
+					    alignOfs, alignSize);
+				return;
+			}
+
+			alignMask = alignSize;
+			alignOffset = alignOfs % alignMask;
 		}
 		return;
 	}
@@ -440,7 +449,7 @@ static void alignTo(uint32_t alignment, uint32_t alignOfs) {
 		if (alignOfs >= alignSize) {
 			scriptError(context, "Cannot align: The alignment offset (%" PRIu32
 					      ") must be less than alignment size (%" PRIu32 ")\n",
-				    alignOfs, 1 << alignment);
+				    alignOfs, alignSize);
 			return;
 		}
 

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -470,7 +470,7 @@ static void alignTo(uint32_t alignment, uint32_t alignOfs) {
 static void pad(uint32_t length) {
 	auto const &context = lexerStack.back();
 	if (activeType == SECTTYPE_INVALID) {
-		scriptError(context, "Cannot pad: no memory region is active");
+		scriptError(context, "Cannot increase the current address: no memory region is active");
 		return;
 	}
 
@@ -484,7 +484,7 @@ static void pad(uint32_t length) {
 
 	assert(pc >= typeInfo.startAddr);
 	if (uint16_t offset = pc - typeInfo.startAddr; length + offset > typeInfo.size) {
-		scriptError(context, "Cannot pad by %u bytes: only %u bytes to $%04" PRIx16,
+		scriptError(context, "Cannot increase the current address by %u bytes: only %u bytes to $%04" PRIx16,
 		            length, typeInfo.size - offset, (uint16_t)(endaddr(activeType) + 1));
 	} else {
 		pc += length;

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -401,7 +401,7 @@ static void makeAddrFloating(void) {
 	}
 
 	isPcFloating = true;
-	floatingAlignMask = 1;
+	floatingAlignMask = 0;
 	floatingAlignOffset = 0;
 }
 
@@ -425,7 +425,7 @@ static void alignTo(uint32_t alignment, uint32_t alignOfs) {
 				return;
 			}
 
-			floatingAlignMask = alignSize;
+			floatingAlignMask = alignSize - 1;
 			floatingAlignOffset = alignOfs % alignSize;
 		}
 		return;
@@ -475,7 +475,7 @@ static void pad(uint32_t length) {
 	}
 
 	if (isPcFloating) {
-		floatingAlignOffset = (floatingAlignOffset + length) % floatingAlignMask;
+		floatingAlignOffset = (floatingAlignOffset + length) & floatingAlignMask;
 		return;
 	}
 
@@ -554,11 +554,11 @@ static void placeSection(std::string const &name, bool isOptional) {
 		}
 	} else {
 		section->isAddressFixed = false;
-		section->isAlignFixed = floatingAlignMask != 1;
+		section->isAlignFixed = floatingAlignMask != 0;
 		section->alignMask = floatingAlignMask;
 		section->alignOfs = floatingAlignOffset;
 
-		floatingAlignOffset = (floatingAlignOffset + section->size) % floatingAlignMask;
+		floatingAlignOffset = (floatingAlignOffset + section->size) & floatingAlignMask;
 	}
 }
 


### PR DESCRIPTION
Makes some progress towards #1008.

The implementation of `FLOATING` is a little slapdash, I'll give you that... but it turns out that the entire linker script processor is *really* assuming that PC is fixed the entire time.

None of this is tested, because it's really meant for experimentation by people who I'd assume would communicate with us in the first place (and I doubt anyone will mind if we tweak/fix the behaviour later on; something something experimental feature gates).

Also, no documentation has been written yet. I intend to fully overhaul `rgblink(5)` once the *behaviour* of this PR has been agreed upon and #1271 has been merged, and once that's done I'll unmark this as draft so we can bikeshed the documentation.

So, for the time being, please review the code and the behaviour it implies, and assume the documentation will be written accordingly afterwards.