### PR TITLE
Update the man pages' dates and history

### DIFF
--- a/man/gbz80.7
+++ b/man/gbz80.7
@@ -1,6 +1,6 @@
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd March 28, 2021
+.Dd December 22, 2023
 .Dt GBZ80 7
 .Os
 .Sh NAME
@@ -1947,10 +1947,15 @@ Flags: See
 .Sx XOR A,r8
 .Sh SEE ALSO
 .Xr rgbasm 1 ,
+.Xr rgblink 1 ,
+.Xr rgbfix 1 ,
+.Xr rgbgfx 1 ,
 .Xr rgbds 7
 .Sh HISTORY
-.Nm rgbds
-was originally written by Carsten S\(/orensen as part of the ASMotor package,
-and was later packaged in RGBDS by Justin Lloyd.
+.Xr rgbasm 1
+was originally written by
+.An Carsten S\(/orensen
+as part of the ASMotor package, and was later repackaged in RGBDS by
+.An Justin Lloyd .
 It is now maintained by a number of contributors at
 .Lk https://github.com/gbdev/rgbds .

--- a/man/rgbasm.1
+++ b/man/rgbasm.1
@@ -1,6 +1,6 @@
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd March 28, 2021
+.Dd December 22, 2023
 .Dt RGBASM 1
 .Os
 .Sh NAME
@@ -352,14 +352,18 @@ and then
 Please report bugs on
 .Lk https://github.com/gbdev/rgbds/issues GitHub .
 .Sh SEE ALSO
-.Xr rgbfix 1 ,
-.Xr rgblink 1 ,
 .Xr rgbasm 5 ,
+.Xr rgblink 1 ,
+.Xr rgbfix 1 ,
+.Xr rgbgfx 1 ,
 .Xr gbz80 7 ,
 .Xr rgbds 5 ,
 .Xr rgbds 7
 .Sh HISTORY
 .Nm
-was originally written by Carsten S\(/orensen as part of the ASMotor package, and was later packaged in RGBDS by Justin Lloyd.
+was originally written by
+.An Carsten S\(/orensen
+as part of the ASMotor package, and was later repackaged in RGBDS by
+.An Justin Lloyd .
 It is now maintained by a number of contributors at
 .Lk https://github.com/gbdev/rgbds .

--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd March 28, 2021
+.Dd December 22, 2023
 .Dt RGBASM 5
 .Os
 .Sh NAME
@@ -2171,15 +2171,19 @@ Note that
 is a shorthand for
 .Ic ALIGN Ns Bq Ar align , No 0 .
 .Sh SEE ALSO
-.Xr gbz80 7 ,
 .Xr rgbasm 1 ,
 .Xr rgblink 1 ,
 .Xr rgblink 5 ,
+.Xr rgbfix 1 ,
+.Xr rgbgfx 1 ,
+.Xr gbz80 7 ,
 .Xr rgbds 5 ,
 .Xr rgbds 7
 .Sh HISTORY
-.Nm
-was originally written by Carsten S\(/orensen as part of the ASMotor package,
-and was later packaged in RGBDS by Justin Lloyd.
+.Xr rgbasm 1
+was originally written by
+.An Carsten S\(/orensen
+as part of the ASMotor package, and was later repackaged in RGBDS by
+.An Justin Lloyd .
 It is now maintained by a number of contributors at
 .Lk https://github.com/gbdev/rgbds .

--- a/man/rgbds.5
+++ b/man/rgbds.5
@@ -1,6 +1,6 @@
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd March 28, 2021
+.Dd December 22, 2023
 .Dt RGBDS 5
 .Os
 .Sh NAME
@@ -397,12 +397,20 @@ ID.
 .El
 .Sh SEE ALSO
 .Xr rgbasm 1 ,
+.Xr rgbasm 5 ,
 .Xr rgblink 1 ,
-.Xr rgbds 7 ,
-.Xr gbz80 7
+.Xr rgblink 5 ,
+.Xr rgbfix 1 ,
+.Xr rgbgfx 1 ,
+.Xr gbz80 7 ,
+.Xr rgbds 7
 .Sh HISTORY
-.Nm
-was originally written by Carsten S\(/orensen as part of the ASMotor package,
-and was later packaged in RGBDS by Justin Lloyd.
+.Xr rgbasm 1
+and
+.Xr rgblink 1
+were originally written by
+.An Carsten S\(/orensen
+as part of the ASMotor package, and was later repackaged in RGBDS by
+.An Justin Lloyd .
 It is now maintained by a number of contributors at
 .Lk https://github.com/gbdev/rgbds .

--- a/man/rgbds.7
+++ b/man/rgbds.7
@@ -1,6 +1,6 @@
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd March 28, 2021
+.Dd December 22, 2023
 .Dt RGBDS 7
 .Os
 .Sh NAME
@@ -9,44 +9,65 @@
 .Sh EXAMPLES
 To get a working ROM image from a single assembly source file:
 .Bd -literal -offset indent
-$ rgbasm \-o bar.o foo.asm
-$ rgblink \-o baz.gb bar.o
-$ rgbfix \-v \-p 0 baz.gb
+$ rgbasm \-o game.o game.asm
+$ rgblink \-o game.gb game.o
+$ rgbfix \-v \-p 0 game.gb
 .Ed
-Or in a single command line:
+.Pp
+Or in a single command line, without creating an intermediate object file:
 .Bd -literal -offset indent
-$ rgbasm \-o - foo.asm | rgblink \-o - - | rgbfix \-v \-p 0 - > baz.gb
+$ (rgbasm -o - - | rgblink -o - - | rgbfix -v -p 0) < game.asm > game.gb
 .Ed
 .Sh SEE ALSO
 .Xr rgbasm 1 ,
-.Xr rgbfix 1 ,
+.Xr rgbasm 5 ,
 .Xr rgblink 1 ,
-.Xr rgbds 5 ,
-.Xr gbz80 7
+.Xr rgblink 5 ,
+.Xr rgbfix 1 ,
+.Xr rgbgfx 1 ,
+.Xr gbz80 7 ,
+.Xr rgbds 5
 .Sh HISTORY
 .Bl -item
 .It
-1997, Carsten S\(/orensen (AKA SurfSmurf) writes ASMotor as a general-purpose
-assembler/linker system for DOS/Win32.
+1996-10-01:
+.An Carsten S\(/orensen
+.Pq a.k.a. SurfSmurf
+releases xAsm, xLink, and RGBFix, a Game Boy SM83 (GBZ80) assembler/linker system for DOS/Win32.
 .It
-1999, Justin Lloyd (AKA Otaku no Zoku) adapts ASMotor to read and produce GBZ80
-assembly/machine code, and releases this version as RGBDS.
+1997-07-03: S\(/orensen releases ASMotor, packaging the three programs together and moving towards making them a general-purpose target-independent system.
 .It
-2009, Vegard Nossum adapts the code to be more UNIX-like and releases this
-version as rgbds-linux on GitHub.
+1999-08-01:
+.An Justin Lloyd
+.Pq a.k.a. Otaku no Zoku
+adapts ASMotor to re-focus on SM83 assembly/machine code, and releases this version as RGBDS.
 .It
-2010, Anthony J. Bentley forks that repository.
-The fork becomes the reference implementation of rgbds.
+2009-06-11:
+.An Vegard Nossum
+adapts the code to be more UNIX-like and releases this version as rgbds-linux.
 .It
-2017, Bentley's repository is moved to a neutral name.
-It is now maintained by a number of contributors at
-.Lk https://github.com/rednex/rgbds .
+2010-01-12:
+.An Anthony J. Bentley
+forks Nossum's repository.
+The fork becomes the reference implementation of RGBDS.
 .It
-2018, codebase relicensed under the MIT license.
+2015-01-18:
+.An stag019
+begins implementing rgbgfx, a PNG‐to‐Game Boy graphics converter, for eventual integration into RGBDS.
 .It
-2020, repository is moved to the gbdev organisation, at
-.Lk https://github.com/gbdev/rgbds .
-The
+2016-09-05: rgbgfx is integrated into Bentley's repository.
+.It
+2017-02-23: Bentley's repository is moved to the
+.Lk https://github.com/rednex/rgbds rednex
+organization.
+.It
+2018-01-26: The codebase is relicensed under the MIT license.
+.It
+2020-09-15: The repository is moved to the
+.Lk https://github.com/gbdev/rgbds gbdev
+organization.
+.It
+2022-05-17: The
 .Lk https://rgbds.gbdev.io
-website serving documentation and downloads is created.
+website for RGBDS documentation and downloads is published.
 .El

--- a/man/rgbfix.1
+++ b/man/rgbfix.1
@@ -1,6 +1,6 @@
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd March 28, 2021
+.Dd December 22, 2023
 .Dt RGBFIX 1
 .Os
 .Sh NAME
@@ -236,9 +236,14 @@ Please report bugs on
 .Sh SEE ALSO
 .Xr rgbasm 1 ,
 .Xr rgblink 1 ,
+.Xr rgbgfx 1 ,
+.Xr gbz80 7 ,
 .Xr rgbds 7
 .Sh HISTORY
 .Nm
-was originally released by Carsten S\(/orensen as a standalone program called gbfix, and was later packaged in RGBDS by Justin Lloyd.
+was originally written by
+.An Carsten S\(/orensen
+as a standalone program called GBFix, which was then packaged in ASMotor, and was later repackaged in RGBDS by
+.An Justin Lloyd .
 It is now maintained by a number of contributors at
 .Lk https://github.com/gbdev/rgbds .

--- a/man/rgbgfx.1
+++ b/man/rgbgfx.1
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd March 28, 2021
+.Dd December 22, 2023
 .Dt RGBGFX 1
 .Os
 .Sh NAME
@@ -653,7 +653,6 @@ Bug reports and feature requests about RGBDS are also welcome!
 .Xr rgbasm 1 ,
 .Xr rgblink 1 ,
 .Xr rgbfix 1 ,
-.Xr gbz80 7 ,
 .Xr rgbds 7
 .Pp
 The Game Boy hardware reference
@@ -661,9 +660,7 @@ The Game Boy hardware reference
 particularly the section about graphics.
 .Sh HISTORY
 .Nm
-was originally created by
-.An stag019
-to be included in RGBDS.
+was originally written by stag019 as a program to be packaged in RGBDS.
 It was later rewritten by
 .An ISSOtm ,
 and is now maintained by a number of contributors at

--- a/man/rgblink.1
+++ b/man/rgblink.1
@@ -1,6 +1,6 @@
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd March 28, 2021
+.Dd December 22, 2023
 .Dt RGBLINK 1
 .Os
 .Sh NAME
@@ -204,10 +204,15 @@ Please report bugs on
 .Xr rgbasm 1 ,
 .Xr rgblink 5 ,
 .Xr rgbfix 1 ,
+.Xr rgbgfx 1 ,
+.Xr gbz80 7 ,
 .Xr rgbds 5 ,
 .Xr rgbds 7
 .Sh HISTORY
 .Nm
-was originally written by Carsten S\(/orensen as part of the ASMotor package, and was later packaged in RGBDS by Justin Lloyd.
+was originally written by
+.An Carsten S\(/orensen
+as part of the ASMotor package, and was later repackaged in RGBDS by
+.An Justin Lloyd .
 It is now maintained by a number of contributors at
 .Lk https://github.com/gbdev/rgbds .

--- a/man/rgblink.5
+++ b/man/rgblink.5
@@ -1,6 +1,6 @@
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd March 28, 2021
+.Dd December 22, 2023
 .Dt RGBLINK 5
 .Os
 .Sh NAME
@@ -103,13 +103,18 @@ in the source code is compatible with
 in the linker script.
 .Sh SEE ALSO
 .Xr rgbasm 1 ,
+.Xr rgbasm 5 ,
 .Xr rgblink 1 ,
 .Xr rgbfix 1 ,
+.Xr rgbgfx 1 ,
+.Xr gbz80 7 ,
 .Xr rgbds 5 ,
 .Xr rgbds 7
 .Sh HISTORY
-.Nm
-was originally written by Carsten S\(/orensen as part of the ASMotor package,
-and was later packaged in RGBDS by Justin Lloyd.
+.Xr rgblink 1
+was originally written by
+.An Carsten S\(/orensen
+as part of the ASMotor package, and was later repackaged in RGBDS by
+.An Justin Lloyd .
 It is now maintained by a number of contributors at
 .Lk https://github.com/gbdev/rgbds .


### PR DESCRIPTION
Fixes #1278

I noticed while updating the dates that the "History" sections were also inconsistent and outdated compared to the README, so I rewrote those (which counts as an update, thus making all these dates the current 2023-12-22).

I tried to make the "See Also" sections consistent, mentioning all the actual programs, and format docs if they're applicable to the specific page.

This is an example of edited usage and history info in `rgblink(1)`:

![image](https://github.com/gbdev/rgbds/assets/35663410/b81a4009-54b9-4120-9f02-b0e5d481de85)

And this is the entire `rgbds(7)` man page, which has more detailed history:

![image](https://github.com/gbdev/rgbds/assets/35663410/31f895bd-b8d7-41c2-8a36-ccfa203f90c5)
