### PR TITLE
Build for macOS 10.14 and below

### DIFF
--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build binaries
         run: |
           export PATH="/usr/local/opt/bison/bin:$PATH"
-          make -j WARNFLAGS="-Wall -Wextra -mmacosx-version-min=10.9" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
+          make -j CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9 -I include/hacks" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
       - name: Package binaries
         run: |
           zip --junk-paths rgbds-${{ env.version }}-macos-x86-64.zip rgb{asm,link,fix,gfx} man/* .github/scripts/install.sh

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,14 +4,14 @@ on:
   - pull_request
 
 jobs:
-  unix-testing:
+  unix:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
         cxx: [g++, clang++]
         buildsys: [make, cmake]
         exclude:
-          # `gcc` is just an alias to `clang` on macOS, don't bother
+          # Don't use `g++` on macOS; it's just an alias to `clang++`.
           - os: macos-11
             cxx: g++
           - os: macos-12
@@ -24,9 +24,9 @@ jobs:
         shell: bash
         run: |
           ./.github/scripts/install_deps.sh ${{ matrix.os }}
-      # The `export` lines are to allow working on macOS...
-      # Apple's base version is severely outdated, not even supporting -Wall,
-      # but it overrides Homebrew's version nonetheless...
+      # Export `bison` to allow using the version we install from Homebrew,
+      # instead of the outdated one preinstalled on macOS (which doesn't
+      # even support `-Wall`...).
       - name: Build & install using Make
         if: matrix.buildsys == 'make'
         run: |
@@ -79,7 +79,64 @@ jobs:
         run: |
           test/run-tests.sh
 
-  windows-testing:
+  macos-static:
+    strategy:
+      matrix:
+        # Don't run on macOS 11; our setup makes clang segfault (YES).
+        os: [macos-12]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install deps
+        shell: bash
+        run: |
+          ./.github/scripts/install_deps.sh ${{ matrix.os }}
+      # Export `bison` to allow using the version we install from Homebrew,
+      # instead of the outdated one preinstalled on macOS (which doesn't
+      # even support `-Wall`...).
+      - name: Build & install
+        run: |
+          export PATH="/usr/local/opt/bison/bin:$PATH"
+          make -j CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9 -I include/hacks" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
+      - name: Package binaries
+        run: |
+          mkdir bins
+          cp rgb{asm,link,fix,gfx} bins
+      - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: rgbds-canary-${{ matrix.os }}-${{ matrix.buildsys }}
+          path: bins
+      - name: Compute test dependency cache params
+        id: test-deps-cache-params
+        shell: bash
+        run: |
+          paths=$(test/fetch-test-deps.sh --get-paths)
+          hash=$(test/fetch-test-deps.sh --get-hash)
+          tee -a <<<"paths=\"${paths//,/\\n}\"" $GITHUB_OUTPUT
+          tee -a <<<"hash=${hash%-}" $GITHUB_OUTPUT
+      - name: Check test dependency repositories cache
+        id: test-deps-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ fromJSON(steps.test-deps-cache-params.outputs.paths) }}
+          key: ${{ matrix.os }}-${{ steps.test-deps-cache-params.outputs.hash }}
+      - if: steps.test-deps-cache.outputs.cache-hit != 'true'
+        name: Fetch test dependency repositories
+        continue-on-error: true
+        run: |
+          test/fetch-test-deps.sh
+      - name: Install test dependency dependencies
+        shell: bash
+        run: |
+          test/fetch-test-deps.sh --get-deps ${{ matrix.os }}
+      - name: Run tests
+        shell: bash
+        run: |
+          test/run-tests.sh
+
+  windows:
     strategy:
       matrix:
         bits: [32, 64]
@@ -169,7 +226,7 @@ jobs:
           cp bins/*.dll test/gfx
           test/run-tests.sh
 
-  windows-xbuild:
+  windows-mingw-build:
     strategy:
       matrix:
         bits: [32, 64]
@@ -220,8 +277,8 @@ jobs:
             test/gfx/randtilegen.exe
             test/gfx/rgbgfx_test.exe
 
-  windows-xtesting:
-    needs: windows-xbuild
+  windows-mingw-testing:
+    needs: windows-mingw-build
     strategy:
       matrix:
         os: [windows-2019, windows-2022]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN apt-get update && \
     apt-get install sudo make cmake gcc build-essential -y
 
 RUN ./.github/scripts/install_deps.sh ubuntu-20.04
-RUN make -j WARNFLAGS="-Wall -Wextra -pedantic  -static" PKG_CONFIG="pkg-config --static" Q=
+RUN make -j CXXFLAGS="-O3 -flto -DNDEBUG -static" PKG_CONFIG="pkg-config --static" Q=
 
 RUN tar caf rgbds-${version}-linux-x86_64.tar.xz --transform='s#.*/##' rgbasm rgblink rgbfix rgbgfx man/* .github/scripts/install.sh

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ WARNFLAGS	:= -Wall -Wno-unknown-warning-option -Wno-c99-designator
 # Overridable CXXFLAGS
 CXXFLAGS	?= -O3 -flto -DNDEBUG
 # Non-overridable CXXFLAGS
-REALCXXFLAGS	:= ${CXXFLAGS} ${WARNFLAGS} -x c++ -std=c++2a -I include \
+REALCXXFLAGS	:= ${CXXFLAGS} ${WARNFLAGS} -std=c++2a -I include \
 		   -D_POSIX_C_SOURCE=200809L -fno-exceptions -fno-rtti
 # Overridable LDFLAGS
 LDFLAGS		?=
@@ -200,7 +200,7 @@ checkdiff:
 # The rationale for some of the flags is documented in the CMakeLists.
 
 develop:
-	$Qenv ${MAKE} WARNFLAGS="${WARNFLAGS} -Werror -Wextra \
+	$Q${MAKE} WARNFLAGS="${WARNFLAGS} -Werror -Wextra \
 		-Walloc-zero -Wcast-align -Wcast-qual -Wduplicated-branches -Wduplicated-cond \
 		-Wfloat-equal -Wlogical-op -Wnull-dereference -Wshift-overflow=2 \
 		-Wstringop-overflow=4 -Wstrict-overflow=5 -Wundef -Wuninitialized -Wunused \

--- a/include/hacks/__availability
+++ b/include/hacks/__availability
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifdef __APPLE__
+
+#include_next <__availability>
+
+/**
+ * This is a hack to make RGBDS build on macOS 10.14 and below. Without it, we get errors like:
+ *     error: 'path' is unavailable: introduced in macOS 10.15
+ * The hack weakens the `std::filesystem::path` availability error into a warning, by removing
+ * `strict` from the availability macros (for information on the `availability` attribute, see
+ * https://releases.llvm.org/17.0.1/tools/clang/docs/AttributeReference.html#availability). This is
+ * acceptable because what we need of `std::filesystem::path` was already supported in macOS 10.14
+ * (the last version to support 32-bit, hence in demand despite being superseded by 10.15 in 2019).
+ */
+
+#ifndef _LIBCPP_HAS_NO_VENDOR_AVAILABILITY_ANNOTATIONS
+# undef _LIBCPP_AVAILABILITY_FILESYSTEM_PUSH
+# define _LIBCPP_AVAILABILITY_FILESYSTEM_PUSH \
+         _Pragma("clang attribute push(__attribute__((availability(macosx,introduced=10.15))), apply_to=any(function,record))") \
+         _Pragma("clang attribute push(__attribute__((availability(ios,introduced=13.0))), apply_to=any(function,record))")     \
+         _Pragma("clang attribute push(__attribute__((availability(tvos,introduced=13.0))), apply_to=any(function,record))")    \
+         _Pragma("clang attribute push(__attribute__((availability(watchos,introduced=6.0))), apply_to=any(function,record))")
+
+# define _LIBCPP_AVAILABILITY_FILESYSTEM \
+         __attribute__((availability(macosx,introduced=10.15))) \
+         __attribute__((availability(ios,introduced=13.0)))     \
+         __attribute__((availability(tvos,introduced=13.0)))    \
+         __attribute__((availability(watchos,introduced=6.0)))
+#endif
+
+#endif // __APPLE__


### PR DESCRIPTION
macOS 10.15 introduced full `std::filesystem::path` support. Before that our use of it would cause the build to fail. This was not caught because "`-mmacosx-version-min=10.9`" was only being passed to `clang++` for release builds.

This passes that flag even in CI test builds, and introduces a hack to make the "path" error become a warning, since we use features already available in 10.9.