### PR TITLE
Fix "build from source" link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ or via mail at ``rgbds at gbdev dot io``.
 -------------------
 
 The `installation procedure <https://rgbds.gbdev.io/install>`__ is available
-online for various platforms. `Building from source <https://rgbds.gbdev.io/install/#building-from-source>`__
+online for various platforms. `Building from source <https://rgbds.gbdev.io/install/source>`__
 is possible using ``make`` or ``cmake``; follow the link for more detailed instructions.
 
 .. code:: sh


### PR DESCRIPTION
Currently the "Build From Source" link in the README doesn't work properly and sends to the more general "installation instructions" page which does not include instructions for building. This fixes that.