### PR TITLE
Increment object file revision number to 10

### DIFF
--- a/include/linkdefs.hpp
+++ b/include/linkdefs.hpp
@@ -8,8 +8,8 @@
 #include <stdint.h>
 #include <string>
 
-#define RGBDS_OBJECT_VERSION_STRING "RGB9"
-#define RGBDS_OBJECT_REV 9U
+#define RGBDS_OBJECT_VERSION_STRING "RGBA"
+#define RGBDS_OBJECT_REV 10U
 
 enum AssertionType {
 	ASSERT_WARN,

--- a/man/rgbds.5
+++ b/man/rgbds.5
@@ -54,7 +54,7 @@ References to other object files are made by imports (symbols), by name (section
 .Ss Header
 .Bl -tag -width Ds -compact
 .It Cm BYTE Ar Magic[4]
-"RGB9"
+"RGBA"
 .It Cm LONG Ar RevisionNumber
 The format's revision number this file uses.
 .Pq This is always in the same place in all revisions.


### PR DESCRIPTION
We added `SIZEOF(secttype)` and `STARTOF(secttype)` RPN IDs in 0.7.0, so this should have been updated.