### PR TITLE
Phrase error messages as "Failed to", not "Could not" or "Couldn't"

### DIFF
--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -259,7 +259,7 @@ int main(int argc, char *argv[])
 				dependFileName = musl_optarg;
 			}
 			if (dependfile == NULL)
-				err("Could not open dependfile %s", dependFileName);
+				err("Failed to open dependfile %s", dependFileName);
 			break;
 
 		case 'o':

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -655,7 +655,7 @@ void sym_Init(time_t now)
 #endif
 
 	if (now == (time_t)-1) {
-		warn("Couldn't determine current time");
+		warn("Failed to determine current time");
 		// Fall back by pretending we are at the Epoch
 		now = 0;
 	}

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -468,7 +468,7 @@ static void parseACOFile(std::filebuf &file) {
 	char buf[10];
 
 	if (file.sgetn(buf, 2) != 2) {
-		error("Couldn't read ACO file version");
+		error("Failed to read ACO file version");
 		return;
 	}
 	if (readBE<uint16_t>(buf) != 1) {
@@ -477,7 +477,7 @@ static void parseACOFile(std::filebuf &file) {
 	}
 
 	if (file.sgetn(buf, 2) != 2) {
-		error("Couldn't read number of colors in palette file");
+		error("Failed to read number of colors in palette file");
 		return;
 	}
 	uint16_t nbColors = readBE<uint16_t>(buf);

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -606,7 +606,7 @@ static std::tuple<DefaultInitVec<size_t>, std::vector<Palette>>
 
 		if (iter == palettes.end()) {
 			assert(!protoPal.empty());
-			error("Could not fit tile colors [%s] in specified palettes", listColors(protoPal));
+			error("Failed to fit tile colors [%s] in specified palettes", listColors(protoPal));
 			bad = true;
 		}
 		mappings[i] = iter - palettes.begin(); // Bogus value, but whatever

--- a/src/gfx/reverse.cpp
+++ b/src/gfx/reverse.cpp
@@ -246,11 +246,11 @@ void reverse() {
 	    const_cast<png_voidp>(static_cast<void const *>(pngFile.c_str(options.input))), pngError,
 	    pngWarning);
 	if (!png) {
-		fatal("Couldn't create PNG write struct: %s", strerror(errno));
+		fatal("Failed to create PNG write struct: %s", strerror(errno));
 	}
 	png_infop pngInfo = png_create_info_struct(png);
 	if (!pngInfo) {
-		fatal("Couldn't create PNG info struct: %s", strerror(errno));
+		fatal("Failed to create PNG info struct: %s", strerror(errno));
 	}
 	png_set_write_fn(png, &pngFile, writePng, flushPng);
 

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -156,7 +156,7 @@ FILE *openFile(char const *fileName, char const *mode)
 		file = fdopen(STDOUT_FILENO, mode);
 
 	if (!file)
-		err("Could not open file \"%s\"", fileName);
+		err("Failed to open file \"%s\"", fileName);
 
 	return file;
 }

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -452,7 +452,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID)
 		file = fdopen(STDIN_FILENO, "rb"); // `stdin` is in text mode by default
 
 	if (!file)
-		err("Could not open file %s", fileName);
+		err("Failed to open file %s", fileName);
 
 	// First, check if the object is a RGBDS object or a SDCC one. If the first byte is 'R',
 	// we'll assume it's a RGBDS object file, and otherwise, that it's a SDCC object file.
@@ -551,7 +551,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID)
 		struct Symbol *symbol = (struct Symbol *)malloc(sizeof(*symbol));
 
 		if (!symbol)
-			err("%s: Couldn't create new symbol", fileName);
+			err("%s: Failed to create new symbol", fileName);
 		readSymbol(file, symbol, fileName, nodes[fileID].nodes);
 
 		fileSymbols[i] = symbol;
@@ -570,7 +570,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID)
 		// Read section
 		fileSections[i] = (struct Section *)malloc(sizeof(*fileSections[i]));
 		if (!fileSections[i])
-			err("%s: Couldn't create new section", fileName);
+			err("%s: Failed to create new section", fileName);
 
 		fileSections[i]->nextu = NULL;
 		readSection(file, fileSections[i], fileName, nodes[fileID].nodes);
@@ -579,8 +579,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID)
 			fileSections[i]->symbols =
 				(struct Symbol **)malloc(nbSymPerSect[i] * sizeof(*fileSections[i]->symbols));
 			if (!fileSections[i]->symbols)
-				err("%s: Couldn't link to symbols",
-				    fileName);
+				err("%s: Failed to link to symbols", fileName);
 		} else {
 			fileSections[i]->symbols = NULL;
 		}
@@ -630,7 +629,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID)
 		struct Assertion *assertion = (struct Assertion *)malloc(sizeof(*assertion));
 
 		if (!assertion)
-			err("%s: Couldn't create new assertion", fileName);
+			err("%s: Failed to create new assertion", fileName);
 		readAssertion(file, assertion, fileName, i, nodes[fileID].nodes);
 		linkPatchToPCSect(&assertion->patch, fileSections);
 		assertion->fileSymbols = fileSymbols;

--- a/src/link/patch.cpp
+++ b/src/link/patch.cpp
@@ -485,7 +485,7 @@ void patch_CheckAssertions(struct Assertion *assert)
 			}
 		} else if (isError && type == ASSERT_FATAL) {
 			fatal(assert->patch.src, assert->patch.lineNo,
-			      "couldn't evaluate assertion%s%s",
+			      "Failed to evaluate assertion%s%s",
 			      assert->message[0] ? ": " : "",
 			      assert->message);
 		}

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -132,7 +132,7 @@ static void includeFile(std::string &&path) {
 
 	if (!newContext.file.open(newContext.path, std::ios_base::in)) {
 		// The order is important: report the error, increment the line number, modify the stack!
-		scriptError(prevContext, "Could not open included linker script \"%s\"",
+		scriptError(prevContext, "Failed to open included linker script \"%s\"",
 		            newContext.path.c_str());
 		++prevContext.lineNo;
 		lexerStack.pop_back();
@@ -574,7 +574,7 @@ void script_ProcessScript(char const *path) {
 	auto &newContext = lexerStack.emplace_back(std::string(path));
 
 	if (!newContext.file.open(newContext.path, std::ios_base::in)) {
-		error(NULL, 0, "Could not open linker script \"%s\"", newContext.path.c_str());
+		error(NULL, 0, "Failed to open linker script \"%s\"", newContext.path.c_str());
 		lexerStack.clear();
 	} else {
 		yy::parser linkerScriptParser;

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -370,7 +370,7 @@ void sdobj_ReadFile(struct FileStackNode const *where, FILE *file) {
 				if (!newFileSymbols)
 					fatal(where, lineNo, "Failed to alloc extra symbols: %s", strerror(errno));
 				if (newFileSymbols != fileSymbols)
-					fatal(where, lineNo, "Couldn't handle extra 'S' lines (pointer moved)");
+					fatal(where, lineNo, "Failed to handle extra 'S' lines (pointer moved)");
 				// No need to assign, obviously
 			}
 #define symbol (fileSymbols[nbSymbols])

--- a/test/gfx/bad_manual_pals.err
+++ b/test/gfx/bad_manual_pals.err
@@ -1,5 +1,5 @@
-error: Could not fit tile colors [$6c8a, $7f55, $7fff] in specified palettes
-error: Could not fit tile colors [$6c8a, $7f55] in specified palettes
+error: Failed to fit tile colors [$6c8a, $7f55, $7fff] in specified palettes
+error: Failed to fit tile colors [$6c8a, $7f55] in specified palettes
 note: The following palettes were specified:
         [$7fff, $7f55]
         [$7fff, $6c8a]

--- a/test/link/cascading-errors-fatal-assert.out
+++ b/test/link/cascading-errors-fatal-assert.out
@@ -1,3 +1,3 @@
 error: cascading-errors-fatal-assert.asm(1): Unknown symbol "UnknownSymbol"
-FATAL: cascading-errors-fatal-assert.asm(1): couldn't evaluate assertion
+FATAL: cascading-errors-fatal-assert.asm(1): Failed to evaluate assertion
 Linking aborted after 2 errors


### PR DESCRIPTION
We had over 100 "Failed to" messages and only 20 or so "Could not"/"Couldn't"'. At first I was just going to remove the contraction, but then decided to just make them all "Failed to".