### PR TITLE
No more anonymous structs (not standard C++)

### DIFF
--- a/include/asm/symbol.hpp
+++ b/include/asm/symbol.hpp
@@ -39,9 +39,9 @@ struct Symbol {
 		int32_t (*numCallback)(void);
 		// For SYM_MACRO and SYM_EQUS; TODO: have separate fields
 		struct {
-			size_t macroSize;
-			char *macro;
-		};
+			size_t size;
+			char *value;
+		} macro;
 		// For SYM_EQUS
 		char const *(*strCallback)(void);
 	};
@@ -97,7 +97,7 @@ static inline char const *sym_GetStringValue(struct Symbol const *sym)
 {
 	if (sym->hasCallback)
 		return sym->strCallback();
-	return sym->macro;
+	return sym->macro.value;
 }
 
 void sym_ForEach(void (*func)(struct Symbol *, void *), void *arg);

--- a/include/link/main.hpp
+++ b/include/link/main.hpp
@@ -37,9 +37,9 @@ struct FileStackNode {
 	union {
 		char *name; // NODE_FILE, NODE_MACRO
 		struct { // NODE_REPT
-			uint32_t reptDepth;
+			uint32_t depth;
 			uint32_t *iters;
-		};
+		} rept;
 	};
 };
 

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -56,7 +56,7 @@
 #define restrict
 
 // C++ doesn't support designated array initializers, but they're a gcc extension
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__STRICT_ANSI__)
 # define AT(index) [index] =
 #else
 # define AT(index)

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -455,7 +455,7 @@ void fstk_RunMacro(char const *macroName, struct MacroArgs *args)
 	memcpy(dest, macro->name, macroNameLen + 1);
 
 	newContext((struct FileStackNode *)fileInfo);
-	contextStack->lexerState = lexer_OpenFileView("MACRO", macro->macro, macro->macroSize,
+	contextStack->lexerState = lexer_OpenFileView("MACRO", macro->macro.value, macro->macro.size,
 						      macro->fileLine);
 	if (!contextStack->lexerState)
 		fatalerror("Failed to set up lexer for macro invocation\n");

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -164,8 +164,8 @@ static void assignStringSymbol(struct Symbol *sym, char const *value)
 		fatalerror("No memory for string equate: %s\n", strerror(errno));
 
 	sym->type = SYM_EQUS;
-	sym->macro = string;
-	sym->macroSize = strlen(string);
+	sym->macro.value = string;
+	sym->macro.size = strlen(string);
 }
 
 struct Symbol *sym_FindExactSymbol(char const *symName)
@@ -233,8 +233,8 @@ void sym_Purge(char const *symName)
 		if (sym->name == labelScope)
 			sym_SetCurrentSymbolScope(NULL);
 
-		// FIXME: this leaks sym->macro for SYM_EQUS and SYM_MACRO, but this can't
-		// free(sym->macro) because the expansion may be purging itself.
+		// FIXME: this leaks sym->macro.value for SYM_EQUS and SYM_MACRO, but this can't
+		// free(sym->macro.value) because the expansion may be purging itself.
 		hash_RemoveElement(symbols, sym->name);
 		// TODO: ideally, also unref the file stack nodes
 		free(sym);
@@ -401,8 +401,8 @@ struct Symbol *sym_RedefString(char const *symName, char const *value)
 	}
 
 	updateSymbolFilename(sym);
-	// FIXME: this leaks the previous sym->macro value, but this can't
-	// free(sym->macro) because the expansion may be redefining itself.
+	// FIXME: this leaks the previous sym->macro.value value, but this can't
+	// free(sym->macro.value) because the expansion may be redefining itself.
 	assignStringSymbol(sym, value);
 
 	return sym;
@@ -574,8 +574,8 @@ struct Symbol *sym_AddMacro(char const *symName, int32_t defLineNo, char *body, 
 		return NULL;
 
 	sym->type = SYM_MACRO;
-	sym->macroSize = size;
-	sym->macro = body;
+	sym->macro.size = size;
+	sym->macro.value = body;
 	setSymbolFilename(sym); // TODO: is this really necessary?
 	// The symbol is created at the line after the `endm`,
 	// override this with the actual definition line

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -61,8 +61,8 @@ char const *dumpFileStack(struct FileStackNode const *node)
 			lastName = node->name;
 		fprintf(stderr, "(%" PRIu32 ") -> %s", node->lineNo, lastName);
 		if (node->type == NODE_REPT) {
-			for (uint32_t i = 0; i < node->reptDepth; i++)
-				fprintf(stderr, "::REPT~%" PRIu32, node->iters[i]);
+			for (uint32_t i = 0; i < node->rept.depth; i++)
+				fprintf(stderr, "::REPT~%" PRIu32, node->rept.iters[i]);
 		}
 	} else {
 		assert(node->type != NODE_REPT);

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -180,15 +180,15 @@ static void readFileStackNode(FILE *file, struct FileStackNode fileNodes[], uint
 		break;
 
 	case NODE_REPT:
-		tryReadlong(fileNodes[i].reptDepth, file,
+		tryReadlong(fileNodes[i].rept.depth, file,
 			    "%s: Cannot read node #%" PRIu32 "'s rept depth: %s", fileName, i);
-		fileNodes[i].iters =
-			(uint32_t *)malloc(sizeof(*fileNodes[i].iters) * fileNodes[i].reptDepth);
-		if (!fileNodes[i].iters)
+		fileNodes[i].rept.iters =
+			(uint32_t *)malloc(sizeof(*fileNodes[i].rept.iters) * fileNodes[i].rept.depth);
+		if (!fileNodes[i].rept.iters)
 			fatal(NULL, 0, "%s: Failed to alloc node #%" PRIu32 "'s iters: %s",
 			      fileName, i, strerror(errno));
-		for (uint32_t k = 0; k < fileNodes[i].reptDepth; k++)
-			tryReadlong(fileNodes[i].iters[k], file,
+		for (uint32_t k = 0; k < fileNodes[i].rept.depth; k++)
+			tryReadlong(fileNodes[i].rept.iters[k], file,
 				    "%s: Cannot read node #%" PRIu32 "'s iter #%" PRIu32 ": %s",
 				    fileName, i, k);
 		if (!fileNodes[i].parent)
@@ -659,7 +659,7 @@ void obj_Setup(unsigned int nbFiles)
 static void freeNode(struct FileStackNode *node)
 {
 	if (node->type == NODE_REPT)
-		free(node->iters);
+		free(node->rept.iters);
 	else
 		free(node->name);
 }


### PR DESCRIPTION
This is one step to restoring `-pedantic` builds.

(The other step is removing flexible array members; see #1307.)