### PR TITLE
No more flexible array members (not standard C++)

### DIFF
--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -29,7 +29,6 @@ struct FileStackNode {
 
 struct FileStackReptNode { // NODE_REPT
 	struct FileStackNode node;
-	// WARNING: if changing this type, change overflow check in `fstk_Init`
 	std::vector<uint32_t> *iters; // REPT iteration counts since last named node, in reverse depth order
 };
 

--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string>
+#include <vector>
 
 #include "asm/lexer.hpp"
 
@@ -28,9 +29,8 @@ struct FileStackNode {
 
 struct FileStackReptNode { // NODE_REPT
 	struct FileStackNode node;
-	uint32_t reptDepth;
 	// WARNING: if changing this type, change overflow check in `fstk_Init`
-	uint32_t *iters; // REPT iteration counts since last named node, in reverse depth order
+	std::vector<uint32_t> *iters; // REPT iteration counts since last named node, in reverse depth order
 };
 
 struct FileStackNamedNode { // NODE_FILE, NODE_MACRO

--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -30,12 +30,12 @@ struct FileStackReptNode { // NODE_REPT
 	struct FileStackNode node;
 	uint32_t reptDepth;
 	// WARNING: if changing this type, change overflow check in `fstk_Init`
-	uint32_t iters[]; // REPT iteration counts since last named node, in reverse depth order
+	uint32_t *iters; // REPT iteration counts since last named node, in reverse depth order
 };
 
 struct FileStackNamedNode { // NODE_FILE, NODE_MACRO
 	struct FileStackNode node;
-	char name[]; // File name for files, file::macro name for macros
+	char *name; // File name for files, file::macro name for macros
 };
 
 #define DEFAULT_MAX_DEPTH 64

--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -35,7 +35,7 @@ struct FileStackReptNode { // NODE_REPT
 
 struct FileStackNamedNode { // NODE_FILE, NODE_MACRO
 	struct FileStackNode node;
-	char *name; // File name for files, file::macro name for macros
+	std::string *name; // File name for files, file::macro name for macros
 };
 
 #define DEFAULT_MAX_DEPTH 64

--- a/include/asm/macro.hpp
+++ b/include/asm/macro.hpp
@@ -15,7 +15,7 @@ struct MacroArgs;
 
 struct MacroArgs *macro_GetCurrentArgs(void);
 struct MacroArgs *macro_NewArgs(void);
-void macro_AppendArg(struct MacroArgs **args, char *s);
+void macro_AppendArg(struct MacroArgs *args, char *s);
 void macro_UseNewArgs(struct MacroArgs *args);
 void macro_FreeArgs(struct MacroArgs *args);
 char const *macro_GetArg(uint32_t i);

--- a/include/asm/symbol.hpp
+++ b/include/asm/symbol.hpp
@@ -23,6 +23,12 @@ enum SymbolType {
 	SYM_REF // Forward reference to a label
 };
 
+// Only used in an anonymous union by `struct Symbol`
+struct strValue {
+	size_t size;
+	char *value;
+};
+
 struct Symbol {
 	char name[MAXSYMLEN + 1];
 	enum SymbolType type;
@@ -36,18 +42,12 @@ struct Symbol {
 	union {
 		// If sym_IsNumeric
 		int32_t value;
-		int32_t (*numCallback)(void);
+		int32_t (*numCallback)(void); // If hasCallback
 		// For SYM_MACRO
-		struct {
-			size_t size;
-			char *value;
-		} macro;
+		struct strValue macro;
 		// For SYM_EQUS
-		struct {
-			size_t size;
-			char *value;
-		} equs;
-		char const *(*strCallback)(void);
+		struct strValue equs;
+		char const *(*strCallback)(void); // If hasCallback
 	};
 
 	uint32_t ID; // ID of the symbol in the object file (-1 if none)

--- a/include/link/main.hpp
+++ b/include/link/main.hpp
@@ -28,6 +28,12 @@ extern bool beVerbose;
 extern bool isWRA0Mode;
 extern bool disablePadding;
 
+// Only used in an anonymous union by `struct FileStackNode`
+struct reptNodeData {
+	uint32_t depth;
+	uint32_t *iters;
+};
+
 struct FileStackNode {
 	struct FileStackNode *parent;
 	// Line at which the parent context was exited; meaningless for the root level
@@ -36,10 +42,7 @@ struct FileStackNode {
 	enum FileStackNodeType type;
 	union {
 		char *name; // NODE_FILE, NODE_MACRO
-		struct { // NODE_REPT
-			uint32_t depth;
-			uint32_t *iters;
-		} rept;
+		struct reptNodeData rept; // NODE_REPT
 	};
 };
 

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -389,7 +389,7 @@ void fstk_RunMacro(char const *macroName, struct MacroArgs *args)
 	size_t reptNameLen = 0;
 	struct FileStackNode const *node = macro->src;
 
-	 if (node->type == NODE_REPT) {
+	if (node->type == NODE_REPT) {
 		struct FileStackReptNode const *reptNode = (struct FileStackReptNode const *)node;
 
 		// 4294967295 = 2^32 - 1, aka UINT32_MAX
@@ -576,19 +576,7 @@ void fstk_Init(char const *mainPath, size_t maxDepth)
 	// Now that it's set up properly, register the context
 	contextStack = context;
 
-	// Check that max recursion depth won't allow overflowing node `malloc`s
-	// This assumes that the rept node is larger
-#define DEPTH_LIMIT (SIZE_MAX / sizeof(uint32_t))
-	if (maxDepth > DEPTH_LIMIT) {
-		error("Recursion depth may not be higher than %zu, defaulting to "
-		      EXPAND_AND_STR(DEFAULT_MAX_DEPTH) "\n", DEPTH_LIMIT);
-		maxRecursionDepth = DEFAULT_MAX_DEPTH;
-	} else {
-		maxRecursionDepth = maxDepth;
-	}
-	// Make sure that the default of 64 is OK, though
-	assert(DEPTH_LIMIT >= DEFAULT_MAX_DEPTH);
-#undef DEPTH_LIMIT
+	maxRecursionDepth = maxDepth;
 
 	runPreIncludeFile();
 }

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -390,7 +390,7 @@ void fstk_RunMacro(char const *macroName, struct MacroArgs *args)
 	struct FileStackNode const *node = macro->src;
 
 	 if (node->type == NODE_REPT) {
-	 	struct FileStackReptNode const *reptNode = (struct FileStackReptNode const *)node;
+		struct FileStackReptNode const *reptNode = (struct FileStackReptNode const *)node;
 
 		// 4294967295 = 2^32 - 1, aka UINT32_MAX
 		reptNameLen += reptNode->iters->size() * strlen("::REPT~4294967295");

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -308,24 +308,28 @@ struct IfStack {
 	bool reachedElseBlock; // Whether an ELSE block ran already
 };
 
+struct MmappedLexerState {
+	char *ptr; // Technically `const` during the lexer's execution
+	size_t size;
+	size_t offset;
+	bool isReferenced; // If a macro in this file requires not unmapping it
+};
+
+struct BufferedLexerState {
+	int fd;
+	size_t index; // Read index into the buffer
+	char buf[LEXER_BUF_SIZE]; // Circular buffer
+	size_t nbChars; // Number of "fresh" chars in the buffer
+};
+
 struct LexerState {
 	char const *path;
 
 	// mmap()-dependent IO state
 	bool isMmapped;
 	union {
-		struct { // If mmap()ed
-			char *ptr; // Technically `const` during the lexer's execution
-			size_t size;
-			size_t offset;
-			bool isReferenced; // If a macro in this file requires not unmapping it
-		} mmap;
-		struct { // Otherwise
-			int fd;
-			size_t index; // Read index into the buffer
-			char buf[LEXER_BUF_SIZE]; // Circular buffer
-			size_t nbChars; // Number of "fresh" chars in the buffer
-		} cbuf;
+		struct MmappedLexerState mmap; // If mmap()ed
+		struct BufferedLexerState cbuf; // Otherwise
 	};
 
 	// Common state

--- a/src/asm/macro.cpp
+++ b/src/asm/macro.cpp
@@ -1,28 +1,22 @@
 /* SPDX-License-Identifier: MIT */
 
 #include <errno.h>
+#include <new>
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <vector>
 
 #include "asm/macro.hpp"
 #include "asm/warning.hpp"
 
 #define MAXMACROARGS 99999
 
-// Your average macro invocation does not go past the tens, but some go further
-// This ensures that sane and slightly insane invocations suffer no penalties,
-// and the rest is insane and thus will assume responsibility.
-// Additionally, ~300 bytes (on x64) of memory per level of nesting has been
-// deemed reasonable. (Halve that on x86.)
-#define INITIAL_ARG_SIZE 32
 struct MacroArgs {
-	unsigned int nbArgs;
 	unsigned int shift;
-	unsigned int capacity;
-	char **args;
+	std::vector<char *> *args;
 };
 
 static struct MacroArgs *macroArgs = NULL;
@@ -43,15 +37,12 @@ struct MacroArgs *macro_NewArgs(void)
 {
 	struct MacroArgs *args = (struct MacroArgs *)malloc(sizeof(*args));
 
-	if (!args)
-		fatalerror("Unable to register macro arguments: %s\n", strerror(errno));
-	args->args = (char **)malloc(sizeof(*args->args) * INITIAL_ARG_SIZE);
-	if (!args->args)
+	if (args)
+		args->args = new(std::nothrow) std::vector<char *>();
+	if (!args || !args->args)
 		fatalerror("Unable to register macro arguments: %s\n", strerror(errno));
 
-	args->nbArgs = 0;
 	args->shift = 0;
-	args->capacity = INITIAL_ARG_SIZE;
 	return args;
 }
 
@@ -59,18 +50,9 @@ void macro_AppendArg(struct MacroArgs *args, char *s)
 {
 	if (s[0] == '\0')
 		warning(WARNING_EMPTY_MACRO_ARG, "Empty macro argument\n");
-	if (args->nbArgs == MAXMACROARGS)
+	if (args->args->size() == MAXMACROARGS)
 		error("A maximum of " EXPAND_AND_STR(MAXMACROARGS) " arguments is allowed\n");
-	if (args->nbArgs >= args->capacity) {
-		args->capacity *= 2;
-		// Check that overflow didn't roll us back
-		if (args->capacity <= args->nbArgs)
-			fatalerror("Failed to add new macro argument: capacity overflow\n");
-		args->args = (char **)realloc(args->args, sizeof(*args->args) * args->capacity);
-		if (!args->args)
-			fatalerror("Error adding new macro argument: %s\n", strerror(errno));
-	}
-	args->args[args->nbArgs++] = s;
+	args->args->push_back(s);
 }
 
 void macro_UseNewArgs(struct MacroArgs *args)
@@ -80,9 +62,9 @@ void macro_UseNewArgs(struct MacroArgs *args)
 
 void macro_FreeArgs(struct MacroArgs *args)
 {
-	for (uint32_t i = 0; i < macroArgs->nbArgs; i++)
-		free(args->args[i]);
-	free(args->args);
+	for (char *arg : *macroArgs->args)
+		free(arg);
+	delete args->args;
 }
 
 char const *macro_GetArg(uint32_t i)
@@ -92,7 +74,7 @@ char const *macro_GetArg(uint32_t i)
 
 	uint32_t realIndex = i + macroArgs->shift - 1;
 
-	return realIndex >= macroArgs->nbArgs ? NULL : macroArgs->args[realIndex];
+	return realIndex >= macroArgs->args->size() ? NULL : (*macroArgs->args)[realIndex];
 }
 
 char const *macro_GetAllArgs(void)
@@ -100,13 +82,15 @@ char const *macro_GetAllArgs(void)
 	if (!macroArgs)
 		return NULL;
 
-	if (macroArgs->shift >= macroArgs->nbArgs)
+	size_t nbArgs = macroArgs->args->size();
+
+	if (macroArgs->shift >= nbArgs)
 		return "";
 
 	size_t len = 0;
 
-	for (uint32_t i = macroArgs->shift; i < macroArgs->nbArgs; i++)
-		len += strlen(macroArgs->args[i]) + 1; // 1 for comma
+	for (uint32_t i = macroArgs->shift; i < nbArgs; i++)
+		len += strlen((*macroArgs->args)[i]) + 1; // 1 for comma
 
 	char *str = (char *)malloc(len + 1); // 1 for '\0'
 	char *ptr = str;
@@ -114,14 +98,15 @@ char const *macro_GetAllArgs(void)
 	if (!str)
 		fatalerror("Failed to allocate memory for expanding '\\#': %s\n", strerror(errno));
 
-	for (uint32_t i = macroArgs->shift; i < macroArgs->nbArgs; i++) {
-		size_t n = strlen(macroArgs->args[i]);
+	for (uint32_t i = macroArgs->shift; i < nbArgs; i++) {
+		char *arg = (*macroArgs->args)[i];
+		size_t n = strlen(arg);
 
-		memcpy(ptr, macroArgs->args[i], n);
+		memcpy(ptr, arg, n);
 		ptr += n;
 
 		// Commas go between args and after a last empty arg
-		if (i < macroArgs->nbArgs - 1 || n == 0)
+		if (i < nbArgs - 1 || n == 0)
 			*ptr++ = ','; // no space after comma
 	}
 	*ptr = '\0';
@@ -174,14 +159,12 @@ void macro_ShiftCurrentArgs(int32_t count)
 {
 	if (!macroArgs) {
 		error("Cannot shift macro arguments outside of a macro\n");
-	} else if (count > 0 && ((uint32_t)count > macroArgs->nbArgs
-		   || macroArgs->shift > macroArgs->nbArgs - count)) {
-		warning(WARNING_MACRO_SHIFT,
-			"Cannot shift macro arguments past their end\n");
-		macroArgs->shift = macroArgs->nbArgs;
+	} else if (size_t nbArgs = macroArgs->args->size();
+		   count > 0 && ((uint32_t)count > nbArgs || macroArgs->shift > nbArgs - count)) {
+		warning(WARNING_MACRO_SHIFT, "Cannot shift macro arguments past their end\n");
+		macroArgs->shift = nbArgs;
 	} else if (count < 0 && macroArgs->shift < (uint32_t)-count) {
-		warning(WARNING_MACRO_SHIFT,
-			"Cannot shift macro arguments past their beginning\n");
+		warning(WARNING_MACRO_SHIFT, "Cannot shift macro arguments past their beginning\n");
 		macroArgs->shift = 0;
 	} else {
 		macroArgs->shift += count;
@@ -190,5 +173,5 @@ void macro_ShiftCurrentArgs(int32_t count)
 
 uint32_t macro_NbArgs(void)
 {
-	return macroArgs->nbArgs - macroArgs->shift;
+	return macroArgs->args->size() - macroArgs->shift;
 }

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -457,7 +457,7 @@ static void writeFileStackNode(struct FileStackNode const *node, FILE *f)
 	putlong(node->lineNo, f);
 	putc(node->type, f);
 	if (node->type != NODE_REPT) {
-		putstring(((struct FileStackNamedNode const *)node)->name, f);
+		putstring(((struct FileStackNamedNode const *)node)->name->c_str(), f);
 	} else {
 		struct FileStackReptNode const *reptNode = (struct FileStackReptNode const *)node;
 

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -461,10 +461,10 @@ static void writeFileStackNode(struct FileStackNode const *node, FILE *f)
 	} else {
 		struct FileStackReptNode const *reptNode = (struct FileStackReptNode const *)node;
 
-		putlong(reptNode->reptDepth, f);
+		putlong(reptNode->iters->size(), f);
 		// Iters are stored by decreasing depth, so reverse the order for output
-		for (uint32_t i = reptNode->reptDepth; i--; )
-			putlong(reptNode->iters[i], f);
+		for (uint32_t i = reptNode->iters->size(); i--; )
+			putlong((*reptNode->iters)[i], f);
 	}
 }
 

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -885,7 +885,7 @@ macroargs	: %empty {
 			$$ = macro_NewArgs();
 		}
 		| macroargs T_STRING {
-			macro_AppendArg(&($$), strdup($2));
+			macro_AppendArg($$, strdup($2));
 		}
 ;
 

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -492,6 +492,15 @@ enum {
 
 %}
 
+%code requires {
+	// Only used in the %union
+	struct ForArgs {
+		int32_t start;
+		int32_t stop;
+		int32_t step;
+	};
+}
+
 %union
 {
 	char symName[MAXSYMLEN + 1];
@@ -506,11 +515,7 @@ enum {
 	struct AlignmentSpec alignSpec;
 	struct DsArgList dsArgs;
 	struct PurgeArgList purgeArgs;
-	struct {
-		int32_t start;
-		int32_t stop;
-		int32_t step;
-	} forArgs;
+	struct ForArgs forArgs;
 	struct StrFmtArgList strfmtArgs;
 	bool captureTerminated;
 }

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -416,7 +416,7 @@ void sdobj_ReadFile(struct FileStackNode const *where, FILE *file) {
 					// definition is in a floating section
 					if ((other->section && !other->section->isAddressFixed)
 					 || (symbol->section && !symbol->section->isAddressFixed)) {
-					 	sym_AddSymbol(symbol); // This will error out
+						sym_AddSymbol(symbol); // This will error out
 					} else if (other->value != symbol->value) {
 						error(where, lineNo,
 						      "Definition of \"%s\" conflicts with definition in %s (%" PRId32 " != %" PRId32 ")",

--- a/test/asm/unique-id.asm
+++ b/test/asm/unique-id.asm
@@ -1,11 +1,11 @@
 DEF warn_unique EQUS "WARN \"\\@!\""
 
 macro m
-    warn_unique
-    REPT 2
-    	warn_unique
-    ENDR
-    warn_unique
+	warn_unique
+	REPT 2
+		warn_unique
+	ENDR
+	warn_unique
 endm
 	; TODO: Ideally we'd test now as well, but it'd cause a fatal error
 	;warn_unique


### PR DESCRIPTION
- [x] `struct FileStackReptNode`
- [x] `struct FileStackNamedNode`
- [x] `struct Charmap`
- [x] `struct MacroArgs`

This is one step to restoring `-pedantic` builds.

(The other step is removing anonymous structs; see #1305.)

(The *other* other step, discovered while trying to get `-pedantic` to actually work, is removing anonymous types declared inside anonymous unions (a very specific circumstance which is nevertheless nonstandard, though only Clang complains). This PR also does that.)