### PR TITLE
Simplify `fstk_FindFile` usage

### DIFF
--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string>
 
 #include "asm/lexer.hpp"
 
@@ -52,9 +53,9 @@ void fstk_AddIncludePath(char const *s);
 void fstk_SetPreIncludeFile(char const *s);
 /*
  * @param path The user-provided file name
- * @return A pointer to the malloc'ed full path, or NULL if no path worked
+ * @return A pointer to the `new`-allocated full path, or NULL if no path worked
  */
-char *fstk_FindFile(char const *path);
+std::string *fstk_FindFile(char const *path);
 
 bool yywrap(void);
 void fstk_RunInclude(char const *path);

--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -52,12 +52,9 @@ void fstk_AddIncludePath(char const *s);
 void fstk_SetPreIncludeFile(char const *s);
 /*
  * @param path The user-provided file name
- * @param fullPath The address of a pointer, which will be made to point at the full path
- *                 The pointer's value must be a valid argument to `realloc`, including NULL
- * @param size Current size of the buffer, or 0 if the pointer is NULL
- * @return True if the file was found, false if no path worked
+ * @return A pointer to the malloc'ed full path, or NULL if no path worked
  */
-bool fstk_FindFile(char const *path, char **fullPath, size_t *size);
+char *fstk_FindFile(char const *path);
 
 bool yywrap(void);
 void fstk_RunInclude(char const *path);

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string>
 #include <string.h>
 
 #include "asm/fstack.hpp"
@@ -807,10 +808,10 @@ void sect_BinaryFile(char const *s, int32_t startPos)
 	if (!checkcodesection())
 		return;
 
-	char *fullPath = fstk_FindFile(s);
-	FILE *f = fullPath ? fopen(fullPath, "rb") : NULL;
+	std::string *fullPath = fstk_FindFile(s);
+	FILE *f = fullPath ? fopen(fullPath->c_str(), "rb") : NULL;
 
-	free(fullPath);
+	delete fullPath;
 
 	if (!f) {
 		if (generatedMissingIncludes) {
@@ -878,10 +879,10 @@ void sect_BinaryFileSlice(char const *s, int32_t start_pos, int32_t length)
 	if (!reserveSpace(length))
 		return;
 
-	char *fullPath = fstk_FindFile(s);
-	FILE *f = fullPath ? fopen(fullPath, "rb") : NULL;
+	std::string *fullPath = fstk_FindFile(s);
+	FILE *f = fullPath ? fopen(fullPath->c_str(), "rb") : NULL;
 
-	free(fullPath);
+	delete fullPath;
 
 	if (!f) {
 		if (generatedMissingIncludes) {

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -807,12 +807,9 @@ void sect_BinaryFile(char const *s, int32_t startPos)
 	if (!checkcodesection())
 		return;
 
-	char *fullPath = NULL;
-	size_t size = 0;
-	FILE *f = NULL;
+	char *fullPath = fstk_FindFile(s);
+	FILE *f = fullPath ? fopen(fullPath, "rb") : NULL;
 
-	if (fstk_FindFile(s, &fullPath, &size))
-		f = fopen(fullPath, "rb");
 	free(fullPath);
 
 	if (!f) {
@@ -881,12 +878,9 @@ void sect_BinaryFileSlice(char const *s, int32_t start_pos, int32_t length)
 	if (!reserveSpace(length))
 		return;
 
-	char *fullPath = NULL;
-	size_t size = 0;
-	FILE *f = NULL;
+	char *fullPath = fstk_FindFile(s);
+	FILE *f = fullPath ? fopen(fullPath, "rb") : NULL;
 
-	if (fstk_FindFile(s, &fullPath, &size))
-		f = fopen(fullPath, "rb");
 	free(fullPath);
 
 	if (!f) {


### PR DESCRIPTION
Every call site was doing `fstk_FindFile(NULL, &0)`, so it could be simplified.