### PR TITLE
Remove now-unnecessary `struct` keyword

### DIFF
--- a/include/asm/format.hpp
+++ b/include/asm/format.hpp
@@ -35,13 +35,13 @@ struct StrFmtArgList {
 	std::vector<std::variant<uint32_t, char *>> *args;
 };
 
-struct FormatSpec fmt_NewSpec(void);
-bool fmt_IsEmpty(struct FormatSpec const *fmt);
-bool fmt_IsValid(struct FormatSpec const *fmt);
-bool fmt_IsFinished(struct FormatSpec const *fmt);
-void fmt_UseCharacter(struct FormatSpec *fmt, int c);
-void fmt_FinishCharacters(struct FormatSpec *fmt);
-void fmt_PrintString(char *buf, size_t bufLen, struct FormatSpec const *fmt, char const *value);
-void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uint32_t value);
+FormatSpec fmt_NewSpec(void);
+bool fmt_IsEmpty(FormatSpec const *fmt);
+bool fmt_IsValid(FormatSpec const *fmt);
+bool fmt_IsFinished(FormatSpec const *fmt);
+void fmt_UseCharacter(FormatSpec *fmt, int c);
+void fmt_FinishCharacters(FormatSpec *fmt);
+void fmt_PrintString(char *buf, size_t bufLen, FormatSpec const *fmt, char const *value);
+void fmt_PrintNumber(char *buf, size_t bufLen, FormatSpec const *fmt, uint32_t value);
 
 #endif // RGBDS_FORMAT_SPEC_H

--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -16,7 +16,7 @@
 #include "linkdefs.hpp"
 
 struct FileStackNode {
-	struct FileStackNode *parent; // Pointer to parent node, for error reporting
+	FileStackNode *parent; // Pointer to parent node, for error reporting
 	// Line at which the parent context was exited; meaningless for the root level
 	uint32_t lineNo;
 
@@ -43,9 +43,9 @@ extern size_t maxRecursionDepth;
 
 struct MacroArgs;
 
-void fstk_Dump(struct FileStackNode const *node, uint32_t lineNo);
+void fstk_Dump(FileStackNode const *node, uint32_t lineNo);
 void fstk_DumpCurrent(void);
-struct FileStackNode *fstk_GetFileStack(void);
+FileStackNode *fstk_GetFileStack(void);
 // The lifetime of the returned chars is until reaching the end of that file
 char const *fstk_GetFileName(void);
 
@@ -59,7 +59,7 @@ std::string *fstk_FindFile(char const *path);
 
 bool yywrap(void);
 void fstk_RunInclude(char const *path);
-void fstk_RunMacro(char const *macroName, struct MacroArgs *args);
+void fstk_RunMacro(char const *macroName, MacroArgs *args);
 void fstk_RunRept(uint32_t count, int32_t reptLineNo, char *body, size_t size);
 void fstk_RunFor(char const *symName, int32_t start, int32_t stop, int32_t step,
 		     int32_t reptLineNo, char *body, size_t size);

--- a/include/asm/lexer.hpp
+++ b/include/asm/lexer.hpp
@@ -60,8 +60,8 @@ struct LexerState {
 	// mmap()-dependent IO state
 	bool isMmapped;
 	union {
-		struct MmappedLexerState mmap; // If mmap()ed
-		struct BufferedLexerState cbuf; // Otherwise
+		MmappedLexerState mmap; // If mmap()ed
+		BufferedLexerState cbuf; // Otherwise
 	};
 
 	// Common state
@@ -73,7 +73,7 @@ struct LexerState {
 	uint32_t colNo;
 	int lastToken;
 
-	std::deque<struct IfStackEntry> ifStack;
+	std::deque<IfStackEntry> ifStack;
 
 	bool capturing; // Whether the text being lexed should be captured
 	size_t captureSize; // Amount of text captured
@@ -84,18 +84,18 @@ struct LexerState {
 	bool disableInterpolation;
 	size_t macroArgScanDistance; // Max distance already scanned for macro args
 	bool expandStrings;
-	std::deque<struct Expansion> expansions; // Front is the innermost current expansion
+	std::deque<Expansion> expansions; // Front is the innermost current expansion
 };
 
-extern struct LexerState *lexerState;
-extern struct LexerState *lexerStateEOL;
+extern LexerState *lexerState;
+extern LexerState *lexerStateEOL;
 
-static inline void lexer_SetState(struct LexerState *state)
+static inline void lexer_SetState(LexerState *state)
 {
 	lexerState = state;
 }
 
-static inline void lexer_SetStateAtEOL(struct LexerState *state)
+static inline void lexer_SetStateAtEOL(LexerState *state)
 {
 	lexerStateEOL = state;
 }
@@ -118,11 +118,10 @@ static inline void lexer_SetGfxDigits(char const digits[4])
 }
 
 // `path` is referenced, but not held onto..!
-bool lexer_OpenFile(struct LexerState &state, char const *path);
-void lexer_OpenFileView(struct LexerState &state, char const *path, char *buf, size_t size,
-                        uint32_t lineNo);
+bool lexer_OpenFile(LexerState &state, char const *path);
+void lexer_OpenFileView(LexerState &state, char const *path, char *buf, size_t size, uint32_t lineNo);
 void lexer_RestartRept(uint32_t lineNo);
-void lexer_CleanupState(struct LexerState &state);
+void lexer_CleanupState(LexerState &state);
 void lexer_Init(void);
 void lexer_SetMode(enum LexerMode mode);
 void lexer_ToggleStringExpansion(bool enable);
@@ -147,8 +146,8 @@ uint32_t lexer_GetLineNo(void);
 uint32_t lexer_GetColNo(void);
 void lexer_DumpStringExpansions(void);
 int yylex(void);
-bool lexer_CaptureRept(struct CaptureBody *capture);
-bool lexer_CaptureMacroBody(struct CaptureBody *capture);
+bool lexer_CaptureRept(CaptureBody *capture);
+bool lexer_CaptureMacroBody(CaptureBody *capture);
 
 struct AlignmentSpec {
 	uint8_t alignment;

--- a/include/asm/macro.hpp
+++ b/include/asm/macro.hpp
@@ -12,11 +12,11 @@
 
 struct MacroArgs;
 
-struct MacroArgs *macro_GetCurrentArgs(void);
-struct MacroArgs *macro_NewArgs(void);
-void macro_AppendArg(struct MacroArgs *args, char *s);
-void macro_UseNewArgs(struct MacroArgs *args);
-void macro_FreeArgs(struct MacroArgs *args);
+MacroArgs *macro_GetCurrentArgs(void);
+MacroArgs *macro_NewArgs(void);
+void macro_AppendArg(MacroArgs *args, char *s);
+void macro_UseNewArgs(MacroArgs *args);
+void macro_FreeArgs(MacroArgs *args);
 char const *macro_GetArg(uint32_t i);
 char const *macro_GetAllArgs(void);
 

--- a/include/asm/output.hpp
+++ b/include/asm/output.hpp
@@ -12,12 +12,11 @@ struct FileStackNode;
 
 extern const char *objectName;
 
-void out_RegisterNode(struct FileStackNode *node);
-void out_ReplaceNode(struct FileStackNode *node);
+void out_RegisterNode(FileStackNode *node);
+void out_ReplaceNode(FileStackNode *node);
 void out_SetFileName(char *s);
-void out_CreatePatch(uint32_t type, struct Expression const *expr, uint32_t ofs, uint32_t pcShift);
-void out_CreateAssert(enum AssertionType type, struct Expression const *expr,
-		      char const *message, uint32_t ofs);
+void out_CreatePatch(uint32_t type, Expression const *expr, uint32_t ofs, uint32_t pcShift);
+void out_CreateAssert(enum AssertionType type, Expression const *expr, char const *message, uint32_t ofs);
 void out_WriteObject(void);
 
 #endif // RGBDS_ASM_OUTPUT_H

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -8,6 +8,8 @@
 
 #include "linkdefs.hpp"
 
+struct Symbol;
+
 struct Expression {
 	int32_t val; // If the expression's value is known, it's here
 	std::string *reason; // Why the expression is not known, if it isn't
@@ -18,41 +20,39 @@ struct Expression {
 };
 
 // Determines if an expression is known at assembly time
-static inline bool rpn_isKnown(struct Expression const *expr)
+static inline bool rpn_isKnown(Expression const *expr)
 {
 	return expr->isKnown;
 }
 
 // Determines if an expression is a symbol suitable for const diffing
-static inline bool rpn_isSymbol(const struct Expression *expr)
+static inline bool rpn_isSymbol(const Expression *expr)
 {
 	return expr->isSymbol;
 }
 
-void rpn_Symbol(struct Expression *expr, char const *symName);
-void rpn_Number(struct Expression *expr, uint32_t i);
-void rpn_LOGNOT(struct Expression *expr, const struct Expression *src);
-struct Symbol const *rpn_SymbolOf(struct Expression const *expr);
-bool rpn_IsDiffConstant(struct Expression const *src, struct Symbol const *symName);
-void rpn_BinaryOp(enum RPNCommand op, struct Expression *expr,
-		  const struct Expression *src1,
-		  const struct Expression *src2);
-void rpn_HIGH(struct Expression *expr, const struct Expression *src);
-void rpn_LOW(struct Expression *expr, const struct Expression *src);
-void rpn_ISCONST(struct Expression *expr, const struct Expression *src);
-void rpn_NEG(struct Expression *expr, const struct Expression *src);
-void rpn_NOT(struct Expression *expr, const struct Expression *src);
-void rpn_BankSymbol(struct Expression *expr, char const *symName);
-void rpn_BankSection(struct Expression *expr, char const *sectionName);
-void rpn_BankSelf(struct Expression *expr);
-void rpn_SizeOfSection(struct Expression *expr, char const *sectionName);
-void rpn_StartOfSection(struct Expression *expr, char const *sectionName);
-void rpn_SizeOfSectionType(struct Expression *expr, enum SectionType type);
-void rpn_StartOfSectionType(struct Expression *expr, enum SectionType type);
-void rpn_Free(struct Expression *expr);
-void rpn_CheckHRAM(struct Expression *expr, const struct Expression *src);
-void rpn_CheckRST(struct Expression *expr, const struct Expression *src);
-void rpn_CheckNBit(struct Expression const *expr, uint8_t n);
-int32_t rpn_GetConstVal(struct Expression const *expr);
+void rpn_Symbol(Expression *expr, char const *symName);
+void rpn_Number(Expression *expr, uint32_t i);
+void rpn_LOGNOT(Expression *expr, const Expression *src);
+Symbol const *rpn_SymbolOf(Expression const *expr);
+bool rpn_IsDiffConstant(Expression const *src, Symbol const *symName);
+void rpn_BinaryOp(enum RPNCommand op, Expression *expr, const Expression *src1, const Expression *src2);
+void rpn_HIGH(Expression *expr, const Expression *src);
+void rpn_LOW(Expression *expr, const Expression *src);
+void rpn_ISCONST(Expression *expr, const Expression *src);
+void rpn_NEG(Expression *expr, const Expression *src);
+void rpn_NOT(Expression *expr, const Expression *src);
+void rpn_BankSymbol(Expression *expr, char const *symName);
+void rpn_BankSection(Expression *expr, char const *sectionName);
+void rpn_BankSelf(Expression *expr);
+void rpn_SizeOfSection(Expression *expr, char const *sectionName);
+void rpn_StartOfSection(Expression *expr, char const *sectionName);
+void rpn_SizeOfSectionType(Expression *expr, enum SectionType type);
+void rpn_StartOfSectionType(Expression *expr, enum SectionType type);
+void rpn_Free(Expression *expr);
+void rpn_CheckHRAM(Expression *expr, const Expression *src);
+void rpn_CheckRST(Expression *expr, const Expression *src);
+void rpn_CheckNBit(Expression const *expr, uint8_t n);
+int32_t rpn_GetConstVal(Expression const *expr);
 
 #endif // RGBDS_ASM_RPN_H

--- a/include/asm/section.hpp
+++ b/include/asm/section.hpp
@@ -17,10 +17,10 @@ struct FileStackNode;
 struct Section;
 
 struct Patch {
-	struct FileStackNode const *src;
+	FileStackNode const *src;
 	uint32_t lineNo;
 	uint32_t offset;
-	struct Section *pcSection;
+	Section *pcSection;
 	uint32_t pcOffset;
 	uint8_t type;
 	std::vector<uint8_t> rpn;
@@ -30,14 +30,14 @@ struct Section {
 	char *name;
 	enum SectionType type;
 	enum SectionModifier modifier;
-	struct FileStackNode const *src; // Where the section was defined
+	FileStackNode const *src; // Where the section was defined
 	uint32_t fileLine; // Line where the section was defined
 	uint32_t size;
 	uint32_t org;
 	uint32_t bank;
 	uint8_t align; // Exactly as specified in `ALIGN[]`
 	uint16_t alignOfs;
-	std::deque<struct Patch> patches;
+	std::deque<Patch> patches;
 	std::vector<uint8_t> data;
 };
 
@@ -47,17 +47,17 @@ struct SectionSpec {
 	uint16_t alignOfs;
 };
 
-extern std::deque<struct Section> sectionList;
-extern struct Section *currentSection;
+extern std::deque<Section> sectionList;
+extern Section *currentSection;
 
-struct Section *sect_FindSectionByName(char const *name);
+Section *sect_FindSectionByName(char const *name);
 void sect_NewSection(char const *name, enum SectionType type, uint32_t org,
-		     struct SectionSpec const *attributes, enum SectionModifier mod);
+		     SectionSpec const *attributes, enum SectionModifier mod);
 void sect_SetLoadSection(char const *name, enum SectionType type, uint32_t org,
-			 struct SectionSpec const *attributes, enum SectionModifier mod);
+			 SectionSpec const *attributes, enum SectionModifier mod);
 void sect_EndLoadSection(void);
 
-struct Section *sect_GetSymbolSection(void);
+Section *sect_GetSymbolSection(void);
 uint32_t sect_GetSymbolOffset(void);
 uint32_t sect_GetOutputOffset(void);
 uint32_t sect_GetAlignBytes(uint8_t alignment, uint16_t offset);
@@ -73,11 +73,11 @@ void sect_AbsByteGroup(uint8_t const *s, size_t length);
 void sect_AbsWordGroup(uint8_t const *s, size_t length);
 void sect_AbsLongGroup(uint8_t const *s, size_t length);
 void sect_Skip(uint32_t skip, bool ds);
-void sect_RelByte(struct Expression *expr, uint32_t pcShift);
-void sect_RelBytes(uint32_t n, std::vector<struct Expression> &exprs);
-void sect_RelWord(struct Expression *expr, uint32_t pcShift);
-void sect_RelLong(struct Expression *expr, uint32_t pcShift);
-void sect_PCRelByte(struct Expression *expr, uint32_t pcShift);
+void sect_RelByte(Expression *expr, uint32_t pcShift);
+void sect_RelBytes(uint32_t n, std::vector<Expression> &exprs);
+void sect_RelWord(Expression *expr, uint32_t pcShift);
+void sect_RelLong(Expression *expr, uint32_t pcShift);
+void sect_PCRelByte(Expression *expr, uint32_t pcShift);
 void sect_BinaryFile(char const *s, int32_t startPos);
 void sect_BinaryFileSlice(char const *s, int32_t start_pos, int32_t length);
 
@@ -85,6 +85,6 @@ void sect_EndSection(void);
 void sect_PushSection(void);
 void sect_PopSection(void);
 
-bool sect_IsSizeKnown(struct Section const NONNULL(name));
+bool sect_IsSizeKnown(Section const NONNULL(name));
 
 #endif // RGBDS_SECTION_H

--- a/include/asm/symbol.hpp
+++ b/include/asm/symbol.hpp
@@ -23,7 +23,7 @@ enum SymbolType {
 	SYM_REF // Forward reference to a label
 };
 
-// Only used in an anonymous union by `struct Symbol`
+// Only used in an anonymous union by `Symbol`
 struct strValue {
 	size_t size;
 	char *value;
@@ -34,8 +34,8 @@ struct Symbol {
 	enum SymbolType type;
 	bool isExported; // Whether the symbol is to be exported
 	bool isBuiltin;  // Whether the symbol is a built-in
-	struct Section *section;
-	struct FileStackNode *src; // Where the symbol was defined
+	Section *section;
+	FileStackNode *src; // Where the symbol was defined
 	uint32_t fileLine; // Line where the symbol was defined
 
 	bool hasCallback;
@@ -44,91 +44,91 @@ struct Symbol {
 		int32_t value;
 		int32_t (*numCallback)(void); // If hasCallback
 		// For SYM_MACRO
-		struct strValue macro;
+		strValue macro;
 		// For SYM_EQUS
-		struct strValue equs;
+		strValue equs;
 		char const *(*strCallback)(void); // If hasCallback
 	};
 
 	uint32_t ID; // ID of the symbol in the object file (-1 if none)
 };
 
-bool sym_IsPC(struct Symbol const *sym);
+bool sym_IsPC(Symbol const *sym);
 
-static inline bool sym_IsDefined(struct Symbol const *sym)
+static inline bool sym_IsDefined(Symbol const *sym)
 {
 	return sym->type != SYM_REF;
 }
 
-static inline struct Section *sym_GetSection(struct Symbol const *sym)
+static inline Section *sym_GetSection(Symbol const *sym)
 {
 	return sym_IsPC(sym) ? sect_GetSymbolSection() : sym->section;
 }
 
-static inline bool sym_IsConstant(struct Symbol const *sym)
+static inline bool sym_IsConstant(Symbol const *sym)
 {
 	if (sym->type == SYM_LABEL) {
-		struct Section const *sect = sym_GetSection(sym);
+		Section const *sect = sym_GetSection(sym);
 
 		return sect && sect->org != (uint32_t)-1;
 	}
 	return sym->type == SYM_EQU || sym->type == SYM_VAR;
 }
 
-static inline bool sym_IsNumeric(struct Symbol const *sym)
+static inline bool sym_IsNumeric(Symbol const *sym)
 {
 	return sym->type == SYM_LABEL || sym->type == SYM_EQU || sym->type == SYM_VAR;
 }
 
-static inline bool sym_IsLabel(struct Symbol const *sym)
+static inline bool sym_IsLabel(Symbol const *sym)
 {
 	return sym->type == SYM_LABEL || sym->type == SYM_REF;
 }
 
-static inline bool sym_IsLocal(struct Symbol const *sym)
+static inline bool sym_IsLocal(Symbol const *sym)
 {
 	return sym_IsLabel(sym) && strchr(sym->name, '.');
 }
 
-static inline bool sym_IsExported(struct Symbol const *sym)
+static inline bool sym_IsExported(Symbol const *sym)
 {
 	return sym->isExported;
 }
 
 // Get a string equate's value
-static inline char const *sym_GetStringValue(struct Symbol const *sym)
+static inline char const *sym_GetStringValue(Symbol const *sym)
 {
 	if (sym->hasCallback)
 		return sym->strCallback();
 	return sym->equs.value;
 }
 
-void sym_ForEach(void (*func)(struct Symbol *));
+void sym_ForEach(void (*func)(Symbol *));
 
-int32_t sym_GetValue(struct Symbol const *sym);
+int32_t sym_GetValue(Symbol const *sym);
 void sym_SetExportAll(bool set);
-struct Symbol *sym_AddLocalLabel(char const *symName);
-struct Symbol *sym_AddLabel(char const *symName);
-struct Symbol *sym_AddAnonLabel(void);
+Symbol *sym_AddLocalLabel(char const *symName);
+Symbol *sym_AddLabel(char const *symName);
+Symbol *sym_AddAnonLabel(void);
 void sym_WriteAnonLabelName(char buf[MIN_NB_ELMS(MAXSYMLEN + 1)], uint32_t ofs, bool neg);
 void sym_Export(char const *symName);
-struct Symbol *sym_AddEqu(char const *symName, int32_t value);
-struct Symbol *sym_RedefEqu(char const *symName, int32_t value);
-struct Symbol *sym_AddVar(char const *symName, int32_t value);
+Symbol *sym_AddEqu(char const *symName, int32_t value);
+Symbol *sym_RedefEqu(char const *symName, int32_t value);
+Symbol *sym_AddVar(char const *symName, int32_t value);
 uint32_t sym_GetPCValue(void);
-uint32_t sym_GetConstantSymValue(struct Symbol const *sym);
+uint32_t sym_GetConstantSymValue(Symbol const *sym);
 uint32_t sym_GetConstantValue(char const *symName);
 // Find a symbol by exact name, bypassing expansion checks
-struct Symbol *sym_FindExactSymbol(char const *symName);
+Symbol *sym_FindExactSymbol(char const *symName);
 // Find a symbol, possibly scoped, by name
-struct Symbol *sym_FindScopedSymbol(char const *symName);
+Symbol *sym_FindScopedSymbol(char const *symName);
 // Find a scoped symbol by name; do not return `@` or `_NARG` when they have no value
-struct Symbol *sym_FindScopedValidSymbol(char const *symName);
-struct Symbol const *sym_GetPC(void);
-struct Symbol *sym_AddMacro(char const *symName, int32_t defLineNo, char *body, size_t size);
-struct Symbol *sym_Ref(char const *symName);
-struct Symbol *sym_AddString(char const *symName, char const *value);
-struct Symbol *sym_RedefString(char const *symName, char const *value);
+Symbol *sym_FindScopedValidSymbol(char const *symName);
+Symbol const *sym_GetPC(void);
+Symbol *sym_AddMacro(char const *symName, int32_t defLineNo, char *body, size_t size);
+Symbol *sym_Ref(char const *symName);
+Symbol *sym_AddString(char const *symName, char const *value);
+Symbol *sym_RedefString(char const *symName, char const *value);
 void sym_Purge(std::string const &symName);
 void sym_Init(time_t now);
 

--- a/include/extern/getopt.hpp
+++ b/include/extern/getopt.hpp
@@ -18,7 +18,7 @@ struct option {
 };
 
 int musl_getopt_long_only(int argc, char **argv, char const *optstring,
-			  const struct option *longopts, int *idx);
+			  const option *longopts, int *idx);
 
 #define no_argument        0
 #define required_argument  1

--- a/include/link/main.hpp
+++ b/include/link/main.hpp
@@ -31,7 +31,7 @@ extern bool isWRAM0Mode;
 extern bool disablePadding;
 
 struct FileStackNode {
-	struct FileStackNode *parent;
+	FileStackNode *parent;
 	// Line at which the parent context was exited; meaningless for the root level
 	uint32_t lineNo;
 
@@ -60,15 +60,12 @@ struct FileStackNode {
  * Dump a file stack to stderr
  * @param node The leaf node to dump the context of
  */
-std::string const *dumpFileStack(struct FileStackNode const *node);
+std::string const *dumpFileStack(FileStackNode const *node);
 
-void warning(struct FileStackNode const *where, uint32_t lineNo,
-	     char const *fmt, ...) format_(printf, 3, 4);
+void warning(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) format_(printf, 3, 4);
 
-void error(struct FileStackNode const *where, uint32_t lineNo,
-	   char const *fmt, ...) format_(printf, 3, 4);
+void error(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) format_(printf, 3, 4);
 
-[[noreturn]] void fatal(struct FileStackNode const *where, uint32_t lineNo,
-		     char const *fmt, ...) format_(printf, 3, 4);
+[[noreturn]] void fatal(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) format_(printf, 3, 4);
 
 #endif // RGBDS_LINK_MAIN_H

--- a/include/link/output.hpp
+++ b/include/link/output.hpp
@@ -12,14 +12,14 @@
  * Registers a section for output.
  * @param section The section to add
  */
-void out_AddSection(struct Section const *section);
+void out_AddSection(Section const *section);
 
 /*
  * Finds an assigned section overlapping another one.
  * @param section The section that is being overlapped
  * @return A section overlapping it
  */
-struct Section const *out_OverlappingSection(struct Section const *section);
+Section const *out_OverlappingSection(Section const *section);
 
 /*
  * Writes all output (bin, sym, map) files.

--- a/include/link/patch.hpp
+++ b/include/link/patch.hpp
@@ -13,17 +13,17 @@
 #include "linkdefs.hpp"
 
 struct Assertion {
-	struct Patch patch; // Also used for its `.type`
+	Patch patch; // Also used for its `.type`
 	std::string message;
 	// This would be redundant with `.section->fileSymbols`... but `section` is sometimes NULL!
-	std::vector<struct Symbol> *fileSymbols;
+	std::vector<Symbol> *fileSymbols;
 };
 
 /*
  * Checks all assertions
  * @return true if assertion failed
  */
-void patch_CheckAssertions(std::deque<struct Assertion> &assertions);
+void patch_CheckAssertions(std::deque<Assertion> &assertions);
 
 /*
  * Applies all SECTIONs' patches to them

--- a/include/link/sdas_obj.hpp
+++ b/include/link/sdas_obj.hpp
@@ -10,6 +10,6 @@
 struct FileStackNode;
 struct Symbol;
 
-void sdobj_ReadFile(struct FileStackNode const *fileName, FILE *file, std::vector<struct Symbol> &fileSymbols);
+void sdobj_ReadFile(FileStackNode const *fileName, FILE *file, std::vector<Symbol> &fileSymbols);
 
 #endif // RGBDS_LINK_SDAS_OBJ_H

--- a/include/link/section.hpp
+++ b/include/link/section.hpp
@@ -16,12 +16,13 @@
 
 struct FileStackNode;
 struct Section;
+struct Symbol;
 
 struct Patch {
-	struct FileStackNode const *src;
+	FileStackNode const *src;
 	uint32_t lineNo;
 	uint32_t offset;
-	struct Section const *pcSection;
+	Section const *pcSection;
 	uint32_t pcSectionID;
 	uint32_t pcOffset;
 	enum PatchType type;
@@ -45,11 +46,11 @@ struct Section {
 	uint16_t alignMask;
 	uint16_t alignOfs;
 	std::vector<uint8_t> data; // Array of size `size`, or 0 if `type` does not have data
-	std::vector<struct Patch> patches;
+	std::vector<Patch> patches;
 	// Extra info computed during linking
-	std::vector<struct Symbol> *fileSymbols;
-	std::vector<struct Symbol *> symbols;
-	struct Section *nextu; // The next "component" of this unionized sect
+	std::vector<Symbol> *fileSymbols;
+	std::vector<Symbol *> symbols;
+	Section *nextu; // The next "component" of this unionized sect
 };
 
 /*
@@ -57,20 +58,20 @@ struct Section {
  * This is to avoid exposing the data structure in which sections are stored.
  * @param callback The function to call for each structure.
  */
-void sect_ForEach(void (*callback)(struct Section *));
+void sect_ForEach(void (*callback)(Section *));
 
 /*
  * Registers a section to be processed.
  * @param section The section to register.
  */
-void sect_AddSection(struct Section *section);
+void sect_AddSection(Section *section);
 
 /*
  * Finds a section by its name.
  * @param name The name of the section to look for
  * @return A pointer to the section, or NULL if it wasn't found
  */
-struct Section *sect_GetSection(std::string const &name);
+Section *sect_GetSection(std::string const &name);
 
 /*
  * Checks if all sections meet reasonable criteria, such as max size

--- a/include/link/symbol.hpp
+++ b/include/link/symbol.hpp
@@ -12,13 +12,14 @@
 #include "linkdefs.hpp"
 
 struct FileStackNode;
+struct Section;
 
 struct Symbol {
 	// Info contained in the object files
 	std::string name;
 	enum ExportLevel type;
 	char const *objFileName;
-	struct FileStackNode const *src;
+	FileStackNode const *src;
 	int32_t lineNo;
 	int32_t sectionID;
 	union {
@@ -27,16 +28,16 @@ struct Symbol {
 		int32_t value;
 	};
 	// Extra info computed during linking
-	struct Section *section;
+	Section *section;
 };
 
-void sym_AddSymbol(struct Symbol *symbol);
+void sym_AddSymbol(Symbol *symbol);
 
 /*
  * Finds a symbol in all the defined symbols.
  * @param name The name of the symbol to look for
  * @return A pointer to the symbol, or NULL if not found.
  */
-struct Symbol *sym_GetSymbol(std::string const &name);
+Symbol *sym_GetSymbol(std::string const &name);
 
 #endif // RGBDS_LINK_SYMBOL_H

--- a/src/asm/charmap.cpp
+++ b/src/asm/charmap.cpp
@@ -30,17 +30,17 @@ struct CharmapNode {
 
 struct Charmap {
 	std::string name;
-	std::vector<struct CharmapNode> nodes; // first node is reserved for the root node
+	std::vector<CharmapNode> nodes; // first node is reserved for the root node
 };
 
-static std::map<std::string, struct Charmap> charmaps;
+static std::map<std::string, Charmap> charmaps;
 
-static struct Charmap *currentCharmap;
-std::stack<struct Charmap *> charmapStack;
+static Charmap *currentCharmap;
+std::stack<Charmap *> charmapStack;
 
 void charmap_New(char const *name, char const *baseName)
 {
-	struct Charmap *base = NULL;
+	Charmap *base = NULL;
 
 	if (baseName != NULL) {
 		auto search = charmaps.find(baseName);
@@ -57,7 +57,7 @@ void charmap_New(char const *name, char const *baseName)
 	}
 
 	// Init the new charmap's fields
-	struct Charmap &charmap = charmaps[name];
+	Charmap &charmap = charmaps[name];
 
 	if (base)
 		charmap.nodes = base->nodes; // Copies `base->nodes`
@@ -96,7 +96,7 @@ void charmap_Pop(void)
 
 void charmap_Add(char *mapping, uint8_t value)
 {
-	struct Charmap &charmap = *currentCharmap;
+	Charmap &charmap = *currentCharmap;
 	size_t nodeIdx = 0;
 
 	for (; *mapping; mapping++) {
@@ -115,7 +115,7 @@ void charmap_Add(char *mapping, uint8_t value)
 		nodeIdx = nextIdx;
 	}
 
-	struct CharmapNode &node = charmap.nodes[nodeIdx];
+	CharmapNode &node = charmap.nodes[nodeIdx];
 
 	if (node.isTerminal)
 		warning(WARNING_CHARMAP_REDEF, "Overriding charmap mapping\n");
@@ -126,7 +126,7 @@ void charmap_Add(char *mapping, uint8_t value)
 
 bool charmap_HasChar(char const *input)
 {
-	struct Charmap const &charmap = *currentCharmap;
+	Charmap const &charmap = *currentCharmap;
 	size_t nodeIdx = 0;
 
 	for (; *input; input++) {
@@ -151,7 +151,7 @@ size_t charmap_ConvertNext(char const **input, std::vector<uint8_t> *output)
 	// For that, advance through the trie with each character read.
 	// If that would lead to a dead end, rewind characters until the last match, and output.
 	// If no match, read a UTF-8 codepoint and output that.
-	struct Charmap const &charmap = *currentCharmap;
+	Charmap const &charmap = *currentCharmap;
 	size_t matchIdx = 0;
 	size_t rewindDistance = 0;
 

--- a/src/asm/format.cpp
+++ b/src/asm/format.cpp
@@ -12,29 +12,29 @@
 #include "asm/format.hpp"
 #include "asm/warning.hpp"
 
-struct FormatSpec fmt_NewSpec(void)
+FormatSpec fmt_NewSpec(void)
 {
-	struct FormatSpec fmt = {};
+	FormatSpec fmt = {};
 
 	return fmt;
 }
 
-bool fmt_IsEmpty(struct FormatSpec const *fmt)
+bool fmt_IsEmpty(FormatSpec const *fmt)
 {
 	return !fmt->state;
 }
 
-bool fmt_IsValid(struct FormatSpec const *fmt)
+bool fmt_IsValid(FormatSpec const *fmt)
 {
 	return fmt->valid || fmt->state == FORMAT_DONE;
 }
 
-bool fmt_IsFinished(struct FormatSpec const *fmt)
+bool fmt_IsFinished(FormatSpec const *fmt)
 {
 	return fmt->state >= FORMAT_DONE;
 }
 
-void fmt_UseCharacter(struct FormatSpec *fmt, int c)
+void fmt_UseCharacter(FormatSpec *fmt, int c)
 {
 	if (fmt->state == FORMAT_INVALID)
 		return;
@@ -121,13 +121,13 @@ invalid:
 	}
 }
 
-void fmt_FinishCharacters(struct FormatSpec *fmt)
+void fmt_FinishCharacters(FormatSpec *fmt)
 {
 	if (!fmt_IsValid(fmt))
 		fmt->state = FORMAT_INVALID;
 }
 
-void fmt_PrintString(char *buf, size_t bufLen, struct FormatSpec const *fmt, char const *value)
+void fmt_PrintString(char *buf, size_t bufLen, FormatSpec const *fmt, char const *value)
 {
 	if (fmt->sign)
 		error("Formatting string with sign flag '%c'\n", fmt->sign);
@@ -166,7 +166,7 @@ void fmt_PrintString(char *buf, size_t bufLen, struct FormatSpec const *fmt, cha
 	buf[totalLen] = '\0';
 }
 
-void fmt_PrintNumber(char *buf, size_t bufLen, struct FormatSpec const *fmt, uint32_t value)
+void fmt_PrintNumber(char *buf, size_t bufLen, FormatSpec const *fmt, uint32_t value)
 {
 	if (fmt->type != 'X' && fmt->type != 'x' && fmt->type != 'b' && fmt->type != 'o'
 	    && fmt->prefix)

--- a/src/asm/macro.cpp
+++ b/src/asm/macro.cpp
@@ -18,7 +18,7 @@ struct MacroArgs {
 	std::vector<char *> args;
 };
 
-static struct MacroArgs *macroArgs = NULL;
+static MacroArgs *macroArgs = NULL;
 static uint32_t uniqueID = 0;
 static uint32_t maxUniqueID = 0;
 // The initialization is somewhat harmful, since it is never used, but it
@@ -27,14 +27,14 @@ static uint32_t maxUniqueID = 0;
 static char uniqueIDBuf[] = "_u4294967295"; // UINT32_MAX
 static char *uniqueIDPtr = NULL;
 
-struct MacroArgs *macro_GetCurrentArgs(void)
+MacroArgs *macro_GetCurrentArgs(void)
 {
 	return macroArgs;
 }
 
-struct MacroArgs *macro_NewArgs(void)
+MacroArgs *macro_NewArgs(void)
 {
-	struct MacroArgs *args = new(std::nothrow) struct MacroArgs();
+	MacroArgs *args = new(std::nothrow) MacroArgs();
 
 	if (!args)
 		fatalerror("Unable to register macro arguments: %s\n", strerror(errno));
@@ -43,7 +43,7 @@ struct MacroArgs *macro_NewArgs(void)
 	return args;
 }
 
-void macro_AppendArg(struct MacroArgs *args, char *s)
+void macro_AppendArg(MacroArgs *args, char *s)
 {
 	if (s[0] == '\0')
 		warning(WARNING_EMPTY_MACRO_ARG, "Empty macro argument\n");
@@ -52,12 +52,12 @@ void macro_AppendArg(struct MacroArgs *args, char *s)
 	args->args.push_back(s);
 }
 
-void macro_UseNewArgs(struct MacroArgs *args)
+void macro_UseNewArgs(MacroArgs *args)
 {
 	macroArgs = args;
 }
 
-void macro_FreeArgs(struct MacroArgs *args)
+void macro_FreeArgs(MacroArgs *args)
 {
 	for (char *arg : args->args)
 		free(arg);

--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -97,7 +97,7 @@ static int depType; // Variants of `-M`
 // except if it doesn't create any ambiguity (`verbose` versus `version`).
 // This is because long opt matching, even to a single char, is prioritized
 // over short opt matching
-static struct option const longopts[] = {
+static option const longopts[] = {
 	{ "binary-digits",    required_argument, NULL,     'b' },
 	{ "define",           required_argument, NULL,     'D' },
 	{ "export-all",       no_argument,       NULL,     'E' },

--- a/src/asm/opt.cpp
+++ b/src/asm/opt.cpp
@@ -31,7 +31,7 @@ struct OptStackEntry {
 	enum WarningState warningStates[numWarningStates];
 };
 
-static std::stack<struct OptStackEntry> stack;
+static std::stack<OptStackEntry> stack;
 
 void opt_B(char const chars[2])
 {
@@ -241,7 +241,7 @@ void opt_Parse(char *s)
 
 void opt_Push(void)
 {
-	struct OptStackEntry entry;
+	OptStackEntry entry;
 
 	// Both of these are pulled from lexer.hpp
 	entry.binary[0] = binDigits[0];
@@ -280,7 +280,7 @@ void opt_Pop(void)
 		return;
 	}
 
-	struct OptStackEntry entry = stack.top();
+	OptStackEntry entry = stack.top();
 	stack.pop();
 
 	opt_B(entry.binary);

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -31,7 +31,7 @@
 #include "linkdefs.hpp"
 #include "platform.hpp" // strncasecmp, strdup
 
-static struct CaptureBody captureBody; // Captures a REPT/FOR or MACRO
+static CaptureBody captureBody; // Captures a REPT/FOR or MACRO
 
 static void upperstring(char *dest, char const *src)
 {
@@ -256,7 +256,7 @@ static void strrpl(char *dest, size_t destLen, char const *src, char const *old,
 	dest[i] = '\0';
 }
 
-static void initStrFmtArgList(struct StrFmtArgList *args)
+static void initStrFmtArgList(StrFmtArgList *args)
 {
 	args->args = new(std::nothrow) std::vector<std::variant<uint32_t, char *>>();
 	if (!args->args)
@@ -264,7 +264,7 @@ static void initStrFmtArgList(struct StrFmtArgList *args)
 			   strerror(errno));
 }
 
-static void freeStrFmtArgList(struct StrFmtArgList *args)
+static void freeStrFmtArgList(StrFmtArgList *args)
 {
 	free(args->format);
 	for (std::variant<uint32_t, char *> &arg : *args->args) {
@@ -297,7 +297,7 @@ static void strfmt(char *dest, size_t destLen, char const *fmt,
 			continue;
 		}
 
-		struct FormatSpec spec = fmt_NewSpec();
+		FormatSpec spec = fmt_NewSpec();
 
 		while (c != '\0') {
 			fmt_UseCharacter(&spec, c);
@@ -347,7 +347,7 @@ static void strfmt(char *dest, size_t destLen, char const *fmt,
 }
 
 static void compoundAssignment(const char *symName, enum RPNCommand op, int32_t constValue) {
-	struct Expression oldExpr, constExpr, newExpr;
+	Expression oldExpr, constExpr, newExpr;
 	int32_t newValue;
 
 	rpn_Symbol(&oldExpr, symName);
@@ -357,9 +357,9 @@ static void compoundAssignment(const char *symName, enum RPNCommand op, int32_t 
 	sym_AddVar(symName, newValue);
 }
 
-static void initDsArgList(std::vector<struct Expression> *&args)
+static void initDsArgList(std::vector<Expression> *&args)
 {
-	args = new(std::nothrow) std::vector<struct Expression>();
+	args = new(std::nothrow) std::vector<Expression>();
 	if (!args)
 		fatalerror("Failed to allocate memory for ds arg list: %s\n", strerror(errno));
 }
@@ -455,18 +455,18 @@ enum {
 {
 	char symName[MAXSYMLEN + 1];
 	char string[MAXSTRLEN + 1];
-	struct Expression expr;
+	Expression expr;
 	int32_t constValue;
 	enum RPNCommand compoundEqual;
 	enum SectionModifier sectMod;
-	struct SectionSpec sectSpec;
-	struct MacroArgs *macroArg;
+	SectionSpec sectSpec;
+	MacroArgs *macroArg;
 	enum AssertionType assertType;
-	struct AlignmentSpec alignSpec;
-	std::vector<struct Expression> *dsArgs;
+	AlignmentSpec alignSpec;
+	std::vector<Expression> *dsArgs;
 	std::vector<std::string> *purgeArgs;
-	struct ForArgs forArgs;
-	struct StrFmtArgList strfmtArgs;
+	ForArgs forArgs;
+	StrFmtArgList strfmtArgs;
 	bool captureTerminated;
 }
 
@@ -704,7 +704,7 @@ line		: plain_directive endofline
 			lexer_SetMode(LEXER_NORMAL);
 			lexer_ToggleStringExpansion(true);
 		} endofline {
-			struct Symbol *macro = sym_FindExactSymbol($1);
+			Symbol *macro = sym_FindExactSymbol($1);
 
 			if (macro && macro->type == SYM_MACRO)
 				fprintf(stderr,
@@ -1649,11 +1649,11 @@ string		: T_STRING
 			freeStrFmtArgList(&$3);
 		}
 		| T_POP_SECTION T_LPAREN scoped_anon_id T_RPAREN {
-			struct Symbol *sym = sym_FindScopedValidSymbol($3);
+			Symbol *sym = sym_FindScopedValidSymbol($3);
 
 			if (!sym)
 				fatalerror("Unknown symbol \"%s\"\n", $3);
-			struct Section const *section = sym_GetSection(sym);
+			Section const *section = sym_GetSection(sym);
 
 			if (!section)
 				fatalerror("\"%s\" does not belong to any section\n", sym->name);

--- a/src/extern/getopt.cpp
+++ b/src/extern/getopt.cpp
@@ -120,10 +120,10 @@ static void permute(char **argv, int dest, int src)
 }
 
 static int musl_getopt_long_core(int argc, char **argv, char const *optstring,
-				 const struct option *longopts, int *idx, int longonly);
+				 const option *longopts, int *idx, int longonly);
 
 static int musl_getopt_long(int argc, char **argv, char const *optstring,
-			    const struct option *longopts, int *idx, int longonly)
+			    const option *longopts, int *idx, int longonly)
 {
 	int ret, skipped, resumed;
 
@@ -160,7 +160,7 @@ static int musl_getopt_long(int argc, char **argv, char const *optstring,
 }
 
 static int musl_getopt_long_core(int argc, char **argv, char const *optstring,
-				 const struct option *longopts, int *idx, int longonly)
+				 const option *longopts, int *idx, int longonly)
 {
 	musl_optarg = 0;
 	if (longopts && argv[musl_optind][0] == '-' &&
@@ -260,7 +260,7 @@ static int musl_getopt_long_core(int argc, char **argv, char const *optstring,
 }
 
 int musl_getopt_long_only(int argc, char **argv, char const *optstring,
-			  const struct option *longopts, int *idx)
+			  const option *longopts, int *idx)
 {
 	return musl_getopt_long(argc, argv, optstring, longopts, idx, 1);
 }

--- a/src/fix/main.cpp
+++ b/src/fix/main.cpp
@@ -36,7 +36,7 @@ static const char *optstring = "Ccf:i:jk:l:m:n:Op:r:st:Vv";
  * This is because long opt matching, even to a single char, is prioritized
  * over short opt matching
  */
-static struct option const longopts[] = {
+static option const longopts[] = {
 	{ "color-only",       no_argument,       NULL, 'C' },
 	{ "color-compatible", no_argument,       NULL, 'c' },
 	{ "fix-spec",         required_argument, NULL, 'f' },

--- a/src/gfx/main.cpp
+++ b/src/gfx/main.cpp
@@ -110,7 +110,7 @@ static char const *optstring = "-Aa:b:Cc:Dd:FfhL:mN:n:Oo:Pp:Qq:r:s:Tt:U:uVvx:Z";
  * This is because long opt matching, even to a single char, is prioritized
  * over short opt matching
  */
-static struct option const longopts[] = {
+static option const longopts[] = {
     {"auto-attr-map",      no_argument,       NULL, 'A'},
     {"output-attr-map",    no_argument,       NULL, -'A'}, // Deprecated
     {"attr-map",           required_argument, NULL, 'a'},

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -72,7 +72,7 @@ std::string const &FileStackNode::name() const {
 }
 
 // Helper function to dump a file stack to stderr
-std::string const *dumpFileStack(struct FileStackNode const *node)
+std::string const *dumpFileStack(FileStackNode const *node)
 {
 	std::string const *lastName;
 
@@ -96,7 +96,7 @@ std::string const *dumpFileStack(struct FileStackNode const *node)
 }
 
 void printDiag(char const *fmt, va_list args, char const *type,
-	       struct FileStackNode const *where, uint32_t lineNo)
+	       FileStackNode const *where, uint32_t lineNo)
 {
 	fputs(type, stderr);
 	fputs(": ", stderr);
@@ -108,7 +108,7 @@ void printDiag(char const *fmt, va_list args, char const *type,
 	putc('\n', stderr);
 }
 
-void warning(struct FileStackNode const *where, uint32_t lineNo, char const *fmt, ...)
+void warning(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...)
 {
 	va_list args;
 
@@ -117,7 +117,7 @@ void warning(struct FileStackNode const *where, uint32_t lineNo, char const *fmt
 	va_end(args);
 }
 
-void error(struct FileStackNode const *where, uint32_t lineNo, char const *fmt, ...)
+void error(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...)
 {
 	va_list args;
 
@@ -143,7 +143,7 @@ void argErr(char flag, char const *fmt, ...)
 		nbErrors++;
 }
 
-[[noreturn]] void fatal(struct FileStackNode const *where, uint32_t lineNo, char const *fmt, ...)
+[[noreturn]] void fatal(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...)
 {
 	va_list args;
 
@@ -172,7 +172,7 @@ static const char *optstring = "dl:m:Mn:O:o:p:S:s:tVvWwx";
  * This is because long opt matching, even to a single char, is prioritized
  * over short opt matching
  */
-static struct option const longopts[] = {
+static option const longopts[] = {
 	{ "dmg",           no_argument,       NULL, 'd' },
 	{ "linkerscript",  required_argument, NULL, 'l' },
 	{ "map",           required_argument, NULL, 'm' },

--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -13,15 +13,15 @@
 #include "error.hpp"
 #include "linkdefs.hpp"
 
-std::map<std::string, struct Section *> sections;
+std::map<std::string, Section *> sections;
 
-void sect_ForEach(void (*callback)(struct Section *))
+void sect_ForEach(void (*callback)(Section *))
 {
 	for (auto &it : sections)
 		callback(it.second);
 }
 
-static void checkSectUnionCompat(struct Section *target, struct Section *other)
+static void checkSectUnionCompat(Section *target, Section *other)
 {
 	if (other->isAddressFixed) {
 		if (target->isAddressFixed) {
@@ -59,7 +59,7 @@ static void checkSectUnionCompat(struct Section *target, struct Section *other)
 	}
 }
 
-static void checkFragmentCompat(struct Section *target, struct Section *other)
+static void checkFragmentCompat(Section *target, Section *other)
 {
 	if (other->isAddressFixed) {
 		uint16_t org = other->org - target->size;
@@ -107,7 +107,7 @@ static void checkFragmentCompat(struct Section *target, struct Section *other)
 	}
 }
 
-static void mergeSections(struct Section *target, struct Section *other, enum SectionModifier mod)
+static void mergeSections(Section *target, Section *other, enum SectionModifier mod)
 {
 	// Common checks
 
@@ -144,7 +144,7 @@ static void mergeSections(struct Section *target, struct Section *other, enum Se
 		if (!other->data.empty()) {
 			target->data.insert(target->data.end(), RANGE(other->data));
 			// Adjust patches' PC offsets
-			for (struct Patch &patch : other->patches)
+			for (Patch &patch : other->patches)
 				patch.pcOffset += other->offset;
 		} else if (!target->data.empty()) {
 			assert(other->size == 0);
@@ -159,10 +159,10 @@ static void mergeSections(struct Section *target, struct Section *other, enum Se
 	target->nextu = other;
 }
 
-void sect_AddSection(struct Section *section)
+void sect_AddSection(Section *section)
 {
 	// Check if the section already exists
-	if (struct Section *other = sect_GetSection(section->name); other) {
+	if (Section *other = sect_GetSection(section->name); other) {
 		if (section->modifier != other->modifier)
 			errx("Section \"%s\" defined as %s and %s", section->name.c_str(),
 			     sectionModNames[section->modifier], sectionModNames[other->modifier]);
@@ -179,13 +179,13 @@ void sect_AddSection(struct Section *section)
 	}
 }
 
-struct Section *sect_GetSection(std::string const &name)
+Section *sect_GetSection(std::string const &name)
 {
 	auto search = sections.find(name);
 	return search != sections.end() ? search->second : NULL;
 }
 
-static void doSanityChecks(struct Section *section)
+static void doSanityChecks(Section *section)
 {
 	// Sanity check the section's type
 	if (section->type < 0 || section->type >= SECTTYPE_INVALID) {

--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -11,12 +11,12 @@
 
 #include "error.hpp"
 
-std::map<std::string, struct Symbol *> symbols;
+std::map<std::string, Symbol *> symbols;
 
-void sym_AddSymbol(struct Symbol *symbol)
+void sym_AddSymbol(Symbol *symbol)
 {
 	// Check if the symbol already exists
-	if (struct Symbol *other = sym_GetSymbol(symbol->name); other) {
+	if (Symbol *other = sym_GetSymbol(symbol->name); other) {
 		fprintf(stderr, "error: \"%s\" both in %s from ", symbol->name.c_str(), symbol->objFileName);
 		dumpFileStack(symbol->src);
 		fprintf(stderr, "(%" PRIu32 ") and in %s from ", symbol->lineNo, other->objFileName);
@@ -29,7 +29,7 @@ void sym_AddSymbol(struct Symbol *symbol)
 	symbols[symbol->name] = symbol;
 }
 
-struct Symbol *sym_GetSymbol(std::string const &name)
+Symbol *sym_GetSymbol(std::string const &name)
 {
 	auto search = symbols.find(name);
 	return search != symbols.end() ? search->second : NULL;

--- a/src/linkdefs.cpp
+++ b/src/linkdefs.cpp
@@ -7,7 +7,7 @@ using namespace std::literals;
 
 // The default values are the most lax, as they are used as-is by RGBASM; only RGBLINK has the full info,
 // so RGBASM's job is only to catch unconditional errors earlier.
-struct SectionTypeInfo sectionTypeInfo[SECTTYPE_INVALID] = {
+SectionTypeInfo sectionTypeInfo[SECTTYPE_INVALID] = {
 	{ // SECTTYPE_WRAM0
 		.name = "WRAM0"s,
 		.startAddr = 0xC000,

--- a/test/gfx/randtilegen.cpp
+++ b/test/gfx/randtilegen.cpp
@@ -56,7 +56,7 @@ static unsigned long long getRandomBits(unsigned count) {
 	return result;
 }
 
-static void generate_tile_attributes(struct Attributes * restrict attributes) {
+static void generate_tile_attributes(Attributes * restrict attributes) {
 	/*
 	 * Images have ten colors, grouped into two groups of 5 colors. The palette index indicates two
 	 * things: which one of those groups will be used, and which colors out of those 5 will be used
@@ -162,8 +162,8 @@ static uint8_t _5to8(uint8_t five) {
 
 // Can't mark as `const`, as the array type is otherwise not compatible (augh)
 static void write_image(char const *filename, uint16_t /* const */ palettes[MIN_NB_ELMS(60)][4],
-                        unsigned char /* const */ (*tileData)[8][8],
-                        struct Attributes const *attributes, uint8_t width, uint8_t height) {
+                        unsigned char /* const */ (*tileData)[8][8], Attributes const *attributes,
+                        uint8_t width, uint8_t height) {
 	uint8_t const nbTiles = width * height;
 	png_structp png = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 	png_infop pngInfo = png_create_info_struct(png);
@@ -224,7 +224,7 @@ static void write_image(char const *filename, uint16_t /* const */ palettes[MIN_
 static void generate_random_image(char const *filename) {
 #define MIN_TILES_PER_SIDE 3
 #define MAX_TILES          ((MIN_TILES_PER_SIDE + 7) * (MIN_TILES_PER_SIDE + 7))
-	struct Attributes attributes[MAX_TILES];
+	Attributes attributes[MAX_TILES];
 	unsigned char tileData[MAX_TILES][8][8];
 	uint8_t width = getRandomBits(3) + MIN_TILES_PER_SIDE,
 	        height = getRandomBits(3) + MIN_TILES_PER_SIDE;


### PR DESCRIPTION
C++ acts like structs are `typedef`ed by default

We do have to keep `struct stat`, since there's ambiguity with the function also called `stat`.