### PR TITLE
Use `std::deque` for free space

### DIFF
--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -470,7 +470,6 @@ int main(int argc, char *argv[])
 		reportErrors();
 	assign_AssignSections();
 	obj_CheckAssertions();
-	assign_Cleanup();
 
 	// and finally output the result.
 	patch_ApplyPatches();


### PR DESCRIPTION
This was a very annoying `struct` to refactor -- it was being (ab)used for two different purposes, as the node in a doubly-linked list, but also as a vector entry for that node (with only the `.next` field actually initialized).