### PR TITLE
Use `std::string_view` for macro bodies

### DIFF
--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -61,9 +61,9 @@ std::string *fstk_FindFile(char const *path);
 bool yywrap();
 void fstk_RunInclude(char const *path);
 void fstk_RunMacro(char const *macroName, MacroArgs *args);
-void fstk_RunRept(uint32_t count, int32_t reptLineNo, char *body, size_t size);
+void fstk_RunRept(uint32_t count, int32_t reptLineNo, char const *body, size_t size);
 void fstk_RunFor(char const *symName, int32_t start, int32_t stop, int32_t step,
-		     int32_t reptLineNo, char *body, size_t size);
+		     int32_t reptLineNo, char const *body, size_t size);
 void fstk_StopRept();
 bool fstk_Break();
 

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -14,11 +14,6 @@
 # include <strings.h>
 #endif
 
-// MSVC has deprecated strdup in favor of _strdup
-#ifdef _MSC_VER
-# define strdup _strdup
-#endif
-
 // MSVC prefixes the names of S_* macros with underscores,
 // and doesn't define any S_IS* macros; define them ourselves
 #ifdef _MSC_VER

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -396,14 +396,14 @@ void fstk_RunMacro(char const *macroName, MacroArgs *args)
 
 	Context &context = newContext(fileInfo);
 
-	lexer_OpenFileView(context.lexerState, "MACRO", macro->macro.value, macro->macro.size,
+	lexer_OpenFileView(context.lexerState, "MACRO", macro->macro->data(), macro->macro->size(),
 	                   macro->fileLine);
 	lexer_SetStateAtEOL(&context.lexerState);
 	context.uniqueID = macro_UseNewUniqueID();
 	macro_UseNewArgs(args);
 }
 
-static bool newReptContext(int32_t reptLineNo, char *body, size_t size)
+static bool newReptContext(int32_t reptLineNo, char const *body, size_t size)
 {
 	uint32_t reptDepth = contextStack.top().fileInfo->type == NODE_REPT
 				? contextStack.top().fileInfo->iters().size()
@@ -432,7 +432,7 @@ static bool newReptContext(int32_t reptLineNo, char *body, size_t size)
 	return true;
 }
 
-void fstk_RunRept(uint32_t count, int32_t reptLineNo, char *body, size_t size)
+void fstk_RunRept(uint32_t count, int32_t reptLineNo, char const *body, size_t size)
 {
 	if (count == 0)
 		return;
@@ -443,7 +443,7 @@ void fstk_RunRept(uint32_t count, int32_t reptLineNo, char *body, size_t size)
 }
 
 void fstk_RunFor(char const *symName, int32_t start, int32_t stop, int32_t step,
-		     int32_t reptLineNo, char *body, size_t size)
+		     int32_t reptLineNo, char const *body, size_t size)
 {
 	Symbol *sym = sym_AddVar(symName, start);
 


### PR DESCRIPTION
This removes the last use of `strdup`

This required making a lot of related pointers be `const`. That in turn conflicted with the need to `munmap()` a pointer eventually, which was similar to the need to eventually `free()` an `Expansion`'s contents, so I used the same solution of a `union`. That lets us normally use the `const` pointer for `const` correctness, and the non-`const` one for the not-really- mutating destruction cases.