### PR TITLE
Replace non-null pointers with references

### DIFF
--- a/include/asm/charmap.hpp
+++ b/include/asm/charmap.hpp
@@ -15,6 +15,6 @@ void charmap_Pop();
 void charmap_Add(char *mapping, uint8_t value);
 bool charmap_HasChar(char const *input);
 void charmap_Convert(char const *input, std::vector<uint8_t> &output);
-size_t charmap_ConvertNext(char const **input, std::vector<uint8_t> *output);
+size_t charmap_ConvertNext(char const *&input, std::vector<uint8_t> *output);
 
 #endif // RGBDS_ASM_CHARMAP_H

--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -60,7 +60,7 @@ std::string *fstk_FindFile(char const *path);
 
 bool yywrap();
 void fstk_RunInclude(char const *path);
-void fstk_RunMacro(char const *macroName, MacroArgs *args);
+void fstk_RunMacro(char const *macroName, MacroArgs &args);
 void fstk_RunRept(uint32_t count, int32_t reptLineNo, char const *body, size_t size);
 void fstk_RunFor(char const *symName, int32_t start, int32_t stop, int32_t step,
 		     int32_t reptLineNo, char const *body, size_t size);

--- a/include/asm/lexer.hpp
+++ b/include/asm/lexer.hpp
@@ -152,7 +152,7 @@ uint32_t lexer_GetLineNo();
 uint32_t lexer_GetColNo();
 void lexer_DumpStringExpansions();
 int yylex();
-bool lexer_CaptureRept(CaptureBody *capture);
-bool lexer_CaptureMacroBody(CaptureBody *capture);
+bool lexer_CaptureRept(CaptureBody &capture);
+bool lexer_CaptureMacroBody(CaptureBody &capture);
 
 #endif // RGBDS_ASM_LEXER_H

--- a/include/asm/output.hpp
+++ b/include/asm/output.hpp
@@ -15,8 +15,8 @@ extern const char *objectName;
 void out_RegisterNode(FileStackNode *node);
 void out_ReplaceNode(FileStackNode *node);
 void out_SetFileName(char *s);
-void out_CreatePatch(uint32_t type, Expression const *expr, uint32_t ofs, uint32_t pcShift);
-void out_CreateAssert(enum AssertionType type, Expression const *expr, char const *message, uint32_t ofs);
+void out_CreatePatch(uint32_t type, Expression const &expr, uint32_t ofs, uint32_t pcShift);
+void out_CreateAssert(enum AssertionType type, Expression const &expr, char const *message, uint32_t ofs);
 void out_WriteObject();
 
 #endif // RGBDS_ASM_OUTPUT_H

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -23,27 +23,27 @@ struct Expression {
 	bool isDiffConstant(Symbol const *symName) const;
 };
 
-void rpn_Symbol(Expression *expr, char const *symName);
-void rpn_Number(Expression *expr, uint32_t i);
-void rpn_LOGNOT(Expression *expr, const Expression *src);
-void rpn_BinaryOp(enum RPNCommand op, Expression *expr, const Expression *src1, const Expression *src2);
-void rpn_HIGH(Expression *expr, const Expression *src);
-void rpn_LOW(Expression *expr, const Expression *src);
-void rpn_ISCONST(Expression *expr, const Expression *src);
-void rpn_NEG(Expression *expr, const Expression *src);
-void rpn_NOT(Expression *expr, const Expression *src);
-void rpn_BankSymbol(Expression *expr, char const *symName);
-void rpn_BankSection(Expression *expr, char const *sectionName);
-void rpn_BankSelf(Expression *expr);
-void rpn_SizeOfSection(Expression *expr, char const *sectionName);
-void rpn_StartOfSection(Expression *expr, char const *sectionName);
-void rpn_SizeOfSectionType(Expression *expr, enum SectionType type);
-void rpn_StartOfSectionType(Expression *expr, enum SectionType type);
+void rpn_Number(Expression &expr, uint32_t val);
+void rpn_Symbol(Expression &expr, char const *symName);
+void rpn_LOGNOT(Expression &expr, const Expression &src);
+void rpn_BinaryOp(enum RPNCommand op, Expression &expr, const Expression &src1, const Expression &src2);
+void rpn_HIGH(Expression &expr, const Expression &src);
+void rpn_LOW(Expression &expr, const Expression &src);
+void rpn_ISCONST(Expression &expr, const Expression &src);
+void rpn_NEG(Expression &expr, const Expression &src);
+void rpn_NOT(Expression &expr, const Expression &src);
+void rpn_BankSymbol(Expression &expr, char const *symName);
+void rpn_BankSection(Expression &expr, char const *sectionName);
+void rpn_BankSelf(Expression &expr);
+void rpn_SizeOfSection(Expression &expr, char const *sectionName);
+void rpn_StartOfSection(Expression &expr, char const *sectionName);
+void rpn_SizeOfSectionType(Expression &expr, enum SectionType type);
+void rpn_StartOfSectionType(Expression &expr, enum SectionType type);
 
-void rpn_Free(Expression *expr);
+void rpn_Free(Expression &expr);
 
-void rpn_CheckHRAM(Expression *expr, const Expression *src);
-void rpn_CheckRST(Expression *expr, const Expression *src);
-void rpn_CheckNBit(Expression const *expr, uint8_t n);
+void rpn_CheckHRAM(Expression &expr, const Expression &src);
+void rpn_CheckRST(Expression &expr, const Expression &src);
+void rpn_CheckNBit(Expression const &expr, uint8_t n);
 
 #endif // RGBDS_ASM_RPN_H

--- a/include/asm/section.hpp
+++ b/include/asm/section.hpp
@@ -53,9 +53,9 @@ extern Section *currentSection;
 
 Section *sect_FindSectionByName(char const *name);
 void sect_NewSection(char const *name, enum SectionType type, uint32_t org,
-		     SectionSpec const *attributes, enum SectionModifier mod);
+		     SectionSpec const &attrs, enum SectionModifier mod);
 void sect_SetLoadSection(char const *name, enum SectionType type, uint32_t org,
-			 SectionSpec const *attributes, enum SectionModifier mod);
+			 SectionSpec const &attrs, enum SectionModifier mod);
 void sect_EndLoadSection();
 
 Section *sect_GetSymbolSection();
@@ -74,11 +74,11 @@ void sect_AbsByteGroup(uint8_t const *s, size_t length);
 void sect_AbsWordGroup(uint8_t const *s, size_t length);
 void sect_AbsLongGroup(uint8_t const *s, size_t length);
 void sect_Skip(uint32_t skip, bool ds);
-void sect_RelByte(Expression *expr, uint32_t pcShift);
+void sect_RelByte(Expression &expr, uint32_t pcShift);
 void sect_RelBytes(uint32_t n, std::vector<Expression> &exprs);
-void sect_RelWord(Expression *expr, uint32_t pcShift);
-void sect_RelLong(Expression *expr, uint32_t pcShift);
-void sect_PCRelByte(Expression *expr, uint32_t pcShift);
+void sect_RelWord(Expression &expr, uint32_t pcShift);
+void sect_RelLong(Expression &expr, uint32_t pcShift);
+void sect_PCRelByte(Expression &expr, uint32_t pcShift);
 void sect_BinaryFile(char const *s, int32_t startPos);
 void sect_BinaryFileSlice(char const *s, int32_t start_pos, int32_t length);
 

--- a/include/asm/symbol.hpp
+++ b/include/asm/symbol.hpp
@@ -64,7 +64,7 @@ struct Symbol {
 	char const *getStringValue() const { return hasCallback ? strCallback() : equs->c_str(); }
 };
 
-void sym_ForEach(void (*func)(Symbol *));
+void sym_ForEach(void (*func)(Symbol &));
 
 void sym_SetExportAll(bool set);
 Symbol *sym_AddLocalLabel(char const *symName);

--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -10,9 +10,9 @@
 	#define attr_(...) __attribute__ ((__VA_ARGS__))
 	// In release builds, define "unreachable" as such, but trap in debug builds
 	#ifdef NDEBUG
-		#define unreachable_	__builtin_unreachable
+		#define unreachable_ __builtin_unreachable
 	#else
-		#define unreachable_	__builtin_trap
+		#define unreachable_ __builtin_trap
 	#endif
 #else
 	// Unsupported, but no need to throw a fit

--- a/include/link/object.hpp
+++ b/include/link/object.hpp
@@ -13,11 +13,6 @@
 void obj_ReadFile(char const *fileName, unsigned int i);
 
 /*
- * Perform validation on the object files' contents
- */
-void obj_DoSanityChecks();
-
-/*
  * Evaluate all assertions
  */
 void obj_CheckAssertions();

--- a/include/link/output.hpp
+++ b/include/link/output.hpp
@@ -12,14 +12,14 @@
  * Registers a section for output.
  * @param section The section to add
  */
-void out_AddSection(Section const *section);
+void out_AddSection(Section const &section);
 
 /*
  * Finds an assigned section overlapping another one.
  * @param section The section that is being overlapped
  * @return A section overlapping it
  */
-Section const *out_OverlappingSection(Section const *section);
+Section const *out_OverlappingSection(Section const &section);
 
 /*
  * Writes all output (bin, sym, map) files.

--- a/include/link/sdas_obj.hpp
+++ b/include/link/sdas_obj.hpp
@@ -10,6 +10,6 @@
 struct FileStackNode;
 struct Symbol;
 
-void sdobj_ReadFile(FileStackNode const *fileName, FILE *file, std::vector<Symbol> &fileSymbols);
+void sdobj_ReadFile(FileStackNode const &where, FILE *file, std::vector<Symbol> &fileSymbols);
 
 #endif // RGBDS_LINK_SDAS_OBJ_H

--- a/include/link/section.hpp
+++ b/include/link/section.hpp
@@ -58,13 +58,13 @@ struct Section {
  * This is to avoid exposing the data structure in which sections are stored.
  * @param callback The function to call for each structure.
  */
-void sect_ForEach(void (*callback)(Section *));
+void sect_ForEach(void (*callback)(Section &));
 
 /*
  * Registers a section to be processed.
  * @param section The section to register.
  */
-void sect_AddSection(Section *section);
+void sect_AddSection(Section &section);
 
 /*
  * Finds a section by its name.

--- a/include/link/symbol.hpp
+++ b/include/link/symbol.hpp
@@ -31,7 +31,7 @@ struct Symbol {
 	Section *section;
 };
 
-void sym_AddSymbol(Symbol *symbol);
+void sym_AddSymbol(Symbol &symbol);
 
 /*
  * Finds a symbol in all the defined symbols.

--- a/src/asm/fixpoint.cpp
+++ b/src/asm/fixpoint.cpp
@@ -14,12 +14,12 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-#define fix2double(i, q)	((double)((i) / pow(2.0, q)))
-#define double2fix(d, q)	((int32_t)round((d) * pow(2.0, q)))
+#define fix2double(i, q) ((double)((i) / pow(2.0, q)))
+#define double2fix(d, q) ((int32_t)round((d) * pow(2.0, q)))
 
 // 2*pi radians == 1 turn
-#define turn2rad(f)	((f) * (M_PI * 2))
-#define rad2turn(r)	((r) / (M_PI * 2))
+#define turn2rad(f) ((f) * (M_PI * 2))
+#define rad2turn(r) ((r) / (M_PI * 2))
 
 uint8_t fixPrecision;
 

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -2264,7 +2264,7 @@ int yylex()
 	return token;
 }
 
-static void startCapture(CaptureBody *capture)
+static void startCapture(CaptureBody &capture)
 {
 	assert(!lexerState->capturing);
 	lexerState->capturing = true;
@@ -2272,26 +2272,26 @@ static void startCapture(CaptureBody *capture)
 	lexerState->disableMacroArgs = true;
 	lexerState->disableInterpolation = true;
 
-	capture->lineNo = lexer_GetLineNo();
+	capture.lineNo = lexer_GetLineNo();
 
 	if (lexerState->isMmapped && lexerState->expansions.empty()) {
-		capture->body = &lexerState->mmap.ptr.unreferenced[lexerState->mmap.offset];
+		capture.body = &lexerState->mmap.ptr.unreferenced[lexerState->mmap.offset];
 	} else {
 		assert(lexerState->captureBuf == nullptr);
 		lexerState->captureBuf = new(std::nothrow) std::vector<char>();
 		if (!lexerState->captureBuf)
 			fatalerror("Failed to allocate capture buffer: %s\n", strerror(errno));
-		capture->body = nullptr; // Indicate to retrieve the capture buffer when done capturing
+		capture.body = nullptr; // Indicate to retrieve the capture buffer when done capturing
 	}
 }
 
-static void endCapture(CaptureBody *capture)
+static void endCapture(CaptureBody &capture)
 {
 	// This being `nullptr` means we're capturing from the capture buf, which is reallocated
 	// during the whole capture process, and so MUST be retrieved at the end
-	if (!capture->body)
-		capture->body = lexerState->captureBuf->data();
-	capture->size = lexerState->captureSize;
+	if (!capture.body)
+		capture.body = lexerState->captureBuf->data();
+	capture.size = lexerState->captureSize;
 
 	lexerState->capturing = false;
 	lexerState->captureBuf = nullptr;
@@ -2299,7 +2299,7 @@ static void endCapture(CaptureBody *capture)
 	lexerState->disableInterpolation = false;
 }
 
-bool lexer_CaptureRept(CaptureBody *capture)
+bool lexer_CaptureRept(CaptureBody &capture)
 {
 	startCapture(capture);
 
@@ -2357,7 +2357,7 @@ finish:
 	return c != EOF;
 }
 
-bool lexer_CaptureMacroBody(CaptureBody *capture)
+bool lexer_CaptureMacroBody(CaptureBody &capture)
 {
 	startCapture(capture);
 

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -22,56 +22,56 @@
 #include "opmath.hpp"
 
 // Init a RPN expression
-static void initExpression(Expression *expr)
+static void initExpression(Expression &expr)
 {
-	expr->reason = nullptr;
-	expr->isKnown = true;
-	expr->isSymbol = false;
-	expr->rpn = nullptr;
-	expr->rpnPatchSize = 0;
+	expr.reason = nullptr;
+	expr.isKnown = true;
+	expr.isSymbol = false;
+	expr.rpn = nullptr;
+	expr.rpnPatchSize = 0;
 }
 
 // Makes an expression "not known", also setting its error message
 template<typename... Ts>
-static void makeUnknown(Expression *expr, Ts ...parts)
+static void makeUnknown(Expression &expr, Ts ...parts)
 {
-	expr->isKnown = false;
-	expr->reason = new std::string();
-	if (!expr->reason)
+	expr.isKnown = false;
+	expr.reason = new std::string();
+	if (!expr.reason)
 		fatalerror("Failed to allocate RPN error string: %s\n", strerror(errno));
-	(expr->reason->append(parts), ...);
+	(expr.reason->append(parts), ...);
 }
 
-static uint8_t *reserveSpace(Expression *expr, uint32_t size)
+static uint8_t *reserveSpace(Expression &expr, uint32_t size)
 {
-	if (!expr->rpn) {
-		expr->rpn = new(std::nothrow) std::vector<uint8_t>();
-		if (!expr->rpn)
+	if (!expr.rpn) {
+		expr.rpn = new(std::nothrow) std::vector<uint8_t>();
+		if (!expr.rpn)
 			fatalerror("Failed to allocate RPN expression: %s\n", strerror(errno));
 	}
 
-	size_t curSize = expr->rpn->size();
+	size_t curSize = expr.rpn->size();
 
-	expr->rpn->resize(curSize + size);
-	return &(*expr->rpn)[curSize];
+	expr.rpn->resize(curSize + size);
+	return &(*expr.rpn)[curSize];
 }
 
 // Free the RPN expression
-void rpn_Free(Expression *expr)
+void rpn_Free(Expression &expr)
 {
-	delete expr->rpn;
-	delete expr->reason;
+	delete expr.rpn;
+	delete expr.reason;
 	initExpression(expr);
 }
 
 // Add symbols, constants and operators to expression
-void rpn_Number(Expression *expr, uint32_t i)
+void rpn_Number(Expression &expr, uint32_t val)
 {
 	initExpression(expr);
-	expr->val = i;
+	expr.val = val;
 }
 
-void rpn_Symbol(Expression *expr, char const *symName)
+void rpn_Symbol(Expression &expr, char const *symName)
 {
 	Symbol *sym = sym_FindScopedSymbol(symName);
 
@@ -80,14 +80,14 @@ void rpn_Symbol(Expression *expr, char const *symName)
 		rpn_Number(expr, 0);
 	} else if (!sym || !sym->isConstant()) {
 		initExpression(expr);
-		expr->isSymbol = true;
+		expr.isSymbol = true;
 
 		if (sym_IsPC(sym))
 			makeUnknown(expr, "PC is not constant at assembly time");
 		else
 			makeUnknown(expr, "'", symName, "' is not constant at assembly time");
 		sym = sym_Ref(symName);
-		expr->rpnPatchSize += 5; // 1-byte opcode + 4-byte symbol ID
+		expr.rpnPatchSize += 5; // 1-byte opcode + 4-byte symbol ID
 
 		size_t nameLen = strlen(sym->name) + 1; // Don't forget NUL!
 		uint8_t *ptr = reserveSpace(expr, nameLen + 1);
@@ -98,29 +98,29 @@ void rpn_Symbol(Expression *expr, char const *symName)
 	}
 }
 
-void rpn_BankSelf(Expression *expr)
+static void bankSelf(Expression &expr)
 {
 	initExpression(expr);
 
 	if (!currentSection) {
 		error("PC has no bank outside a section\n");
-		expr->val = 1;
+		expr.val = 1;
 	} else if (currentSection->bank == (uint32_t)-1) {
 		makeUnknown(expr, "Current section's bank is not known");
-		expr->rpnPatchSize++;
+		expr.rpnPatchSize++;
 		*reserveSpace(expr, 1) = RPN_BANK_SELF;
 	} else {
-		expr->val = currentSection->bank;
+		expr.val = currentSection->bank;
 	}
 }
 
-void rpn_BankSymbol(Expression *expr, char const *symName)
+void rpn_BankSymbol(Expression &expr, char const *symName)
 {
 	Symbol const *sym = sym_FindScopedSymbol(symName);
 
 	// The @ symbol is treated differently.
 	if (sym_IsPC(sym)) {
-		rpn_BankSelf(expr);
+		bankSelf(expr);
 		return;
 	}
 
@@ -133,10 +133,10 @@ void rpn_BankSymbol(Expression *expr, char const *symName)
 
 		if (sym->getSection() && sym->getSection()->bank != (uint32_t)-1) {
 			// Symbol's section is known and bank is fixed
-			expr->val = sym->getSection()->bank;
+			expr.val = sym->getSection()->bank;
 		} else {
 			makeUnknown(expr, "\"", symName, "\"'s bank is not known");
-			expr->rpnPatchSize += 5; // opcode + 4-byte sect ID
+			expr.rpnPatchSize += 5; // opcode + 4-byte sect ID
 
 			size_t nameLen = strlen(sym->name) + 1; // Room for NUL!
 			uint8_t *ptr = reserveSpace(expr, nameLen + 1);
@@ -147,130 +147,130 @@ void rpn_BankSymbol(Expression *expr, char const *symName)
 	}
 }
 
-void rpn_BankSection(Expression *expr, char const *sectionName)
+void rpn_BankSection(Expression &expr, char const *sectionName)
 {
 	initExpression(expr);
 
 	Section *section = sect_FindSectionByName(sectionName);
 
 	if (section && section->bank != (uint32_t)-1) {
-		expr->val = section->bank;
+		expr.val = section->bank;
 	} else {
 		makeUnknown(expr, "Section \"", sectionName, "\"'s bank is not known");
 
 		size_t nameLen = strlen(sectionName) + 1; // Room for NUL!
 		uint8_t *ptr = reserveSpace(expr, nameLen + 1);
 
-		expr->rpnPatchSize += nameLen + 1;
+		expr.rpnPatchSize += nameLen + 1;
 		*ptr++ = RPN_BANK_SECT;
 		memcpy(ptr, sectionName, nameLen);
 	}
 }
 
-void rpn_SizeOfSection(Expression *expr, char const *sectionName)
+void rpn_SizeOfSection(Expression &expr, char const *sectionName)
 {
 	initExpression(expr);
 
 	Section *section = sect_FindSectionByName(sectionName);
 
 	if (section && section->isSizeKnown()) {
-		expr->val = section->size;
+		expr.val = section->size;
 	} else {
 		makeUnknown(expr, "Section \"", sectionName, "\"'s size is not known");
 
 		size_t nameLen = strlen(sectionName) + 1; // Room for NUL!
 		uint8_t *ptr = reserveSpace(expr, nameLen + 1);
 
-		expr->rpnPatchSize += nameLen + 1;
+		expr.rpnPatchSize += nameLen + 1;
 		*ptr++ = RPN_SIZEOF_SECT;
 		memcpy(ptr, sectionName, nameLen);
 	}
 }
 
-void rpn_StartOfSection(Expression *expr, char const *sectionName)
+void rpn_StartOfSection(Expression &expr, char const *sectionName)
 {
 	initExpression(expr);
 
 	Section *section = sect_FindSectionByName(sectionName);
 
 	if (section && section->org != (uint32_t)-1) {
-		expr->val = section->org;
+		expr.val = section->org;
 	} else {
 		makeUnknown(expr, "Section \"", sectionName, "\"'s start is not known");
 
 		size_t nameLen = strlen(sectionName) + 1; // Room for NUL!
 		uint8_t *ptr = reserveSpace(expr, nameLen + 1);
 
-		expr->rpnPatchSize += nameLen + 1;
+		expr.rpnPatchSize += nameLen + 1;
 		*ptr++ = RPN_STARTOF_SECT;
 		memcpy(ptr, sectionName, nameLen);
 	}
 }
 
-void rpn_SizeOfSectionType(Expression *expr, enum SectionType type)
+void rpn_SizeOfSectionType(Expression &expr, enum SectionType type)
 {
 	initExpression(expr);
 	makeUnknown(expr, "Section type's size is not known");
 
 	uint8_t *ptr = reserveSpace(expr, 2);
 
-	expr->rpnPatchSize += 2;
+	expr.rpnPatchSize += 2;
 	*ptr++ = RPN_SIZEOF_SECTTYPE;
 	*ptr++ = type;
 }
 
-void rpn_StartOfSectionType(Expression *expr, enum SectionType type)
+void rpn_StartOfSectionType(Expression &expr, enum SectionType type)
 {
 	initExpression(expr);
 	makeUnknown(expr, "Section type's start is not known");
 
 	uint8_t *ptr = reserveSpace(expr, 2);
 
-	expr->rpnPatchSize += 2;
+	expr.rpnPatchSize += 2;
 	*ptr++ = RPN_STARTOF_SECTTYPE;
 	*ptr++ = type;
 }
 
-void rpn_CheckHRAM(Expression *expr, const Expression *src)
+void rpn_CheckHRAM(Expression &expr, const Expression &src)
 {
-	*expr = *src;
-	expr->isSymbol = false;
+	expr = src;
+	expr.isSymbol = false;
 
-	if (!expr->isKnown) {
-		expr->rpnPatchSize++;
+	if (!expr.isKnown) {
+		expr.rpnPatchSize++;
 		*reserveSpace(expr, 1) = RPN_HRAM;
-	} else if (expr->val >= 0xFF00 && expr->val <= 0xFFFF) {
+	} else if (expr.val >= 0xFF00 && expr.val <= 0xFFFF) {
 		// That range is valid, but only keep the lower byte
-		expr->val &= 0xFF;
-	} else if (expr->val < 0 || expr->val > 0xFF) {
-		error("Source address $%" PRIx32 " not between $FF00 to $FFFF\n", expr->val);
+		expr.val &= 0xFF;
+	} else if (expr.val < 0 || expr.val > 0xFF) {
+		error("Source address $%" PRIx32 " not between $FF00 to $FFFF\n", expr.val);
 	}
 }
 
-void rpn_CheckRST(Expression *expr, const Expression *src)
+void rpn_CheckRST(Expression &expr, const Expression &src)
 {
-	*expr = *src;
+	expr = src;
 
-	if (expr->isKnown) {
+	if (expr.isKnown) {
 		// A valid RST address must be masked with 0x38
-		if (expr->val & ~0x38)
-			error("Invalid address $%" PRIx32 " for RST\n", expr->val);
+		if (expr.val & ~0x38)
+			error("Invalid address $%" PRIx32 " for RST\n", expr.val);
 		// The target is in the "0x38" bits, all other bits are set
-		expr->val |= 0xC7;
+		expr.val |= 0xC7;
 	} else {
-		expr->rpnPatchSize++;
+		expr.rpnPatchSize++;
 		*reserveSpace(expr, 1) = RPN_RST;
 	}
 }
 
 // Checks that an RPN expression's value fits within N bits (signed or unsigned)
-void rpn_CheckNBit(Expression const *expr, uint8_t n)
+void rpn_CheckNBit(Expression const &expr, uint8_t n)
 {
 	assert(n != 0); // That doesn't make sense
 	assert(n < CHAR_BIT * sizeof(int)); // Otherwise `1 << n` is UB
 
-	if (expr->isKnown) {
-		int32_t val = expr->val;
+	if (expr.isKnown) {
+		int32_t val = expr.val;
 
 		if (val < -(1 << n) || val >= 1 << n)
 			warning(WARNING_TRUNCATION_1, "Expression must be %u-bit\n", n);
@@ -288,15 +288,15 @@ int32_t Expression::getConstVal() const
 	return val;
 }
 
-void rpn_LOGNOT(Expression *expr, const Expression *src)
+void rpn_LOGNOT(Expression &expr, const Expression &src)
 {
-	*expr = *src;
-	expr->isSymbol = false;
+	expr = src;
+	expr.isSymbol = false;
 
-	if (expr->isKnown) {
-		expr->val = !expr->val;
+	if (expr.isKnown) {
+		expr.val = !expr.val;
 	} else {
-		expr->rpnPatchSize++;
+		expr.rpnPatchSize++;
 		*reserveSpace(expr, 1) = RPN_LOGNOT;
 	}
 }
@@ -328,164 +328,165 @@ bool Expression::isDiffConstant(Symbol const *sym) const
  *
  * @return The constant result if it can be computed, or -1 otherwise.
  */
-static int32_t tryConstMask(Expression const *lhs, Expression const *rhs)
+static int32_t tryConstMask(Expression const &lhs, Expression const &rhs)
 {
-	Symbol const *sym = lhs->symbolOf();
-	Expression const *expr = rhs;
+	Symbol const *lhsSymbol = lhs.symbolOf();
+	Symbol const *rhsSymbol = lhsSymbol ? nullptr : rhs.symbolOf();
+	bool lhsIsSymbol = lhsSymbol && lhsSymbol->getSection();
+	bool rhsIsSymbol = rhsSymbol && rhsSymbol->getSection();
 
-	if (!sym || !sym->getSection()) {
-		// If the lhs isn't a symbol, try again the other way around
-		sym = rhs->symbolOf();
-		expr = lhs;
-
-		if (!sym || !sym->getSection())
-			return -1;
-	}
-	assert(sym->isNumeric());
-
-	if (!expr->isKnown)
+	if (!lhsIsSymbol && !rhsIsSymbol)
 		return -1;
-	// We can now safely use `expr->val`
-	Section const *sect = sym->getSection();
-	int32_t unknownBits = (1 << 16) - (1 << sect->align); // The max alignment is 16
+
+	// If the lhs isn't a symbol, try again the other way around
+	Symbol const &sym = lhsIsSymbol ? *lhsSymbol : *rhsSymbol;
+	Expression const &expr = lhsIsSymbol ? rhs : lhs; // Opposite side of `sym`
+
+	assert(sym.isNumeric());
+
+	if (!expr.isKnown)
+		return -1;
+	// We can now safely use `expr.val`
+	Section const &sect = *sym.getSection();
+	int32_t unknownBits = (1 << 16) - (1 << sect.align); // The max alignment is 16
 
 	// The mask must ignore all unknown bits
-	if ((expr->val & unknownBits) != 0)
+	if ((expr.val & unknownBits) != 0)
 		return -1;
 
-	// `sym->getValue()` attempts to add the section's address, but that's "-1"
+	// `sym.getValue()` attempts to add the section's address, but that's "-1"
 	// because the section is floating (otherwise we wouldn't be here)
-	assert(sect->org == (uint32_t)-1);
-	int32_t symbolOfs = sym->getValue() + 1;
+	assert(sect.org == (uint32_t)-1);
+	int32_t symbolOfs = sym.getValue() + 1;
 
-	return (symbolOfs + sect->alignOfs) & ~unknownBits;
+	return (symbolOfs + sect.alignOfs) & ~unknownBits;
 }
 
-void rpn_BinaryOp(enum RPNCommand op, Expression *expr, const Expression *src1, const Expression *src2)
+void rpn_BinaryOp(enum RPNCommand op, Expression &expr, const Expression &src1, const Expression &src2)
 {
-	expr->isSymbol = false;
+	expr.isSymbol = false;
 	int32_t constMaskVal;
 
 	// First, check if the expression is known
-	expr->isKnown = src1->isKnown && src2->isKnown;
-	if (expr->isKnown) {
+	expr.isKnown = src1.isKnown && src2.isKnown;
+	if (expr.isKnown) {
 		initExpression(expr); // Init the expression to something sane
 
 		// If both expressions are known, just compute the value
-		uint32_t uleft = src1->val, uright = src2->val;
+		uint32_t uleft = src1.val, uright = src2.val;
 
 		switch (op) {
 		case RPN_LOGOR:
-			expr->val = src1->val || src2->val;
+			expr.val = src1.val || src2.val;
 			break;
 		case RPN_LOGAND:
-			expr->val = src1->val && src2->val;
+			expr.val = src1.val && src2.val;
 			break;
 		case RPN_LOGEQ:
-			expr->val = src1->val == src2->val;
+			expr.val = src1.val == src2.val;
 			break;
 		case RPN_LOGGT:
-			expr->val = src1->val > src2->val;
+			expr.val = src1.val > src2.val;
 			break;
 		case RPN_LOGLT:
-			expr->val = src1->val < src2->val;
+			expr.val = src1.val < src2.val;
 			break;
 		case RPN_LOGGE:
-			expr->val = src1->val >= src2->val;
+			expr.val = src1.val >= src2.val;
 			break;
 		case RPN_LOGLE:
-			expr->val = src1->val <= src2->val;
+			expr.val = src1.val <= src2.val;
 			break;
 		case RPN_LOGNE:
-			expr->val = src1->val != src2->val;
+			expr.val = src1.val != src2.val;
 			break;
 		case RPN_ADD:
-			expr->val = uleft + uright;
+			expr.val = uleft + uright;
 			break;
 		case RPN_SUB:
-			expr->val = uleft - uright;
+			expr.val = uleft - uright;
 			break;
 		case RPN_XOR:
-			expr->val = src1->val ^ src2->val;
+			expr.val = src1.val ^ src2.val;
 			break;
 		case RPN_OR:
-			expr->val = src1->val | src2->val;
+			expr.val = src1.val | src2.val;
 			break;
 		case RPN_AND:
-			expr->val = src1->val & src2->val;
+			expr.val = src1.val & src2.val;
 			break;
 		case RPN_SHL:
-			if (src2->val < 0)
+			if (src2.val < 0)
 				warning(WARNING_SHIFT_AMOUNT,
 					"Shifting left by negative amount %" PRId32 "\n",
-					src2->val);
+					src2.val);
 
-			if (src2->val >= 32)
+			if (src2.val >= 32)
 				warning(WARNING_SHIFT_AMOUNT,
-					"Shifting left by large amount %" PRId32 "\n", src2->val);
+					"Shifting left by large amount %" PRId32 "\n", src2.val);
 
-			expr->val = op_shift_left(src1->val, src2->val);
+			expr.val = op_shift_left(src1.val, src2.val);
 			break;
 		case RPN_SHR:
-			if (src1->val < 0)
+			if (src1.val < 0)
 				warning(WARNING_SHIFT,
-					"Shifting right negative value %" PRId32 "\n", src1->val);
+					"Shifting right negative value %" PRId32 "\n", src1.val);
 
-			if (src2->val < 0)
+			if (src2.val < 0)
 				warning(WARNING_SHIFT_AMOUNT,
 					"Shifting right by negative amount %" PRId32 "\n",
-					src2->val);
+					src2.val);
 
-			if (src2->val >= 32)
+			if (src2.val >= 32)
 				warning(WARNING_SHIFT_AMOUNT,
 					"Shifting right by large amount %" PRId32 "\n",
-					src2->val);
+					src2.val);
 
-			expr->val = op_shift_right(src1->val, src2->val);
+			expr.val = op_shift_right(src1.val, src2.val);
 			break;
 		case RPN_USHR:
-			if (src2->val < 0)
+			if (src2.val < 0)
 				warning(WARNING_SHIFT_AMOUNT,
 					"Shifting right by negative amount %" PRId32 "\n",
-					src2->val);
+					src2.val);
 
-			if (src2->val >= 32)
+			if (src2.val >= 32)
 				warning(WARNING_SHIFT_AMOUNT,
 					"Shifting right by large amount %" PRId32 "\n",
-					src2->val);
+					src2.val);
 
-			expr->val = op_shift_right_unsigned(src1->val, src2->val);
+			expr.val = op_shift_right_unsigned(src1.val, src2.val);
 			break;
 		case RPN_MUL:
-			expr->val = uleft * uright;
+			expr.val = uleft * uright;
 			break;
 		case RPN_DIV:
-			if (src2->val == 0)
+			if (src2.val == 0)
 				fatalerror("Division by zero\n");
 
-			if (src1->val == INT32_MIN && src2->val == -1) {
+			if (src1.val == INT32_MIN && src2.val == -1) {
 				warning(WARNING_DIV,
 					"Division of %" PRId32 " by -1 yields %" PRId32 "\n",
 					INT32_MIN, INT32_MIN);
-				expr->val = INT32_MIN;
+				expr.val = INT32_MIN;
 			} else {
-				expr->val = op_divide(src1->val, src2->val);
+				expr.val = op_divide(src1.val, src2.val);
 			}
 			break;
 		case RPN_MOD:
-			if (src2->val == 0)
+			if (src2.val == 0)
 				fatalerror("Modulo by zero\n");
 
-			if (src1->val == INT32_MIN && src2->val == -1)
-				expr->val = 0;
+			if (src1.val == INT32_MIN && src2.val == -1)
+				expr.val = 0;
 			else
-				expr->val = op_modulo(src1->val, src2->val);
+				expr.val = op_modulo(src1.val, src2.val);
 			break;
 		case RPN_EXP:
-			if (src2->val < 0)
+			if (src2.val < 0)
 				fatalerror("Exponentiation by negative power\n");
 
-			expr->val = op_exponent(src1->val, src2->val);
+			expr.val = op_exponent(src1.val, src2.val);
 			break;
 
 		case RPN_NEG:
@@ -505,36 +506,36 @@ void rpn_BinaryOp(enum RPNCommand op, Expression *expr, const Expression *src1, 
 			fatalerror("%d is not a binary operator\n", op);
 		}
 
-	} else if (op == RPN_SUB && src1->isDiffConstant(src2->symbolOf())) {
-		Symbol const *symbol1 = src1->symbolOf();
-		Symbol const *symbol2 = src2->symbolOf();
+	} else if (op == RPN_SUB && src1.isDiffConstant(src2.symbolOf())) {
+		Symbol const &symbol1 = *src1.symbolOf();
+		Symbol const &symbol2 = *src2.symbolOf();
 
-		expr->val = symbol1->getValue() - symbol2->getValue();
-		expr->isKnown = true;
+		expr.val = symbol1.getValue() - symbol2.getValue();
+		expr.isKnown = true;
 	} else if (op == RPN_AND && (constMaskVal = tryConstMask(src1, src2)) != -1) {
-		expr->val = constMaskVal;
-		expr->isKnown = true;
+		expr.val = constMaskVal;
+		expr.isKnown = true;
 	} else {
 		// If it's not known, start computing the RPN expression
 
 		// Convert the left-hand expression if it's constant
-		if (src1->isKnown) {
-			uint32_t lval = src1->val;
+		if (src1.isKnown) {
+			uint32_t lval = src1.val;
 			uint8_t bytes[] = {RPN_CONST, (uint8_t)lval, (uint8_t)(lval >> 8),
 					   (uint8_t)(lval >> 16), (uint8_t)(lval >> 24)};
-			expr->rpnPatchSize = sizeof(bytes);
-			expr->rpn = nullptr;
+			expr.rpnPatchSize = sizeof(bytes);
+			expr.rpn = nullptr;
 			memcpy(reserveSpace(expr, sizeof(bytes)), bytes, sizeof(bytes));
 
 			// Use the other expression's un-const reason
-			expr->reason = src2->reason;
-			delete src1->reason;
+			expr.reason = src2.reason;
+			delete src1.reason;
 		} else {
 			// Otherwise just reuse its RPN buffer
-			expr->rpnPatchSize = src1->rpnPatchSize;
-			expr->rpn = src1->rpn;
-			expr->reason = src1->reason;
-			delete src2->reason;
+			expr.rpnPatchSize = src1.rpnPatchSize;
+			expr.rpn = src1.rpn;
+			expr.reason = src1.reason;
+			delete src2.reason;
 		}
 
 		// Now, merge the right expression into the left one
@@ -543,17 +544,17 @@ void rpn_BinaryOp(enum RPNCommand op, Expression *expr, const Expression *src1, 
 		uint32_t patchSize = 0;
 
 		// If the right expression is constant, merge a shim instead
-		uint32_t rval = src2->val;
+		uint32_t rval = src2.val;
 		uint8_t bytes[] = {RPN_CONST, (uint8_t)rval, (uint8_t)(rval >> 8),
 				   (uint8_t)(rval >> 16), (uint8_t)(rval >> 24)};
-		if (src2->isKnown) {
+		if (src2.isKnown) {
 			ptr = bytes;
 			len = sizeof(bytes);
 			patchSize = sizeof(bytes);
 		} else {
-			ptr = src2->rpn->data(); // Pointer to the right RPN
-			len = src2->rpn->size(); // Size of the right RPN
-			patchSize = src2->rpnPatchSize;
+			ptr = src2.rpn->data(); // Pointer to the right RPN
+			len = src2.rpn->size(); // Size of the right RPN
+			patchSize = src2.rpnPatchSize;
 		}
 		// Copy the right RPN and append the operator
 		uint8_t *buf = reserveSpace(expr, len + 1);
@@ -563,71 +564,71 @@ void rpn_BinaryOp(enum RPNCommand op, Expression *expr, const Expression *src1, 
 			memcpy(buf, ptr, len);
 		buf[len] = op;
 
-		delete src2->rpn; // If there was none, this is `delete nullptr`
-		expr->rpnPatchSize += patchSize + 1;
+		delete src2.rpn; // If there was none, this is `delete nullptr`
+		expr.rpnPatchSize += patchSize + 1;
 	}
 }
 
-void rpn_HIGH(Expression *expr, const Expression *src)
+void rpn_HIGH(Expression &expr, const Expression &src)
 {
-	*expr = *src;
-	expr->isSymbol = false;
+	expr = src;
+	expr.isSymbol = false;
 
-	if (expr->isKnown) {
-		expr->val = (uint32_t)expr->val >> 8 & 0xFF;
+	if (expr.isKnown) {
+		expr.val = (uint32_t)expr.val >> 8 & 0xFF;
 	} else {
 		uint8_t bytes[] = {RPN_CONST,    8, 0, 0, 0, RPN_SHR,
 				   RPN_CONST, 0xFF, 0, 0, 0, RPN_AND};
-		expr->rpnPatchSize += sizeof(bytes);
+		expr.rpnPatchSize += sizeof(bytes);
 		memcpy(reserveSpace(expr, sizeof(bytes)), bytes, sizeof(bytes));
 	}
 }
 
-void rpn_LOW(Expression *expr, const Expression *src)
+void rpn_LOW(Expression &expr, const Expression &src)
 {
-	*expr = *src;
-	expr->isSymbol = false;
+	expr = src;
+	expr.isSymbol = false;
 
-	if (expr->isKnown) {
-		expr->val = expr->val & 0xFF;
+	if (expr.isKnown) {
+		expr.val = expr.val & 0xFF;
 	} else {
 		uint8_t bytes[] = {RPN_CONST, 0xFF, 0, 0, 0, RPN_AND};
 
-		expr->rpnPatchSize += sizeof(bytes);
+		expr.rpnPatchSize += sizeof(bytes);
 		memcpy(reserveSpace(expr, sizeof(bytes)), bytes, sizeof(bytes));
 	}
 }
 
-void rpn_ISCONST(Expression *expr, const Expression *src)
+void rpn_ISCONST(Expression &expr, const Expression &src)
 {
 	initExpression(expr);
-	expr->val = src->isKnown;
-	expr->isKnown = true;
-	expr->isSymbol = false;
+	expr.val = src.isKnown;
+	expr.isKnown = true;
+	expr.isSymbol = false;
 }
 
-void rpn_NEG(Expression *expr, const Expression *src)
+void rpn_NEG(Expression &expr, const Expression &src)
 {
-	*expr = *src;
-	expr->isSymbol = false;
+	expr = src;
+	expr.isSymbol = false;
 
-	if (expr->isKnown) {
-		expr->val = -(uint32_t)expr->val;
+	if (expr.isKnown) {
+		expr.val = -(uint32_t)expr.val;
 	} else {
-		expr->rpnPatchSize++;
+		expr.rpnPatchSize++;
 		*reserveSpace(expr, 1) = RPN_NEG;
 	}
 }
 
-void rpn_NOT(Expression *expr, const Expression *src)
+void rpn_NOT(Expression &expr, const Expression &src)
 {
-	*expr = *src;
-	expr->isSymbol = false;
+	expr = src;
+	expr.isSymbol = false;
 
-	if (expr->isKnown) {
-		expr->val = ~expr->val;
+	if (expr.isKnown) {
+		expr.val = ~expr.val;
 	} else {
-		expr->rpnPatchSize++;
+		expr.rpnPatchSize++;
 		*reserveSpace(expr, 1) = RPN_NOT;
 	}
 }

--- a/src/fix/main.cpp
+++ b/src/fix/main.cpp
@@ -188,10 +188,10 @@ static uint8_t tpp1Rev[2];
 /*
  * @return False on failure
  */
-static bool readMBCSlice(char const **name, char const *expected)
+static bool readMBCSlice(char const *&name, char const *expected)
 {
 	while (*expected) {
-		char c = *(*name)++;
+		char c = *name++;
 
 		if (c == '\0') // Name too short
 			return false;
@@ -243,7 +243,7 @@ static enum MbcType parseMBC(char const *name)
 
 #define tryReadSlice(expected) \
 do { \
-	if (!readMBCSlice(&ptr, expected)) \
+	if (!readMBCSlice(ptr, expected)) \
 		return MBC_BAD; \
 } while (0)
 

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -342,11 +342,13 @@ next:
 	exit(1);
 }
 
-static void freeSection(Section *section)
+static void freeSection(Section &section)
 {
-	for (Section *next; section; section = next) {
-		next = section->nextu;
-		delete section;
+	Section *next = &section;
+
+	for (Section *nextu; next; next = nextu) {
+		nextu = next->nextu;
+		delete next;
 	};
 }
 
@@ -478,7 +480,7 @@ int main(int argc, char *argv[])
 	}
 
 	// then process them,
-	obj_DoSanityChecks();
+	sect_DoSanityChecks();
 	if (nbErrors != 0)
 		reportErrors();
 	assign_AssignSections();

--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -15,122 +15,122 @@
 
 std::map<std::string, Section *> sections;
 
-void sect_ForEach(void (*callback)(Section *))
+void sect_ForEach(void (*callback)(Section &))
 {
 	for (auto &it : sections)
-		callback(it.second);
+		callback(*it.second);
 }
 
-static void checkSectUnionCompat(Section *target, Section *other)
+static void checkSectUnionCompat(Section &target, Section &other)
 {
-	if (other->isAddressFixed) {
-		if (target->isAddressFixed) {
-			if (target->org != other->org)
+	if (other.isAddressFixed) {
+		if (target.isAddressFixed) {
+			if (target.org != other.org)
 				errx("Section \"%s\" is defined with conflicting addresses $%04"
-				     PRIx16 " and $%04" PRIx16, other->name.c_str(), target->org,
-				     other->org);
-		} else if (target->isAlignFixed) {
-			if ((other->org - target->alignOfs) & target->alignMask)
+				     PRIx16 " and $%04" PRIx16, other.name.c_str(), target.org,
+				     other.org);
+		} else if (target.isAlignFixed) {
+			if ((other.org - target.alignOfs) & target.alignMask)
 				errx("Section \"%s\" is defined with conflicting %d-byte alignment (offset %"
-				     PRIu16 ") and address $%04" PRIx16, other->name.c_str(),
-				     target->alignMask + 1, target->alignOfs, other->org);
+				     PRIu16 ") and address $%04" PRIx16, other.name.c_str(),
+				     target.alignMask + 1, target.alignOfs, other.org);
 		}
-		target->isAddressFixed = true;
-		target->org = other->org;
+		target.isAddressFixed = true;
+		target.org = other.org;
 
-	} else if (other->isAlignFixed) {
-		if (target->isAddressFixed) {
-			if ((target->org - other->alignOfs) & other->alignMask)
+	} else if (other.isAlignFixed) {
+		if (target.isAddressFixed) {
+			if ((target.org - other.alignOfs) & other.alignMask)
 				errx("Section \"%s\" is defined with conflicting address $%04"
 				     PRIx16 " and %d-byte alignment (offset %" PRIu16 ")",
-				     other->name.c_str(), target->org, other->alignMask + 1,
-				     other->alignOfs);
-		} else if (target->isAlignFixed
-			&& (other->alignMask & target->alignOfs)
-				 != (target->alignMask & other->alignOfs)) {
+				     other.name.c_str(), target.org, other.alignMask + 1,
+				     other.alignOfs);
+		} else if (target.isAlignFixed
+			&& (other.alignMask & target.alignOfs)
+				 != (target.alignMask & other.alignOfs)) {
 			errx("Section \"%s\" is defined with conflicting %d-byte alignment (offset %"
 			     PRIu16 ") and %d-byte alignment (offset %" PRIu16 ")",
-			     other->name.c_str(), target->alignMask + 1, target->alignOfs,
-			     other->alignMask + 1, other->alignOfs);
-		} else if (!target->isAlignFixed || (other->alignMask > target->alignMask)) {
-			target->isAlignFixed = true;
-			target->alignMask = other->alignMask;
+			     other.name.c_str(), target.alignMask + 1, target.alignOfs,
+			     other.alignMask + 1, other.alignOfs);
+		} else if (!target.isAlignFixed || (other.alignMask > target.alignMask)) {
+			target.isAlignFixed = true;
+			target.alignMask = other.alignMask;
 		}
 	}
 }
 
-static void checkFragmentCompat(Section *target, Section *other)
+static void checkFragmentCompat(Section &target, Section &other)
 {
-	if (other->isAddressFixed) {
-		uint16_t org = other->org - target->size;
+	if (other.isAddressFixed) {
+		uint16_t org = other.org - target.size;
 
-		if (target->isAddressFixed) {
-			if (target->org != org)
+		if (target.isAddressFixed) {
+			if (target.org != org)
 				errx("Section \"%s\" is defined with conflicting addresses $%04"
-				     PRIx16 " and $%04" PRIx16, other->name.c_str(), target->org,
-				     other->org);
+				     PRIx16 " and $%04" PRIx16, other.name.c_str(), target.org,
+				     other.org);
 
-		} else if (target->isAlignFixed) {
-			if ((org - target->alignOfs) & target->alignMask)
+		} else if (target.isAlignFixed) {
+			if ((org - target.alignOfs) & target.alignMask)
 				errx("Section \"%s\" is defined with conflicting %d-byte alignment (offset %"
-				     PRIu16 ") and address $%04" PRIx16, other->name.c_str(),
-				     target->alignMask + 1, target->alignOfs, other->org);
+				     PRIu16 ") and address $%04" PRIx16, other.name.c_str(),
+				     target.alignMask + 1, target.alignOfs, other.org);
 		}
-		target->isAddressFixed = true;
-		target->org = org;
+		target.isAddressFixed = true;
+		target.org = org;
 
-	} else if (other->isAlignFixed) {
-		int32_t ofs = (other->alignOfs - target->size) % (other->alignMask + 1);
+	} else if (other.isAlignFixed) {
+		int32_t ofs = (other.alignOfs - target.size) % (other.alignMask + 1);
 
 		if (ofs < 0)
-			ofs += other->alignMask + 1;
+			ofs += other.alignMask + 1;
 
-		if (target->isAddressFixed) {
-			if ((target->org - ofs) & other->alignMask)
+		if (target.isAddressFixed) {
+			if ((target.org - ofs) & other.alignMask)
 				errx("Section \"%s\" is defined with conflicting address $%04"
 				     PRIx16 " and %d-byte alignment (offset %" PRIu16 ")",
-				     other->name.c_str(), target->org, other->alignMask + 1,
-				     other->alignOfs);
+				     other.name.c_str(), target.org, other.alignMask + 1,
+				     other.alignOfs);
 
-		} else if (target->isAlignFixed
-			&& (other->alignMask & target->alignOfs) != (target->alignMask & ofs)) {
+		} else if (target.isAlignFixed
+			&& (other.alignMask & target.alignOfs) != (target.alignMask & ofs)) {
 			errx("Section \"%s\" is defined with conflicting %d-byte alignment (offset %"
 			     PRIu16 ") and %d-byte alignment (offset %" PRIu16 ")",
-			     other->name.c_str(), target->alignMask + 1, target->alignOfs,
-			     other->alignMask + 1, other->alignOfs);
+			     other.name.c_str(), target.alignMask + 1, target.alignOfs,
+			     other.alignMask + 1, other.alignOfs);
 
-		} else if (!target->isAlignFixed || (other->alignMask > target->alignMask)) {
-			target->isAlignFixed = true;
-			target->alignMask = other->alignMask;
-			target->alignOfs = ofs;
+		} else if (!target.isAlignFixed || (other.alignMask > target.alignMask)) {
+			target.isAlignFixed = true;
+			target.alignMask = other.alignMask;
+			target.alignOfs = ofs;
 		}
 	}
 }
 
-static void mergeSections(Section *target, Section *other, enum SectionModifier mod)
+static void mergeSections(Section &target, Section &other, enum SectionModifier mod)
 {
 	// Common checks
 
-	if (target->type != other->type)
+	if (target.type != other.type)
 		errx("Section \"%s\" is defined with conflicting types %s and %s",
-		     other->name.c_str(), sectionTypeInfo[target->type].name.c_str(),
-		     sectionTypeInfo[other->type].name.c_str());
+		     other.name.c_str(), sectionTypeInfo[target.type].name.c_str(),
+		     sectionTypeInfo[other.type].name.c_str());
 
-	if (other->isBankFixed) {
-		if (!target->isBankFixed) {
-			target->isBankFixed = true;
-			target->bank = other->bank;
-		} else if (target->bank != other->bank) {
+	if (other.isBankFixed) {
+		if (!target.isBankFixed) {
+			target.isBankFixed = true;
+			target.bank = other.bank;
+		} else if (target.bank != other.bank) {
 			errx("Section \"%s\" is defined with conflicting banks %" PRIu32 " and %"
-			     PRIu32, other->name.c_str(), target->bank, other->bank);
+			     PRIu32, other.name.c_str(), target.bank, other.bank);
 		}
 	}
 
 	switch (mod) {
 	case SECTION_UNION:
 		checkSectUnionCompat(target, other);
-		if (other->size > target->size)
-			target->size = other->size;
+		if (other.size > target.size)
+			target.size = other.size;
 		break;
 
 	case SECTION_FRAGMENT:
@@ -138,16 +138,16 @@ static void mergeSections(Section *target, Section *other, enum SectionModifier 
 		// Append `other` to `target`
 		// Note that the order in which fragments are stored in the `nextu` list does not
 		// really matter, only that offsets are properly computed
-		other->offset = target->size;
-		target->size += other->size;
+		other.offset = target.size;
+		target.size += other.size;
 		// Normally we'd check that `sect_HasData`, but SDCC areas may be `_INVALID` here
-		if (!other->data.empty()) {
-			target->data.insert(target->data.end(), RANGE(other->data));
+		if (!other.data.empty()) {
+			target.data.insert(target.data.end(), RANGE(other.data));
 			// Adjust patches' PC offsets
-			for (Patch &patch : other->patches)
-				patch.pcOffset += other->offset;
-		} else if (!target->data.empty()) {
-			assert(other->size == 0);
+			for (Patch &patch : other.patches)
+				patch.pcOffset += other.offset;
+		} else if (!target.data.empty()) {
+			assert(other.size == 0);
 		}
 		break;
 
@@ -155,27 +155,27 @@ static void mergeSections(Section *target, Section *other, enum SectionModifier 
 		unreachable_();
 	}
 
-	other->nextu = target->nextu;
-	target->nextu = other;
+	other.nextu = target.nextu;
+	target.nextu = &other;
 }
 
-void sect_AddSection(Section *section)
+void sect_AddSection(Section &section)
 {
 	// Check if the section already exists
-	if (Section *other = sect_GetSection(section->name); other) {
-		if (section->modifier != other->modifier)
-			errx("Section \"%s\" defined as %s and %s", section->name.c_str(),
-			     sectionModNames[section->modifier], sectionModNames[other->modifier]);
-		else if (section->modifier == SECTION_NORMAL)
-			errx("Section name \"%s\" is already in use", section->name.c_str());
+	if (Section *other = sect_GetSection(section.name); other) {
+		if (section.modifier != other->modifier)
+			errx("Section \"%s\" defined as %s and %s", section.name.c_str(),
+			     sectionModNames[section.modifier], sectionModNames[other->modifier]);
+		else if (section.modifier == SECTION_NORMAL)
+			errx("Section name \"%s\" is already in use", section.name.c_str());
 		else
-			mergeSections(other, section, section->modifier);
-	} else if (section->modifier == SECTION_UNION && sect_HasData(section->type)) {
+			mergeSections(*other, section, section.modifier);
+	} else if (section.modifier == SECTION_UNION && sect_HasData(section.type)) {
 		errx("Section \"%s\" is of type %s, which cannot be unionized",
-		     section->name.c_str(), sectionTypeInfo[section->type].name.c_str());
+		     section.name.c_str(), sectionTypeInfo[section.type].name.c_str());
 	} else {
 		// If not, add it
-		sections[section->name] = section;
+		sections[section.name] = &section;
 	}
 }
 
@@ -185,84 +185,84 @@ Section *sect_GetSection(std::string const &name)
 	return search != sections.end() ? search->second : nullptr;
 }
 
-static void doSanityChecks(Section *section)
+static void doSanityChecks(Section &section)
 {
 	// Sanity check the section's type
-	if (section->type < 0 || section->type >= SECTTYPE_INVALID) {
-		error(nullptr, 0, "Section \"%s\" has an invalid type", section->name.c_str());
+	if (section.type < 0 || section.type >= SECTTYPE_INVALID) {
+		error(nullptr, 0, "Section \"%s\" has an invalid type", section.name.c_str());
 		return;
 	}
 
-	if (is32kMode && section->type == SECTTYPE_ROMX) {
-		if (section->isBankFixed && section->bank != 1)
+	if (is32kMode && section.type == SECTTYPE_ROMX) {
+		if (section.isBankFixed && section.bank != 1)
 			error(nullptr, 0, "%s: ROMX sections must be in bank 1 (if any) with option -t",
-			     section->name.c_str());
+			     section.name.c_str());
 		else
-			section->type = SECTTYPE_ROM0;
+			section.type = SECTTYPE_ROM0;
 	}
-	if (isWRAM0Mode && section->type == SECTTYPE_WRAMX) {
-		if (section->isBankFixed && section->bank != 1)
+	if (isWRAM0Mode && section.type == SECTTYPE_WRAMX) {
+		if (section.isBankFixed && section.bank != 1)
 			error(nullptr, 0, "%s: WRAMX sections must be in bank 1 with options -w or -d",
-			     section->name.c_str());
+			     section.name.c_str());
 		else
-			section->type = SECTTYPE_WRAM0;
+			section.type = SECTTYPE_WRAM0;
 	}
-	if (isDmgMode && section->type == SECTTYPE_VRAM && section->bank == 1)
+	if (isDmgMode && section.type == SECTTYPE_VRAM && section.bank == 1)
 		error(nullptr, 0, "%s: VRAM bank 1 can't be used with option -d",
-		     section->name.c_str());
+		     section.name.c_str());
 
 	// Check if alignment is reasonable, this is important to avoid UB
 	// An alignment of zero is equivalent to no alignment, basically
-	if (section->isAlignFixed && section->alignMask == 0)
-		section->isAlignFixed = false;
+	if (section.isAlignFixed && section.alignMask == 0)
+		section.isAlignFixed = false;
 
 	// Too large an alignment may not be satisfiable
-	if (section->isAlignFixed && (section->alignMask & sectionTypeInfo[section->type].startAddr))
+	if (section.isAlignFixed && (section.alignMask & sectionTypeInfo[section.type].startAddr))
 		error(nullptr, 0, "%s: %s sections cannot be aligned to $%04x bytes",
-		     section->name.c_str(), sectionTypeInfo[section->type].name.c_str(),
-		     section->alignMask + 1);
+		     section.name.c_str(), sectionTypeInfo[section.type].name.c_str(),
+		     section.alignMask + 1);
 
-	uint32_t minbank = sectionTypeInfo[section->type].firstBank, maxbank = sectionTypeInfo[section->type].lastBank;
+	uint32_t minbank = sectionTypeInfo[section.type].firstBank, maxbank = sectionTypeInfo[section.type].lastBank;
 
-	if (section->isBankFixed && section->bank < minbank && section->bank > maxbank)
+	if (section.isBankFixed && section.bank < minbank && section.bank > maxbank)
 		error(nullptr, 0, minbank == maxbank
 			? "Cannot place section \"%s\" in bank %" PRIu32 ", it must be %" PRIu32
 			: "Cannot place section \"%s\" in bank %" PRIu32 ", it must be between %" PRIu32 " and %" PRIu32,
-		     section->name.c_str(), section->bank, minbank, maxbank);
+		     section.name.c_str(), section.bank, minbank, maxbank);
 
 	// Check if section has a chance to be placed
-	if (section->size > sectionTypeInfo[section->type].size)
+	if (section.size > sectionTypeInfo[section.type].size)
 		error(nullptr, 0, "Section \"%s\" is bigger than the max size for that type: $%"
 		      PRIx16 " > $%" PRIx16,
-		      section->name.c_str(), section->size, sectionTypeInfo[section->type].size);
+		      section.name.c_str(), section.size, sectionTypeInfo[section.type].size);
 
 	// Translate loose constraints to strong ones when they're equivalent
 
 	if (minbank == maxbank) {
-		section->bank = minbank;
-		section->isBankFixed = true;
+		section.bank = minbank;
+		section.isBankFixed = true;
 	}
 
-	if (section->isAddressFixed) {
+	if (section.isAddressFixed) {
 		// It doesn't make sense to have both org and alignment set
-		if (section->isAlignFixed) {
-			if ((section->org & section->alignMask) != section->alignOfs)
+		if (section.isAlignFixed) {
+			if ((section.org & section.alignMask) != section.alignOfs)
 				error(nullptr, 0, "Section \"%s\"'s fixed address doesn't match its alignment",
-				     section->name.c_str());
-			section->isAlignFixed = false;
+				     section.name.c_str());
+			section.isAlignFixed = false;
 		}
 
 		// Ensure the target address is valid
-		if (section->org < sectionTypeInfo[section->type].startAddr
-		 || section->org > endaddr(section->type))
+		if (section.org < sectionTypeInfo[section.type].startAddr
+		 || section.org > endaddr(section.type))
 			error(nullptr, 0, "Section \"%s\"'s fixed address $%04" PRIx16 " is outside of range [$%04"
-			     PRIx16 "; $%04" PRIx16 "]", section->name.c_str(), section->org,
-			     sectionTypeInfo[section->type].startAddr, endaddr(section->type));
+			     PRIx16 "; $%04" PRIx16 "]", section.name.c_str(), section.org,
+			     sectionTypeInfo[section.type].startAddr, endaddr(section.type));
 
-		if (section->org + section->size > endaddr(section->type) + 1)
+		if (section.org + section.size > endaddr(section.type) + 1)
 			error(nullptr, 0, "Section \"%s\"'s end address $%04x is greater than last address $%04x",
-			      section->name.c_str(), section->org + section->size,
-			      endaddr(section->type) + 1);
+			      section.name.c_str(), section.org + section.size,
+			      endaddr(section.type) + 1);
 	}
 }
 

--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -13,20 +13,20 @@
 
 std::map<std::string, Symbol *> symbols;
 
-void sym_AddSymbol(Symbol *symbol)
+void sym_AddSymbol(Symbol &symbol)
 {
 	// Check if the symbol already exists
-	if (Symbol *other = sym_GetSymbol(symbol->name); other) {
-		fprintf(stderr, "error: \"%s\" both in %s from ", symbol->name.c_str(), symbol->objFileName);
-		symbol->src->dumpFileStack();
-		fprintf(stderr, "(%" PRIu32 ") and in %s from ", symbol->lineNo, other->objFileName);
+	if (Symbol *other = sym_GetSymbol(symbol.name); other) {
+		fprintf(stderr, "error: \"%s\" both in %s from ", symbol.name.c_str(), symbol.objFileName);
+		symbol.src->dumpFileStack();
+		fprintf(stderr, "(%" PRIu32 ") and in %s from ", symbol.lineNo, other->objFileName);
 		other->src->dumpFileStack();
 		fprintf(stderr, "(%" PRIu32 ")\n", other->lineNo);
 		exit(1);
 	}
 
 	// If not, add it
-	symbols[symbol->name] = symbol;
+	symbols[symbol.name] = &symbol;
 }
 
 Symbol *sym_GetSymbol(std::string const &name)


### PR DESCRIPTION
I didn't replace some pointers which are conventionally expected to be pointers (`char *` for strings, `FILE *` for files, etc). Pointers are also used for "optional references", because `std::optional<std::reference_wrapper<...>>` would be just too much.