### PR TITLE
Use uncommented sizes for pointer-to-array arguments

### DIFF
--- a/include/asm/symbol.hpp
+++ b/include/asm/symbol.hpp
@@ -70,7 +70,7 @@ void sym_SetExportAll(bool set);
 Symbol *sym_AddLocalLabel(char const *symName);
 Symbol *sym_AddLabel(char const *symName);
 Symbol *sym_AddAnonLabel();
-void sym_WriteAnonLabelName(char buf[/* MAXSYMLEN + 1 */], uint32_t ofs, bool neg);
+void sym_WriteAnonLabelName(char buf[MAXSYMLEN + 1], uint32_t ofs, bool neg);
 void sym_Export(char const *symName);
 Symbol *sym_AddEqu(char const *symName, int32_t value);
 Symbol *sym_RedefEqu(char const *symName, int32_t value);

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -493,7 +493,7 @@ Symbol *sym_AddAnonLabel()
 }
 
 // Write an anonymous label's name to a buffer
-void sym_WriteAnonLabelName(char buf[/* MAXSYMLEN + 1 */], uint32_t ofs, bool neg)
+void sym_WriteAnonLabelName(char buf[MAXSYMLEN + 1], uint32_t ofs, bool neg)
 {
 	uint32_t id = 0;
 

--- a/test/gfx/randtilegen.cpp
+++ b/test/gfx/randtilegen.cpp
@@ -75,7 +75,7 @@ static void generate_tile_attributes(Attributes *attributes) {
 	attributes->nbColors = popcount[pal];
 }
 
-static void generate_tile_data(unsigned char tiledata[/* 8 */][8], unsigned colorcount) {
+static void generate_tile_data(unsigned char tiledata[8][8], unsigned colorcount) {
 	switch (colorcount) {
 	case 2: // 1bpp
 		for (uint8_t y = 0; y < 8; y++) {
@@ -104,9 +104,8 @@ static void generate_tile_data(unsigned char tiledata[/* 8 */][8], unsigned colo
 	}
 }
 
-// Can't mark as `const`, as the array type is otherwise not compatible (augh)
 static void
-    copy_tile_data(unsigned char destination[/* 8 */][8], unsigned char /* const */ source[/* 8 */][8]) {
+    copy_tile_data(unsigned char destination[8][8], unsigned char const source[8][8]) {
 	// Apply a random rotation to the copy
 	// coord ^ 7 = inverted coordinate; coord ^ 0 = regular coordinate
 	unsigned xmask = getRandomBits(1) * 7;


### PR DESCRIPTION
This is syntactically valid despite not being enforced, and is a feature we already use elsewhere.