### PR TITLE
Use automatic allocation and `std::move` for RPN bytes

### DIFF
--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -27,13 +27,13 @@ struct Expression {
 
 void rpn_Number(Expression &expr, uint32_t val);
 void rpn_Symbol(Expression &expr, char const *symName);
-void rpn_LOGNOT(Expression &expr, Expression &src);
-void rpn_BinaryOp(RPNCommand op, Expression &expr, Expression &src1, const Expression &src2);
-void rpn_HIGH(Expression &expr, Expression &src);
-void rpn_LOW(Expression &expr, Expression &src);
+void rpn_LOGNOT(Expression &expr, Expression &&src);
+void rpn_BinaryOp(RPNCommand op, Expression &expr, Expression &&src1, const Expression &src2);
+void rpn_HIGH(Expression &expr, Expression &&src);
+void rpn_LOW(Expression &expr, Expression &&src);
 void rpn_ISCONST(Expression &expr, const Expression &src);
-void rpn_NEG(Expression &expr, Expression &src);
-void rpn_NOT(Expression &expr, Expression &src);
+void rpn_NEG(Expression &expr, Expression &&src);
+void rpn_NOT(Expression &expr, Expression &&src);
 void rpn_BankSymbol(Expression &expr, char const *symName);
 void rpn_BankSection(Expression &expr, char const *sectionName);
 void rpn_BankSelf(Expression &expr);

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -3,7 +3,6 @@
 #ifndef RGBDS_ASM_RPN_H
 #define RGBDS_ASM_RPN_H
 
-#include <memory>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -17,12 +16,17 @@ struct Expression {
 	std::string reason; // Why the expression is not known, if it isn't
 	bool isKnown;       // Whether the expression's value is known at assembly time
 	bool isSymbol;      // Whether the expression represents a symbol suitable for const diffing
-	std::unique_ptr<std::vector<uint8_t>> rpn; // Bytes serializing the RPN expression
-	uint32_t rpnPatchSize;                     // Size the expression will take in the object file
+	std::vector<uint8_t> rpn; // Bytes serializing the RPN expression
+	uint32_t rpnPatchSize;    // Size the expression will take in the object file
 
 	int32_t getConstVal() const;
 	Symbol const *symbolOf() const;
 	bool isDiffConstant(Symbol const *symName) const;
+
+	Expression() = default;
+	Expression(Expression &&) = default;
+
+	Expression &operator=(Expression &&) = default;
 };
 
 void rpn_Number(Expression &expr, uint32_t val);

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -25,6 +25,10 @@ struct Expression {
 
 	Expression() = default;
 	Expression(Expression &&) = default;
+#ifdef _MSC_VER
+	// MSVC and WinFlexBison won't build without this...
+	Expression(const Expression &) = default;
+#endif
 
 	Expression &operator=(Expression &&) = default;
 };

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -3,6 +3,7 @@
 #ifndef RGBDS_ASM_RPN_H
 #define RGBDS_ASM_RPN_H
 
+#include <memory>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -16,8 +17,8 @@ struct Expression {
 	std::string reason; // Why the expression is not known, if it isn't
 	bool isKnown;       // Whether the expression's value is known at assembly time
 	bool isSymbol;      // Whether the expression represents a symbol suitable for const diffing
-	std::vector<uint8_t> *rpn; // Bytes serializing the RPN expression
-	uint32_t rpnPatchSize;     // Size the expression will take in the object file
+	std::unique_ptr<std::vector<uint8_t>> rpn; // Bytes serializing the RPN expression
+	uint32_t rpnPatchSize;                     // Size the expression will take in the object file
 
 	int32_t getConstVal() const;
 	Symbol const *symbolOf() const;
@@ -26,13 +27,13 @@ struct Expression {
 
 void rpn_Number(Expression &expr, uint32_t val);
 void rpn_Symbol(Expression &expr, char const *symName);
-void rpn_LOGNOT(Expression &expr, const Expression &src);
-void rpn_BinaryOp(RPNCommand op, Expression &expr, const Expression &src1, const Expression &src2);
-void rpn_HIGH(Expression &expr, const Expression &src);
-void rpn_LOW(Expression &expr, const Expression &src);
+void rpn_LOGNOT(Expression &expr, Expression &src);
+void rpn_BinaryOp(RPNCommand op, Expression &expr, Expression &src1, const Expression &src2);
+void rpn_HIGH(Expression &expr, Expression &src);
+void rpn_LOW(Expression &expr, Expression &src);
 void rpn_ISCONST(Expression &expr, const Expression &src);
-void rpn_NEG(Expression &expr, const Expression &src);
-void rpn_NOT(Expression &expr, const Expression &src);
+void rpn_NEG(Expression &expr, Expression &src);
+void rpn_NOT(Expression &expr, Expression &src);
 void rpn_BankSymbol(Expression &expr, char const *symName);
 void rpn_BankSection(Expression &expr, char const *sectionName);
 void rpn_BankSelf(Expression &expr);
@@ -43,8 +44,8 @@ void rpn_StartOfSectionType(Expression &expr, SectionType type);
 
 void rpn_Free(Expression &expr);
 
-void rpn_CheckHRAM(Expression &expr, const Expression &src);
-void rpn_CheckRST(Expression &expr, const Expression &src);
-void rpn_CheckNBit(Expression const &expr, uint8_t n);
+void rpn_CheckHRAM(Expression &expr);
+void rpn_CheckRST(Expression &expr);
+void rpn_CheckNBit(const Expression &expr, uint8_t n);
 
 #endif // RGBDS_ASM_RPN_H

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -276,7 +276,7 @@ static void initpatch(Patch &patch, uint32_t type, Expression const &expr, uint3
 		patch.rpn[4] = (uint32_t)expr.val >> 24;
 	} else {
 		patch.rpn.resize(expr.rpnPatchSize);
-		writerpn(patch.rpn, *expr.rpn);
+		writerpn(patch.rpn, expr.rpn);
 	}
 }
 

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -968,11 +968,11 @@ ds:
 
 ds_args:
 	reloc_8bit {
-		$$.push_back($1);
+		$$.push_back(std::move($1));
 	}
 	| ds_args COMMA reloc_8bit {
-		$1.push_back($3);
-		$$ = $1;
+		$1.push_back(std::move($3));
+		$$ = std::move($1);
 	}
 ;
 
@@ -1243,21 +1243,21 @@ constlist_32bit_entry:
 reloc_8bit:
 	relocexpr {
 		rpn_CheckNBit($1, 8);
-		$$ = $1;
+		$$ = std::move($1);
 	}
 ;
 
 reloc_8bit_no_str:
 	relocexpr_no_str {
 		rpn_CheckNBit($1, 8);
-		$$ = $1;
+		$$ = std::move($1);
 	}
 ;
 
 reloc_8bit_offset:
 	OP_ADD relocexpr {
 		rpn_CheckNBit($2, 8);
-		$$ = $2;
+		$$ = std::move($2);
 	}
 	| OP_SUB relocexpr {
 		rpn_NEG($$, $2);
@@ -1268,19 +1268,21 @@ reloc_8bit_offset:
 reloc_16bit:
 	relocexpr {
 		rpn_CheckNBit($1, 16);
-		$$ = $1;
+		$$ = std::move($1);
 	}
 ;
 
 reloc_16bit_no_str:
 	relocexpr_no_str {
 		rpn_CheckNBit($1, 16);
-		$$ = $1;
+		$$ = std::move($1);
 	}
 ;
 
 relocexpr:
-	  relocexpr_no_str
+	relocexpr_no_str {
+		$$ = std::move($1);
+	}
 	| string {
 		std::vector<uint8_t> output;
 
@@ -1360,7 +1362,7 @@ relocexpr_no_str:
 		rpn_BinaryOp(RPN_EXP, $$, $1, $3);
 	}
 	| OP_ADD relocexpr %prec NEG {
-		$$ = $2;
+		$$ = std::move($2);
 	}
 	| OP_SUB relocexpr %prec NEG {
 		rpn_NEG($$, $2);
@@ -1470,7 +1472,7 @@ relocexpr_no_str:
 		rpn_Number($$, charmap_HasChar($3.string));
 	}
 	| LPAREN relocexpr RPAREN {
-		$$ = $2;
+		$$ = std::move($2);
 	}
 ;
 
@@ -1904,13 +1906,13 @@ z80_ldd:
 
 z80_ldio:
 	Z80_LDH MODE_A COMMA op_mem_ind {
-		rpn_CheckHRAM($4, $4);
+		rpn_CheckHRAM($4);
 
 		sect_AbsByte(0xF0);
 		sect_RelByte($4, 1);
 	}
 	| Z80_LDH op_mem_ind COMMA MODE_A {
-		rpn_CheckHRAM($2, $2);
+		rpn_CheckHRAM($2);
 
 		sect_AbsByte(0xE0);
 		sect_RelByte($2, 1);
@@ -2166,7 +2168,7 @@ z80_rrca:
 
 z80_rst:
 	Z80_RST reloc_8bit {
-		rpn_CheckRST($2, $2);
+		rpn_CheckRST($2);
 		if (!$2.isKnown)
 			sect_RelByte($2, 0);
 		else
@@ -2261,7 +2263,7 @@ z80_xor:
 
 op_mem_ind:
 	LBRACK reloc_16bit RBRACK {
-		$$ = $2;
+		$$ = std::move($2);
 	}
 ;
 
@@ -2273,9 +2275,11 @@ op_a_r:
 ;
 
 op_a_n:
-	  reloc_8bit
+	reloc_8bit {
+		$$ = std::move($1);
+	}
 	| MODE_A COMMA reloc_8bit {
-		$$ = $3;
+		$$ = std::move($3);
 	}
 ;
 

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -1260,7 +1260,7 @@ reloc_8bit_offset:
 		$$ = std::move($2);
 	}
 	| OP_SUB relocexpr {
-		rpn_NEG($$, $2);
+		rpn_NEG($$, std::move($2));
 		rpn_CheckNBit($$, 8);
 	}
 ;
@@ -1299,82 +1299,82 @@ relocexpr_no_str:
 		rpn_Number($$, $1);
 	}
 	| OP_LOGICNOT relocexpr %prec NEG {
-		rpn_LOGNOT($$, $2);
+		rpn_LOGNOT($$, std::move($2));
 	}
 	| relocexpr OP_LOGICOR relocexpr {
-		rpn_BinaryOp(RPN_LOGOR, $$, $1, $3);
+		rpn_BinaryOp(RPN_LOGOR, $$, std::move($1), $3);
 	}
 	| relocexpr OP_LOGICAND relocexpr {
-		rpn_BinaryOp(RPN_LOGAND, $$, $1, $3);
+		rpn_BinaryOp(RPN_LOGAND, $$, std::move($1), $3);
 	}
 	| relocexpr OP_LOGICEQU relocexpr {
-		rpn_BinaryOp(RPN_LOGEQ, $$, $1, $3);
+		rpn_BinaryOp(RPN_LOGEQ, $$, std::move($1), $3);
 	}
 	| relocexpr OP_LOGICGT relocexpr {
-		rpn_BinaryOp(RPN_LOGGT, $$, $1, $3);
+		rpn_BinaryOp(RPN_LOGGT, $$, std::move($1), $3);
 	}
 	| relocexpr OP_LOGICLT relocexpr {
-		rpn_BinaryOp(RPN_LOGLT, $$, $1, $3);
+		rpn_BinaryOp(RPN_LOGLT, $$, std::move($1), $3);
 	}
 	| relocexpr OP_LOGICGE relocexpr {
-		rpn_BinaryOp(RPN_LOGGE, $$, $1, $3);
+		rpn_BinaryOp(RPN_LOGGE, $$, std::move($1), $3);
 	}
 	| relocexpr OP_LOGICLE relocexpr {
-		rpn_BinaryOp(RPN_LOGLE, $$, $1, $3);
+		rpn_BinaryOp(RPN_LOGLE, $$, std::move($1), $3);
 	}
 	| relocexpr OP_LOGICNE relocexpr {
-		rpn_BinaryOp(RPN_LOGNE, $$, $1, $3);
+		rpn_BinaryOp(RPN_LOGNE, $$, std::move($1), $3);
 	}
 	| relocexpr OP_ADD relocexpr {
-		rpn_BinaryOp(RPN_ADD, $$, $1, $3);
+		rpn_BinaryOp(RPN_ADD, $$, std::move($1), $3);
 	}
 	| relocexpr OP_SUB relocexpr {
-		rpn_BinaryOp(RPN_SUB, $$, $1, $3);
+		rpn_BinaryOp(RPN_SUB, $$, std::move($1), $3);
 	}
 	| relocexpr OP_XOR relocexpr {
-		rpn_BinaryOp(RPN_XOR, $$, $1, $3);
+		rpn_BinaryOp(RPN_XOR, $$, std::move($1), $3);
 	}
 	| relocexpr OP_OR relocexpr {
-		rpn_BinaryOp(RPN_OR, $$, $1, $3);
+		rpn_BinaryOp(RPN_OR, $$, std::move($1), $3);
 	}
 	| relocexpr OP_AND relocexpr {
-		rpn_BinaryOp(RPN_AND, $$, $1, $3);
+		rpn_BinaryOp(RPN_AND, $$, std::move($1), $3);
 	}
 	| relocexpr OP_SHL relocexpr {
-		rpn_BinaryOp(RPN_SHL, $$, $1, $3);
+		rpn_BinaryOp(RPN_SHL, $$, std::move($1), $3);
 	}
 	| relocexpr OP_SHR relocexpr {
-		rpn_BinaryOp(RPN_SHR, $$, $1, $3);
+		rpn_BinaryOp(RPN_SHR, $$, std::move($1), $3);
 	}
 	| relocexpr OP_USHR relocexpr {
-		rpn_BinaryOp(RPN_USHR, $$, $1, $3);
+		rpn_BinaryOp(RPN_USHR, $$, std::move($1), $3);
 	}
 	| relocexpr OP_MUL relocexpr {
-		rpn_BinaryOp(RPN_MUL, $$, $1, $3);
+		rpn_BinaryOp(RPN_MUL, $$, std::move($1), $3);
 	}
 	| relocexpr OP_DIV relocexpr {
-		rpn_BinaryOp(RPN_DIV, $$, $1, $3);
+		rpn_BinaryOp(RPN_DIV, $$, std::move($1), $3);
 	}
 	| relocexpr OP_MOD relocexpr {
-		rpn_BinaryOp(RPN_MOD, $$, $1, $3);
+		rpn_BinaryOp(RPN_MOD, $$, std::move($1), $3);
 	}
 	| relocexpr OP_EXP relocexpr {
-		rpn_BinaryOp(RPN_EXP, $$, $1, $3);
+		rpn_BinaryOp(RPN_EXP, $$, std::move($1), $3);
 	}
 	| OP_ADD relocexpr %prec NEG {
 		$$ = std::move($2);
 	}
 	| OP_SUB relocexpr %prec NEG {
-		rpn_NEG($$, $2);
+		rpn_NEG($$, std::move($2));
 	}
 	| OP_NOT relocexpr %prec NEG {
-		rpn_NOT($$, $2);
+		rpn_NOT($$, std::move($2));
 	}
 	| OP_HIGH LPAREN relocexpr RPAREN {
-		rpn_HIGH($$, $3);
+		rpn_HIGH($$, std::move($3));
 	}
 	| OP_LOW LPAREN relocexpr RPAREN {
-		rpn_LOW($$, $3);
+		rpn_LOW($$, std::move($3));
 	}
 	| OP_ISCONST LPAREN relocexpr RPAREN {
 		rpn_ISCONST($$, $3);
@@ -2733,7 +2733,7 @@ static void compoundAssignment(const char *symName, RPNCommand op, int32_t const
 
 	rpn_Symbol(oldExpr, symName);
 	rpn_Number(constExpr, constValue);
-	rpn_BinaryOp(op, newExpr, oldExpr, constExpr);
+	rpn_BinaryOp(op, newExpr, std::move(oldExpr), constExpr);
 	newValue = newExpr.getConstVal();
 	sym_AddVar(symName, newValue);
 }

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -267,7 +267,7 @@ int32_t Expression::getConstVal() const {
 	return val;
 }
 
-void rpn_LOGNOT(Expression &expr, Expression &src) {
+void rpn_LOGNOT(Expression &expr, Expression &&src) {
 	expr = std::move(src);
 	expr.isSymbol = false;
 
@@ -337,7 +337,7 @@ static int32_t tryConstMask(Expression const &lhs, Expression const &rhs) {
 	return (symbolOfs + sect.alignOfs) & ~unknownBits;
 }
 
-void rpn_BinaryOp(RPNCommand op, Expression &expr, Expression &src1, const Expression &src2) {
+void rpn_BinaryOp(RPNCommand op, Expression &expr, Expression &&src1, const Expression &src2) {
 	initExpression(expr);
 	expr.isSymbol = false;
 	int32_t constMaskVal;
@@ -556,7 +556,7 @@ void rpn_BinaryOp(RPNCommand op, Expression &expr, Expression &src1, const Expre
 	}
 }
 
-void rpn_HIGH(Expression &expr, Expression &src) {
+void rpn_HIGH(Expression &expr, Expression &&src) {
 	expr = std::move(src);
 	expr.isSymbol = false;
 
@@ -569,7 +569,7 @@ void rpn_HIGH(Expression &expr, Expression &src) {
 	}
 }
 
-void rpn_LOW(Expression &expr, Expression &src) {
+void rpn_LOW(Expression &expr, Expression &&src) {
 	expr = std::move(src);
 	expr.isSymbol = false;
 
@@ -590,7 +590,7 @@ void rpn_ISCONST(Expression &expr, const Expression &src) {
 	expr.isSymbol = false;
 }
 
-void rpn_NEG(Expression &expr, Expression &src) {
+void rpn_NEG(Expression &expr, Expression &&src) {
 	expr = std::move(src);
 	expr.isSymbol = false;
 
@@ -602,7 +602,7 @@ void rpn_NEG(Expression &expr, Expression &src) {
 	}
 }
 
-void rpn_NOT(Expression &expr, Expression &src) {
+void rpn_NOT(Expression &expr, Expression &&src) {
 	expr = std::move(src);
 	expr.isSymbol = false;
 


### PR DESCRIPTION
Without the copy constructor, MSVC would give this build error:
```
6>D:\a\rgbds\rgbds\src\asm\parser.hpp(286,35): error C2280: 'Expression::Expression(const Expression &)': attempting to reference a deleted function [D:\a\rgbds\rgbds\build\src\rgbasm.vcxproj]
    (compiling source file '../../src/asm/parser.cpp')
    D:\a\rgbds\rgbds\include\asm\rpn.hpp(30,1):
    compiler has generated 'Expression::Expression' here
    D:\a\rgbds\rgbds\include\asm\rpn.hpp(30,1):
    'Expression::Expression(const Expression &)': function was implicitly deleted because 'Expression' has a user-defined move constructor
    D:\a\rgbds\rgbds\src\asm\parser.hpp(286,35):
    the template instantiation context (the oldest one first) is
    	D:\a\rgbds\rgbds\src\asm\parser.cpp(274,14):
    	see reference to function template instantiation 'void yy::parser::value_type::copy<Expression>(const yy::parser::value_type::self_type &)' being compiled
    	D:\a\rgbds\rgbds\src\asm\parser.hpp(371,7):
    	see reference to function template instantiation 'T &yy::parser::value_type::emplace<Expression>(const T &)' being compiled
            with
            [
                T=Expression
            ]
```

I can't tell what the problem with WinFlexBison is here.