### PR TITLE
Allow multiple identical exported numeric constants

### DIFF
--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -26,8 +26,12 @@ Label const &Symbol::label() const {
 }
 
 void sym_AddSymbol(Symbol &symbol) {
-	// Check if the symbol already exists
-	if (Symbol *other = sym_GetSymbol(symbol.name); other) {
+	Symbol *other = sym_GetSymbol(symbol.name);
+	int32_t const *symValue = std::get_if<int32_t>(&symbol.data);
+	int32_t const *otherValue = other ? std::get_if<int32_t>(&other->data) : nullptr;
+
+	// Check if the symbol already exists with a different value
+	if (other && !(symValue && otherValue && *symValue == *otherValue)) {
 		fprintf(stderr, "error: \"%s\" both in %s from ", symbol.name.c_str(), symbol.objFileName);
 		symbol.src->dump(symbol.lineNo);
 		fprintf(stderr, " and in %s from ", other->objFileName);
@@ -36,7 +40,7 @@ void sym_AddSymbol(Symbol &symbol) {
 		exit(1);
 	}
 
-	// If not, add it
+	// If not, add it (potentially replacing the previous same-value symbol)
 	symbols[symbol.name] = &symbol;
 }
 

--- a/test/link/same-consts/a.asm
+++ b/test/link/same-consts/a.asm
@@ -1,0 +1,2 @@
+def constant equ 42
+export constant

--- a/test/link/same-consts/b.asm
+++ b/test/link/same-consts/b.asm
@@ -1,0 +1,2 @@
+def constant equ 42
+export constant

--- a/test/link/test.sh
+++ b/test/link/test.sh
@@ -190,6 +190,15 @@ tryDiff "$test"/out.err "$outtemp"
 tryCmp "$test"/out.gb "$gbtemp"
 evaluateTest
 
+test="same-consts"
+startTest
+"$RGBASM" -o "$otemp" "$test"/a.asm
+"$RGBASM" -o "$gbtemp2" "$test"/b.asm
+continueTest
+rgblinkQuiet -o "$gbtemp" "$gbtemp2" "$otemp" 2>"$outtemp"
+tryDiff "$test"/out.err "$outtemp"
+evaluateTest
+
 test="scramble-romx"
 startTest
 "$RGBASM" -o "$otemp" "$test"/a.asm


### PR DESCRIPTION
This does not allow identical exported label constants, which *is* possible using a WRAM SECTION UNION. That can be addressed when or if it's requested for a real use case.

Symbols only store one source filename + line number, so this arbitrarily keeps the last read symbol as the reported one.

Fixes #1340