### PR TITLE
Reduce the header declarations

### DIFF
--- a/include/extern/utf8decoder.hpp
+++ b/include/extern/utf8decoder.hpp
@@ -3,6 +3,8 @@
 #ifndef EXTERN_UTF8DECODER_H
 #define EXTERN_UTF8DECODER_H
 
+#include <stdint.h>
+
 uint32_t decode(uint32_t *state, uint32_t *codep, uint8_t byte);
 
 #endif // EXTERN_UTF8DECODER_H

--- a/include/gfx/rgba.hpp
+++ b/include/gfx/rgba.hpp
@@ -3,7 +3,6 @@
 #ifndef RGBDS_GFX_RGBA_HPP
 #define RGBDS_GFX_RGBA_HPP
 
-#include <cstdint>
 #include <stdint.h>
 
 struct Rgba {

--- a/include/itertools.hpp
+++ b/include/itertools.hpp
@@ -3,16 +3,8 @@
 #ifndef RGBDS_ITERTOOLS_HPP
 #define RGBDS_ITERTOOLS_HPP
 
-#include <stdio.h>
 #include <tuple>
 #include <utility>
-
-#include "platform.hpp" // __PRETTY_FUNCTION__
-
-template<typename... Ts>
-static inline void report() {
-	puts(__PRETTY_FUNCTION__);
-}
 
 template<typename T>
 class EnumSeqIterator {

--- a/include/itertools.hpp
+++ b/include/itertools.hpp
@@ -3,6 +3,7 @@
 #ifndef RGBDS_ITERTOOLS_HPP
 #define RGBDS_ITERTOOLS_HPP
 
+#include <stdio.h>
 #include <tuple>
 #include <utility>
 

--- a/include/link/assign.hpp
+++ b/include/link/assign.hpp
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-// Assigning all sections a place
 #ifndef RGBDS_LINK_ASSIGN_H
 #define RGBDS_LINK_ASSIGN_H
 

--- a/include/link/main.hpp
+++ b/include/link/main.hpp
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-// Declarations that all modules use, as well as `main` and related
 #ifndef RGBDS_LINK_MAIN_H
 #define RGBDS_LINK_MAIN_H
 

--- a/include/link/object.hpp
+++ b/include/link/object.hpp
@@ -1,7 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-// Declarations related to processing of object (.o) files
-
 #ifndef RGBDS_LINK_OBJECT_H
 #define RGBDS_LINK_OBJECT_H
 

--- a/include/link/output.hpp
+++ b/include/link/output.hpp
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-// Outputting the result of linking
 #ifndef RGBDS_LINK_OUTPUT_H
 #define RGBDS_LINK_OUTPUT_H
 

--- a/include/link/patch.hpp
+++ b/include/link/patch.hpp
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-// Applying patches to SECTIONs
 #ifndef RGBDS_LINK_PATCH_H
 #define RGBDS_LINK_PATCH_H
 

--- a/include/link/sdas_obj.hpp
+++ b/include/link/sdas_obj.hpp
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-// Assigning all sections a place
 #ifndef RGBDS_LINK_SDAS_OBJ_H
 #define RGBDS_LINK_SDAS_OBJ_H
 

--- a/include/link/section.hpp
+++ b/include/link/section.hpp
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-// Declarations manipulating symbols
 #ifndef RGBDS_LINK_SECTION_H
 #define RGBDS_LINK_SECTION_H
 

--- a/include/link/symbol.hpp
+++ b/include/link/symbol.hpp
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-// Declarations manipulating symbols
 #ifndef RGBDS_LINK_SYMBOL_H
 #define RGBDS_LINK_SYMBOL_H
 

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -22,15 +22,6 @@
 	#define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
 #endif
 
-// gcc has __PRETTY_FUNCTION__, MSVC has __FUNCSIG__, __func__ is standard
-#ifndef __PRETTY_FUNCTION__
-	#ifdef __FUNCSIG__
-		#define __PRETTY_FUNCTION__ __FUNCSIG__
-	#else
-		#define __PRETTY_FUNCTION__ __func__
-	#endif
-#endif
-
 // MSVC doesn't use POSIX types or defines for `read`
 #ifdef _MSC_VER
 	#include <io.h>

--- a/src/asm/charmap.cpp
+++ b/src/asm/charmap.cpp
@@ -5,12 +5,10 @@
 #include <errno.h>
 #include <map>
 #include <stack>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <string>
-#include <vector>
 
 #include "util.hpp"
 

--- a/src/asm/fixpoint.cpp
+++ b/src/asm/fixpoint.cpp
@@ -4,9 +4,7 @@
 
 #include "asm/fixpoint.hpp"
 
-#include <inttypes.h>
 #include <math.h>
-#include <stdint.h>
 
 #include "asm/symbol.hpp"
 #include "asm/warning.hpp"

--- a/src/asm/format.cpp
+++ b/src/asm/format.cpp
@@ -6,7 +6,6 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <math.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -8,13 +8,8 @@
 #include <new>
 #include <optional>
 #include <stack>
-#include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string>
 #include <string_view>
-#include <variant>
-#include <vector>
 
 #include "error.hpp"
 #include "platform.hpp" // S_ISDIR (stat macro)

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -11,20 +11,15 @@
 #include <limits.h>
 #include <math.h>
 #include <new>
-#include <optional>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <string>
 #include <unordered_map>
-#include <variant>
-#include <vector>
 #ifndef _MSC_VER
 	#include <unistd.h>
 #endif
 
-#include "platform.hpp" // For `ssize_t` and `AT`
 #include "util.hpp"
 
 #include "asm/fixpoint.hpp"

--- a/src/asm/macro.cpp
+++ b/src/asm/macro.cpp
@@ -6,11 +6,7 @@
 #include <inttypes.h>
 #include <new>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <vector>
-
-#include "asm/warning.hpp"
 
 #define MAXMACROARGS 99999
 

--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -9,16 +9,12 @@
 #include <limits.h>
 #include <math.h>
 #include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <string>
 #include <time.h>
 
 #include "error.hpp"
 #include "extern/getopt.hpp"
-#include "helpers.hpp"
 #include "parser.hpp"
 #include "version.hpp"
 

--- a/src/asm/opt.cpp
+++ b/src/asm/opt.cpp
@@ -3,7 +3,6 @@
 #include <ctype.h>
 #include <errno.h>
 #include <stack>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -1,7 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-// Outputs an objectfile
-
 #include "asm/output.hpp"
 
 #include <algorithm>
@@ -9,7 +7,6 @@
 #include <deque>
 #include <errno.h>
 #include <inttypes.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -17,7 +14,6 @@
 #include <vector>
 
 #include "error.hpp"
-#include "linkdefs.hpp"
 
 #include "asm/charmap.hpp"
 #include "asm/fstack.hpp"

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -1,7 +1,5 @@
 /* SPDX-License-Identifier: MIT */
 
-// Controls RPN expressions for objectfiles
-
 #include "asm/rpn.hpp"
 
 #include <assert.h>
@@ -9,11 +7,9 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <new>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <vector>
 
 #include "opmath.hpp"
 

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <deque>
 #include <errno.h>
 #include <inttypes.h>
 #include <optional>
@@ -13,10 +12,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <string>
-#include <vector>
 
 #include "error.hpp"
-#include "linkdefs.hpp"
 
 #include "asm/fstack.hpp"
 #include "asm/main.hpp"

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -8,14 +8,7 @@
 #include <limits.h>
 #include <map>
 #include <new>
-#include <optional>
-#include <stdint.h>
 #include <stdio.h>
-#include <string.h>
-#include <string>
-#include <string_view>
-#include <time.h>
-#include <variant>
 
 #include "error.hpp"
 #include "helpers.hpp"
@@ -27,7 +20,6 @@
 #include "asm/macro.hpp"
 #include "asm/main.hpp"
 #include "asm/output.hpp"
-#include "asm/section.hpp"
 #include "asm/warning.hpp"
 
 std::map<std::string, Symbol> symbols;

--- a/src/extern/utf8decoder.cpp
+++ b/src/extern/utf8decoder.cpp
@@ -2,7 +2,7 @@
 
 /* UTF-8 decoder: http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ */
 
-#include <stdint.h>
+#include "extern/utf8decoder.hpp"
 
 static const uint8_t utf8d[] = {
     0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 00..0f */

--- a/src/gfx/main.cpp
+++ b/src/gfx/main.cpp
@@ -4,15 +4,13 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <cinttypes>
-#include <cstdint>
 #include <ctype.h>
 #include <fstream>
+#include <inttypes.h>
 #include <ios>
 #include <limits>
 #include <numeric>
 #include <stdarg.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -27,7 +25,6 @@
 #include "gfx/pal_spec.hpp"
 #include "gfx/process.hpp"
 #include "gfx/reverse.hpp"
-#include "gfx/rgba.hpp"
 
 using namespace std::literals::string_view_literals;
 

--- a/src/gfx/pal_packing.cpp
+++ b/src/gfx/pal_packing.cpp
@@ -5,20 +5,16 @@
 #include <algorithm>
 #include <assert.h>
 #include <bitset>
-#include <cinttypes>
 #include <deque>
+#include <inttypes.h>
 #include <numeric>
 #include <optional>
 #include <queue>
-#include <tuple>
 #include <type_traits>
 #include <unordered_set>
-#include <vector>
 
-#include "defaultinitalloc.hpp"
 #include "helpers.hpp"
 
-#include "gfx/main.hpp"
 #include "gfx/proto_palette.hpp"
 
 using std::swap;

--- a/src/gfx/pal_sorting.cpp
+++ b/src/gfx/pal_sorting.cpp
@@ -3,8 +3,6 @@
 #include "gfx/pal_sorting.hpp"
 
 #include <algorithm>
-#include <png.h>
-#include <vector>
 
 #include "helpers.hpp"
 

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -3,20 +3,19 @@
 #include "gfx/pal_spec.hpp"
 
 #include <algorithm>
-#include <cassert>
+#include <assert.h>
 #include <charconv>
-#include <cinttypes>
-#include <climits>
-#include <cstdint>
-#include <cstdio>
-#include <cstring>
 #include <fstream>
-#include <limits>
+#include <inttypes.h>
+#include <limits.h>
 #include <optional>
 #include <ostream>
+#include <stdint.h>
+#include <stdio.h>
 #include <streambuf>
-#include <string>
+#include <string.h>
 #include <string_view>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -4,16 +4,16 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <cinttypes>
-#include <climits>
-#include <cstdio>
 #include <errno.h>
 #include <fstream>
+#include <inttypes.h>
+#include <limits.h>
 #include <memory>
 #include <optional>
 #include <png.h>
 #include <setjmp.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 #include <tuple>
 #include <unordered_set>

--- a/src/gfx/proto_palette.cpp
+++ b/src/gfx/proto_palette.cpp
@@ -2,11 +2,7 @@
 
 #include "gfx/proto_palette.hpp"
 
-#include <algorithm>
-#include <array>
-#include <cassert>
-#include <stddef.h>
-#include <stdint.h>
+#include <assert.h>
 
 #include "helpers.hpp"
 

--- a/src/gfx/reverse.cpp
+++ b/src/gfx/reverse.cpp
@@ -5,9 +5,9 @@
 #include <algorithm>
 #include <array>
 #include <assert.h>
-#include <cinttypes>
 #include <errno.h>
 #include <fstream>
+#include <inttypes.h>
 #include <optional>
 #include <png.h>
 #include <string.h>

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -7,18 +7,12 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <string>
-#include <variant>
-#include <vector>
 
 #include "error.hpp"
 #include "extern/getopt.hpp"
 #include "itertools.hpp"
-#include "linkdefs.hpp"
 #include "platform.hpp"
 #include "script.hpp"
 #include "version.hpp"

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -6,7 +6,6 @@
 #include <assert.h>
 #include <deque>
 #include <inttypes.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -18,7 +17,6 @@
 #include "linkdefs.hpp"
 
 #include "link/main.hpp"
-#include "link/section.hpp"
 #include "link/symbol.hpp"
 
 #define BANK_SIZE 0x4000

--- a/src/link/patch.cpp
+++ b/src/link/patch.cpp
@@ -3,7 +3,6 @@
 #include "link/patch.hpp"
 
 #include <assert.h>
-#include <deque>
 #include <inttypes.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -12,12 +11,10 @@
 
 #include "error.hpp"
 #include "helpers.hpp"
-#include "linkdefs.hpp"
 #include "opmath.hpp"
 #include "platform.hpp"
 
 #include "link/object.hpp"
-#include "link/section.hpp"
 #include "link/symbol.hpp"
 
 struct RPNStackEntry {

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -17,8 +17,8 @@
 	#include <array>
 	#include <assert.h>
 	#include <bit>
-	#include <cinttypes>
 	#include <fstream>
+	#include <inttypes.h>
 	#include <locale>
 	#include <stdio.h>
 	#include <string_view>

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -8,12 +8,10 @@
 #include <inttypes.h>
 #include <memory>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <tuple>
 #include <variant>
-#include <vector>
 
 #include "helpers.hpp"
 #include "linkdefs.hpp"

--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -5,15 +5,10 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <map>
-#include <memory>
 #include <stdlib.h>
 #include <string.h>
-#include <string>
 
 #include "error.hpp"
-#include "linkdefs.hpp"
-
-#include "link/main.hpp"
 
 std::map<std::string, std::unique_ptr<Section>> sections;
 

--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -5,8 +5,6 @@
 #include <inttypes.h>
 #include <map>
 #include <stdlib.h>
-#include <string>
-#include <variant>
 
 #include "error.hpp"
 #include "helpers.hpp"


### PR DESCRIPTION
- Since we have style rules to include foo.hpp at the top of its corresponding foo.cpp, this takes any headers included by foo.hpp as being also guaranteed for foo.cpp.

- Use C-style `<foo.h>` instead of `<cfoo>`, since the latter only guarantees putting symbols in the `std` namespace, which we are not using for C functions (e.g. `printf` not `std::printf`).