### PR TITLE
Strip release binaries built with `make`

### DIFF
--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           export PATH="/usr/local/opt/bison/bin:$PATH"
           make -j CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
+          strip rgb{asm,link,fix,gfx}
       - name: Package binaries
         run: |
           zip --junk-paths rgbds-${{ env.version }}-macos-x86_64.zip rgb{asm,link,fix,gfx} man/* .github/scripts/install.sh
@@ -108,7 +109,8 @@ jobs:
           ./.github/scripts/install_deps.sh ubuntu-20.04
       - name: Build binaries
         run: |
-          make -j WARNFLAGS="-Wall -Wextra -pedantic  -static" PKG_CONFIG="pkg-config --static" Q=
+          make -j WARNFLAGS="-Wall -Wextra -pedantic -static" PKG_CONFIG="pkg-config --static" Q=
+          strip rgb{asm,link,fix,gfx}
       - name: Package binaries
         run: |
           tar caf rgbds-${{ env.version }}-linux-x86_64.tar.xz --transform='s#.*/##' rgb{asm,link,fix,gfx} man/* .github/scripts/install.sh


### PR DESCRIPTION
Fixes #1344

The `cmake` builds already use [`--strip`](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-install-strip), so this just puts the typical `make` build on an even footing.

This only affects release binaries, not CI ones (for which `cmake` did not have `--strip` anyway).