### PR TITLE
Use `std::string` for most intermediate parsed strings

### DIFF
--- a/include/asm/charmap.hpp
+++ b/include/asm/charmap.hpp
@@ -4,17 +4,18 @@
 #define RGBDS_ASM_CHARMAP_H
 
 #include <stdint.h>
+#include <string>
 #include <vector>
 
 #define DEFAULT_CHARMAP_NAME "main"
 
-void charmap_New(char const *name, char const *baseName);
-void charmap_Set(char const *name);
+void charmap_New(std::string const &name, std::string const *baseName);
+void charmap_Set(std::string const &name);
 void charmap_Push();
 void charmap_Pop();
-void charmap_Add(char const *mapping, uint8_t value);
-bool charmap_HasChar(char const *input);
-void charmap_Convert(char const *input, std::vector<uint8_t> &output);
+void charmap_Add(std::string const &mapping, uint8_t value);
+bool charmap_HasChar(std::string const &input);
+void charmap_Convert(std::string const &input, std::vector<uint8_t> &output);
 size_t charmap_ConvertNext(char const *&input, std::vector<uint8_t> *output);
 
 #endif // RGBDS_ASM_CHARMAP_H

--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -61,10 +61,10 @@ std::optional<std::string> fstk_FindFile(char const *path);
 
 bool yywrap();
 void fstk_RunInclude(char const *path);
-void fstk_RunMacro(char const *macroName, MacroArgs &args);
+void fstk_RunMacro(std::string const &macroName, MacroArgs &args);
 void fstk_RunRept(uint32_t count, int32_t reptLineNo, char const *body, size_t size);
 void fstk_RunFor(
-    char const *symName,
+    std::string const &symName,
     int32_t start,
     int32_t stop,
     int32_t step,

--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -52,15 +52,13 @@ struct MacroArgs;
 
 void fstk_DumpCurrent();
 FileStackNode *fstk_GetFileStack();
-// The lifetime of the returned chars is until reaching the end of that file
-char const *fstk_GetFileName();
 
-void fstk_AddIncludePath(char const *s);
-void fstk_SetPreIncludeFile(char const *s);
-std::optional<std::string> fstk_FindFile(char const *path);
+void fstk_AddIncludePath(std::string const &path);
+void fstk_SetPreIncludeFile(std::string const &path);
+std::optional<std::string> fstk_FindFile(std::string const &path);
 
 bool yywrap();
-void fstk_RunInclude(char const *path);
+void fstk_RunInclude(std::string const &path);
 void fstk_RunMacro(std::string const &macroName, MacroArgs &args);
 void fstk_RunRept(uint32_t count, int32_t reptLineNo, char const *body, size_t size);
 void fstk_RunFor(
@@ -76,6 +74,6 @@ void fstk_StopRept();
 bool fstk_Break();
 
 void fstk_NewRecursionDepth(size_t newDepth);
-void fstk_Init(char const *mainPath, size_t maxDepth);
+void fstk_Init(std::string const &mainPath, size_t maxDepth);
 
 #endif // RGBDS_ASM_FSTACK_H

--- a/include/asm/lexer.hpp
+++ b/include/asm/lexer.hpp
@@ -65,7 +65,7 @@ struct BufferedLexerState {
 };
 
 struct LexerState {
-	char const *path;
+	std::string path;
 
 	LexerMode mode;
 	bool atLineStart;
@@ -115,7 +115,7 @@ static inline void lexer_SetGfxDigits(char const digits[4]) {
 }
 
 // `path` is referenced, but not held onto..!
-bool lexer_OpenFile(LexerState &state, char const *path);
+bool lexer_OpenFile(LexerState &state, std::string const &path);
 void lexer_OpenFileView(
     LexerState &state, char const *path, char const *buf, size_t size, uint32_t lineNo
 );
@@ -144,7 +144,6 @@ struct String {
 };
 
 void lexer_CheckRecursionDepth();
-char const *lexer_GetFileName();
 uint32_t lexer_GetLineNo();
 uint32_t lexer_GetColNo();
 void lexer_DumpStringExpansions();

--- a/include/asm/output.hpp
+++ b/include/asm/output.hpp
@@ -4,20 +4,21 @@
 #define RGBDS_ASM_OUTPUT_H
 
 #include <stdint.h>
+#include <string>
 
 #include "linkdefs.hpp"
 
 struct Expression;
 struct FileStackNode;
 
-extern char const *objectName;
+extern std::string objectName;
 
 void out_RegisterNode(FileStackNode *node);
 void out_ReplaceNode(FileStackNode *node);
-void out_SetFileName(char *s);
+void out_SetFileName(std::string const &name);
 void out_CreatePatch(uint32_t type, Expression const &expr, uint32_t ofs, uint32_t pcShift);
 void out_CreateAssert(
-    AssertionType type, Expression const &expr, char const *message, uint32_t ofs
+    AssertionType type, Expression const &expr, std::string const &message, uint32_t ofs
 );
 void out_WriteObject();
 

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -43,10 +43,10 @@ void rpn_ISCONST(Expression &expr, Expression const &src);
 void rpn_NEG(Expression &expr, Expression &&src);
 void rpn_NOT(Expression &expr, Expression &&src);
 void rpn_BankSymbol(Expression &expr, std::string const &symName);
-void rpn_BankSection(Expression &expr, char const *sectionName);
+void rpn_BankSection(Expression &expr, std::string const &sectionName);
 void rpn_BankSelf(Expression &expr);
-void rpn_SizeOfSection(Expression &expr, char const *sectionName);
-void rpn_StartOfSection(Expression &expr, char const *sectionName);
+void rpn_SizeOfSection(Expression &expr, std::string const &sectionName);
+void rpn_StartOfSection(Expression &expr, std::string const &sectionName);
 void rpn_SizeOfSectionType(Expression &expr, SectionType type);
 void rpn_StartOfSectionType(Expression &expr, SectionType type);
 

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -34,7 +34,7 @@ struct Expression {
 };
 
 void rpn_Number(Expression &expr, uint32_t val);
-void rpn_Symbol(Expression &expr, char const *symName);
+void rpn_Symbol(Expression &expr, std::string const &symName);
 void rpn_LOGNOT(Expression &expr, Expression &&src);
 void rpn_BinaryOp(RPNCommand op, Expression &expr, Expression &&src1, Expression const &src2);
 void rpn_HIGH(Expression &expr, Expression &&src);
@@ -42,7 +42,7 @@ void rpn_LOW(Expression &expr, Expression &&src);
 void rpn_ISCONST(Expression &expr, Expression const &src);
 void rpn_NEG(Expression &expr, Expression &&src);
 void rpn_NOT(Expression &expr, Expression &&src);
-void rpn_BankSymbol(Expression &expr, char const *symName);
+void rpn_BankSymbol(Expression &expr, std::string const &symName);
 void rpn_BankSection(Expression &expr, char const *sectionName);
 void rpn_BankSelf(Expression &expr);
 void rpn_SizeOfSection(Expression &expr, char const *sectionName);

--- a/include/asm/section.hpp
+++ b/include/asm/section.hpp
@@ -54,7 +54,7 @@ extern std::deque<Section> sectionList;
 extern std::unordered_map<std::string, size_t> sectionMap; // Indexes into `sectionList`
 extern Section *currentSection;
 
-Section *sect_FindSectionByName(char const *name);
+Section *sect_FindSectionByName(std::string const &name);
 void sect_NewSection(
     std::string const &name,
     SectionType type,

--- a/include/asm/section.hpp
+++ b/include/asm/section.hpp
@@ -56,10 +56,18 @@ extern Section *currentSection;
 
 Section *sect_FindSectionByName(char const *name);
 void sect_NewSection(
-    char const *name, SectionType type, uint32_t org, SectionSpec const &attrs, SectionModifier mod
+    std::string const &name,
+    SectionType type,
+    uint32_t org,
+    SectionSpec const &attrs,
+    SectionModifier mod
 );
 void sect_SetLoadSection(
-    char const *name, SectionType type, uint32_t org, SectionSpec const &attrs, SectionModifier mod
+    std::string const &name,
+    SectionType type,
+    uint32_t org,
+    SectionSpec const &attrs,
+    SectionModifier mod
 );
 void sect_EndLoadSection();
 
@@ -84,8 +92,8 @@ void sect_RelBytes(uint32_t n, std::vector<Expression> &exprs);
 void sect_RelWord(Expression &expr, uint32_t pcShift);
 void sect_RelLong(Expression &expr, uint32_t pcShift);
 void sect_PCRelByte(Expression &expr, uint32_t pcShift);
-void sect_BinaryFile(char const *s, int32_t startPos);
-void sect_BinaryFileSlice(char const *s, int32_t start_pos, int32_t length);
+void sect_BinaryFile(std::string const &name, int32_t startPos);
+void sect_BinaryFileSlice(std::string const &name, int32_t startPos, int32_t length);
 
 void sect_EndSection();
 void sect_PushSection();

--- a/include/asm/symbol.hpp
+++ b/include/asm/symbol.hpp
@@ -68,27 +68,29 @@ struct Symbol {
 void sym_ForEach(void (*func)(Symbol &));
 
 void sym_SetExportAll(bool set);
-Symbol *sym_AddLocalLabel(char const *symName);
-Symbol *sym_AddLabel(char const *symName);
+Symbol *sym_AddLocalLabel(std::string const &symName);
+Symbol *sym_AddLabel(std::string const &symName);
 Symbol *sym_AddAnonLabel();
 std::string sym_MakeAnonLabelName(uint32_t ofs, bool neg);
-void sym_Export(char const *symName);
-Symbol *sym_AddEqu(char const *symName, int32_t value);
-Symbol *sym_RedefEqu(char const *symName, int32_t value);
-Symbol *sym_AddVar(char const *symName, int32_t value);
+void sym_Export(std::string const &symName);
+Symbol *sym_AddEqu(std::string const &symName, int32_t value);
+Symbol *sym_RedefEqu(std::string const &symName, int32_t value);
+Symbol *sym_AddVar(std::string const &symName, int32_t value);
 uint32_t sym_GetPCValue();
-uint32_t sym_GetConstantValue(char const *symName);
+int32_t sym_GetRSValue();
+void sym_SetRSValue(int32_t value);
+uint32_t sym_GetConstantValue(std::string const &symName);
 // Find a symbol by exact name, bypassing expansion checks
-Symbol *sym_FindExactSymbol(char const *symName);
+Symbol *sym_FindExactSymbol(std::string const &symName);
 // Find a symbol, possibly scoped, by name
-Symbol *sym_FindScopedSymbol(char const *symName);
+Symbol *sym_FindScopedSymbol(std::string const &symName);
 // Find a scoped symbol by name; do not return `@` or `_NARG` when they have no value
-Symbol *sym_FindScopedValidSymbol(char const *symName);
+Symbol *sym_FindScopedValidSymbol(std::string const &symName);
 Symbol const *sym_GetPC();
-Symbol *sym_AddMacro(char const *symName, int32_t defLineNo, char const *body, size_t size);
-Symbol *sym_Ref(char const *symName);
-Symbol *sym_AddString(char const *symName, char const *value);
-Symbol *sym_RedefString(char const *symName, char const *value);
+Symbol *sym_AddMacro(std::string const &symName, int32_t defLineNo, char const *body, size_t size);
+Symbol *sym_Ref(std::string const &symName);
+Symbol *sym_AddString(std::string const &symName, char const *value);
+Symbol *sym_RedefString(std::string const &symName, char const *value);
 void sym_Purge(std::string const &symName);
 void sym_Init(time_t now);
 

--- a/src/asm/charmap.cpp
+++ b/src/asm/charmap.cpp
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <string>
 #include <unordered_map>
 
 #include "util.hpp"
@@ -36,20 +35,20 @@ static std::unordered_map<std::string, Charmap> charmaps;
 static Charmap *currentCharmap;
 std::stack<Charmap *> charmapStack;
 
-void charmap_New(char const *name, char const *baseName) {
+void charmap_New(std::string const &name, std::string const *baseName) {
 	Charmap *base = nullptr;
 
 	if (baseName != nullptr) {
-		auto search = charmaps.find(baseName);
+		auto search = charmaps.find(*baseName);
 
 		if (search == charmaps.end())
-			error("Base charmap '%s' doesn't exist\n", baseName);
+			error("Base charmap '%s' doesn't exist\n", baseName->c_str());
 		else
 			base = &search->second;
 	}
 
 	if (charmaps.find(name) != charmaps.end()) {
-		error("Charmap '%s' already exists\n", name);
+		error("Charmap '%s' already exists\n", name.c_str());
 		return;
 	}
 
@@ -65,11 +64,11 @@ void charmap_New(char const *name, char const *baseName) {
 	currentCharmap = &charmap;
 }
 
-void charmap_Set(char const *name) {
+void charmap_Set(std::string const &name) {
 	auto search = charmaps.find(name);
 
 	if (search == charmaps.end())
-		error("Charmap '%s' doesn't exist\n", name);
+		error("Charmap '%s' doesn't exist\n", name.c_str());
 	else
 		currentCharmap = &search->second;
 }
@@ -88,12 +87,12 @@ void charmap_Pop() {
 	charmapStack.pop();
 }
 
-void charmap_Add(char const *mapping, uint8_t value) {
+void charmap_Add(std::string const &mapping, uint8_t value) {
 	Charmap &charmap = *currentCharmap;
 	size_t nodeIdx = 0;
 
-	for (; *mapping; mapping++) {
-		size_t &nextIdxRef = charmap.nodes[nodeIdx].next[(uint8_t)*mapping - 1];
+	for (char c : mapping) {
+		size_t &nextIdxRef = charmap.nodes[nodeIdx].next[(uint8_t)c - 1];
 		size_t nextIdx = nextIdxRef;
 
 		if (!nextIdx) {
@@ -117,12 +116,12 @@ void charmap_Add(char const *mapping, uint8_t value) {
 	node.value = value;
 }
 
-bool charmap_HasChar(char const *input) {
+bool charmap_HasChar(std::string const &input) {
 	Charmap const &charmap = *currentCharmap;
 	size_t nodeIdx = 0;
 
-	for (; *input; input++) {
-		nodeIdx = charmap.nodes[nodeIdx].next[(uint8_t)*input - 1];
+	for (char c : input) {
+		nodeIdx = charmap.nodes[nodeIdx].next[(uint8_t)c - 1];
 
 		if (!nodeIdx)
 			return false;
@@ -131,8 +130,9 @@ bool charmap_HasChar(char const *input) {
 	return charmap.nodes[nodeIdx].isTerminal;
 }
 
-void charmap_Convert(char const *input, std::vector<uint8_t> &output) {
-	while (charmap_ConvertNext(input, &output))
+void charmap_Convert(std::string const &input, std::vector<uint8_t> &output) {
+	char const *ptr = input.c_str();
+	while (charmap_ConvertNext(ptr, &output))
 		;
 }
 

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -265,7 +265,7 @@ void fstk_RunInclude(std::string const &path) {
 	uint32_t uniqueID = contextStack.top().uniqueID;
 
 	Context &context = newContext(*fileInfo);
-	if (!lexer_OpenFile(context.lexerState, fileInfo->name().c_str()))
+	if (!lexer_OpenFile(context.lexerState, fileInfo->name()))
 		fatalerror("Failed to set up lexer for file include\n");
 	lexer_SetStateAtEOL(&context.lexerState);
 	// We're back at top-level, so most things are reset,
@@ -293,7 +293,7 @@ static void runPreIncludeFile() {
 	}
 
 	Context &context = newContext(*fileInfo);
-	if (!lexer_OpenFile(context.lexerState, fileInfo->name().c_str()))
+	if (!lexer_OpenFile(context.lexerState, fileInfo->name()))
 		fatalerror("Failed to set up lexer for file include\n");
 	lexer_SetState(&context.lexerState);
 	// We're back at top-level, so most things are reset
@@ -447,11 +447,11 @@ void fstk_NewRecursionDepth(size_t newDepth) {
 
 void fstk_Init(std::string const &mainPath, size_t maxDepth) {
 	Context &context = contextStack.emplace();
-	if (!lexer_OpenFile(context.lexerState, mainPath.c_str()))
+	if (!lexer_OpenFile(context.lexerState, mainPath))
 		fatalerror("Failed to open main file\n");
 	lexer_SetState(&context.lexerState);
 
-	context.fileInfo = new (std::nothrow) FileStackNode(NODE_FILE, lexer_GetFileName());
+	context.fileInfo = new (std::nothrow) FileStackNode(NODE_FILE, context.lexerState.path);
 	if (!context.fileInfo)
 		fatalerror("Failed to allocate memory for main file info: %s\n", strerror(errno));
 	// lineNo and nbReptIters are unused on the top-level context

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -198,7 +198,7 @@ bool yywrap() {
 			// Avoid arithmetic overflow runtime error
 			uint32_t forValue = (uint32_t)context.forValue + (uint32_t)context.forStep;
 			context.forValue = forValue <= INT32_MAX ? forValue : -(int32_t)~forValue - 1;
-			Symbol *sym = sym_AddVar(context.forName.c_str(), context.forValue);
+			Symbol *sym = sym_AddVar(context.forName, context.forValue);
 
 			// This error message will refer to the current iteration
 			if (sym->type != SYM_VAR)
@@ -309,15 +309,15 @@ static void runPreIncludeFile() {
 	context.uniqueID = macro_UndefUniqueID();
 }
 
-void fstk_RunMacro(char const *macroName, MacroArgs &args) {
+void fstk_RunMacro(std::string const &macroName, MacroArgs &args) {
 	Symbol *macro = sym_FindExactSymbol(macroName);
 
 	if (!macro) {
-		error("Macro \"%s\" not defined\n", macroName);
+		error("Macro \"%s\" not defined\n", macroName.c_str());
 		return;
 	}
 	if (macro->type != SYM_MACRO) {
-		error("\"%s\" is not a macro\n", macroName);
+		error("\"%s\" is not a macro\n", macroName.c_str());
 		return;
 	}
 	contextStack.top().macroArgs = macro_GetCurrentArgs();
@@ -392,7 +392,7 @@ void fstk_RunRept(uint32_t count, int32_t reptLineNo, char const *body, size_t s
 }
 
 void fstk_RunFor(
-    char const *symName,
+    std::string const &symName,
     int32_t start,
     int32_t stop,
     int32_t step,

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -558,7 +558,7 @@ static uint32_t readBracketedMacroArgNum() {
 			shiftChar();
 		}
 
-		Symbol const *sym = sym_FindScopedValidSymbol(symName.c_str());
+		Symbol const *sym = sym_FindScopedValidSymbol(symName);
 
 		if (!sym) {
 			error("Bracketed symbol \"%s\" does not exist\n", symName.c_str());
@@ -1188,7 +1188,7 @@ static char const *readInterpolation(size_t depth) {
 
 	static char buf[MAXSTRLEN + 1];
 
-	Symbol const *sym = sym_FindScopedValidSymbol(fmtBuf.c_str());
+	Symbol const *sym = sym_FindScopedValidSymbol(fmtBuf);
 
 	if (!sym) {
 		error("Interpolated symbol \"%s\" does not exist\n", fmtBuf.c_str());
@@ -1820,8 +1820,7 @@ static Token yylex_NORMAL() {
 				// Local symbols cannot be string expansions
 				if (token.type == T_(ID) && lexerState->expandStrings) {
 					// Attempt string expansion
-					Symbol const *sym =
-					    sym_FindExactSymbol(std::get<std::string>(token.value).c_str());
+					Symbol const *sym = sym_FindExactSymbol(std::get<std::string>(token.value));
 
 					if (sym && sym->type == SYM_EQUS) {
 						char const *str = sym->getEqus()->c_str();

--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -377,17 +377,17 @@ int main(int argc, char *argv[]) {
 		exit(1);
 	}
 
-	char const *mainFileName = argv[musl_optind];
+	std::string mainFileName = argv[musl_optind];
 
 	if (verbose)
-		printf("Assembling %s\n", mainFileName);
+		printf("Assembling %s\n", mainFileName.c_str());
 
 	if (dependfile) {
 		if (targetFileName.empty())
 			errx("Dependency files can only be created if a target file is specified with either "
 			     "-o, -MQ or -MT");
 
-		fprintf(dependfile, "%s: %s\n", targetFileName.c_str(), mainFileName);
+		fprintf(dependfile, "%s: %s\n", targetFileName.c_str(), mainFileName.c_str());
 	}
 
 	charmap_New(DEFAULT_CHARMAP_NAME, nullptr);

--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -362,7 +362,7 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
-	if (targetFileName.empty() && objectName)
+	if (targetFileName.empty() && !objectName.empty())
 		targetFileName = objectName;
 
 	if (argc == musl_optind) {
@@ -413,7 +413,7 @@ int main(int argc, char *argv[]) {
 		return 0;
 
 	// If no path specified, don't write file
-	if (objectName != nullptr)
+	if (!objectName.empty())
 		out_WriteObject();
 	return 0;
 }

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -187,10 +187,10 @@ static void writerpn(std::vector<uint8_t> &rpnexpr, std::vector<uint8_t> const &
 			}
 
 			// The symbol name is always written expanded
-			sym = sym_FindExactSymbol(symName.c_str());
+			sym = sym_FindExactSymbol(symName);
 			if (sym->isConstant()) {
 				rpnexpr[rpnptr++] = RPN_CONST;
-				value = sym_GetConstantValue(symName.c_str());
+				value = sym_GetConstantValue(symName);
 			} else {
 				rpnexpr[rpnptr++] = RPN_SYM;
 				value = getSymbolID(*sym);
@@ -212,7 +212,7 @@ static void writerpn(std::vector<uint8_t> &rpnexpr, std::vector<uint8_t> const &
 			}
 
 			// The symbol name is always written expanded
-			sym = sym_FindExactSymbol(symName.c_str());
+			sym = sym_FindExactSymbol(symName);
 			value = getSymbolID(*sym);
 
 			rpnexpr[rpnptr++] = RPN_BANK_SYM;

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -1415,13 +1415,13 @@ relocexpr_no_str:
 		rpn_BankSymbol($$, $3);
 	}
 	| OP_BANK LPAREN string RPAREN {
-		rpn_BankSection($$, $3.c_str());
+		rpn_BankSection($$, $3);
 	}
 	| OP_SIZEOF LPAREN string RPAREN {
-		rpn_SizeOfSection($$, $3.c_str());
+		rpn_SizeOfSection($$, $3);
 	}
 	| OP_STARTOF LPAREN string RPAREN {
-		rpn_StartOfSection($$, $3.c_str());
+		rpn_StartOfSection($$, $3);
 	}
 	| OP_SIZEOF LPAREN sectiontype RPAREN {
 		rpn_SizeOfSectionType($$, (SectionType)$3);

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -1123,7 +1123,7 @@ export_list_entry:
 
 include:
 	label POP_INCLUDE string endofline {
-		fstk_RunInclude($3.c_str());
+		fstk_RunInclude($3);
 		if (failedOnMissingInclude)
 			YYACCEPT;
 	}

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -1141,22 +1141,22 @@ incbin:
 
 charmap:
 	POP_CHARMAP string COMMA const_8bit {
-		charmap_Add($2.c_str(), (uint8_t)$4);
+		charmap_Add($2, (uint8_t)$4);
 	}
 ;
 
 newcharmap:
 	POP_NEWCHARMAP ID {
-		charmap_New($2.c_str(), nullptr);
+		charmap_New($2, nullptr);
 	}
 	| POP_NEWCHARMAP ID COMMA ID {
-		charmap_New($2.c_str(), $4.c_str());
+		charmap_New($2, &$4);
 	}
 ;
 
 setcharmap:
 	POP_SETCHARMAP ID {
-		charmap_Set($2.c_str());
+		charmap_Set($2);
 	}
 ;
 
@@ -1224,7 +1224,7 @@ constlist_8bit_entry:
 	| string {
 		std::vector<uint8_t> output;
 
-		charmap_Convert($1.c_str(), output);
+		charmap_Convert($1, output);
 		sect_AbsByteGroup(output.data(), output.size());
 	}
 ;
@@ -1241,7 +1241,7 @@ constlist_16bit_entry:
 	| string {
 		std::vector<uint8_t> output;
 
-		charmap_Convert($1.c_str(), output);
+		charmap_Convert($1, output);
 		sect_AbsWordGroup(output.data(), output.size());
 	}
 ;
@@ -1258,7 +1258,7 @@ constlist_32bit_entry:
 	| string {
 		std::vector<uint8_t> output;
 
-		charmap_Convert($1.c_str(), output);
+		charmap_Convert($1, output);
 		sect_AbsLongGroup(output.data(), output.size());
 	}
 ;
@@ -1309,7 +1309,7 @@ relocexpr:
 	| string {
 		std::vector<uint8_t> output;
 
-		charmap_Convert($1.c_str(), output);
+		charmap_Convert($1, output);
 		rpn_Number($$, str2int2(output));
 	}
 ;
@@ -1492,7 +1492,7 @@ relocexpr_no_str:
 		rpn_Number($$, charlenUTF8($3));
 	}
 	| OP_INCHARMAP LPAREN string RPAREN {
-		rpn_Number($$, charmap_HasChar($3.c_str()));
+		rpn_Number($$, charmap_HasChar($3));
 	}
 	| LPAREN relocexpr RPAREN {
 		$$ = std::move($2);

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -88,7 +88,7 @@
 	);
 	static void compoundAssignment(std::string const &symName, RPNCommand op, int32_t constValue);
 	static void failAssert(AssertionType type);
-	static void failAssertMsg(AssertionType type, char const *msg);
+	static void failAssertMsg(AssertionType type, std::string const &message);
 
 	// The CPU encodes instructions in a logical way, so most instructions actually follow patterns.
 	// These enums thus help with bit twiddling to compute opcodes.
@@ -824,9 +824,9 @@ assert:
 	}
 	| POP_ASSERT assert_type relocexpr COMMA string {
 		if (!$3.isKnown) {
-			out_CreateAssert($2, $3, $5.c_str(), sect_GetOutputOffset());
+			out_CreateAssert($2, $3, $5, sect_GetOutputOffset());
 		} else if ($3.val == 0) {
-			failAssertMsg($2, $5.c_str());
+			failAssertMsg($2, $5);
 		}
 	}
 	| POP_STATIC_ASSERT assert_type const {
@@ -835,7 +835,7 @@ assert:
 	}
 	| POP_STATIC_ASSERT assert_type const COMMA string {
 		if ($3 == 0)
-			failAssertMsg($2, $5.c_str());
+			failAssertMsg($2, $5);
 	}
 ;
 
@@ -2736,15 +2736,15 @@ static void failAssert(AssertionType type) {
 	}
 }
 
-static void failAssertMsg(AssertionType type, char const *msg) {
+static void failAssertMsg(AssertionType type, std::string const &message) {
 	switch (type) {
 	case ASSERT_FATAL:
-		fatalerror("Assertion failed: %s\n", msg);
+		fatalerror("Assertion failed: %s\n", message.c_str());
 	case ASSERT_ERROR:
-		error("Assertion failed: %s\n", msg);
+		error("Assertion failed: %s\n", message.c_str());
 		break;
 	case ASSERT_WARN:
-		warning(WARNING_ASSERT, "Assertion failed: %s\n", msg);
+		warning(WARNING_ASSERT, "Assertion failed: %s\n", message.c_str());
 		break;
 	}
 }

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -850,7 +850,7 @@ shift:
 
 load:
 	POP_LOAD sectmod string COMMA sectiontype sectorg sectattrs {
-		sect_SetLoadSection($3.c_str(), (SectionType)$5, $6, $7, $2);
+		sect_SetLoadSection($3, (SectionType)$5, $6, $7, $2);
 	}
 	| POP_ENDL {
 		sect_EndLoadSection();
@@ -1123,17 +1123,17 @@ include:
 
 incbin:
 	POP_INCBIN string {
-		sect_BinaryFile($2.c_str(), 0);
+		sect_BinaryFile($2, 0);
 		if (failedOnMissingInclude)
 			YYACCEPT;
 	}
 	| POP_INCBIN string COMMA const {
-		sect_BinaryFile($2.c_str(), $4);
+		sect_BinaryFile($2, $4);
 		if (failedOnMissingInclude)
 			YYACCEPT;
 	}
 	| POP_INCBIN string COMMA const COMMA const {
-		sect_BinaryFileSlice($2.c_str(), $4, $6);
+		sect_BinaryFileSlice($2, $4, $6);
 		if (failedOnMissingInclude)
 			YYACCEPT;
 	}
@@ -1630,7 +1630,7 @@ strfmt_va_args:
 
 section:
 	POP_SECTION sectmod string COMMA sectiontype sectorg sectattrs {
-		sect_NewSection($3.c_str(), (SectionType)$5, $6, $7, $2);
+		sect_NewSection($3, (SectionType)$5, $6, $7, $2);
 	}
 ;
 

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -126,7 +126,7 @@ void rpn_BankSymbol(Expression &expr, std::string const &symName) {
 	}
 }
 
-void rpn_BankSection(Expression &expr, char const *sectionName) {
+void rpn_BankSection(Expression &expr, std::string const &sectionName) {
 	initExpression(expr);
 
 	Section *section = sect_FindSectionByName(sectionName);
@@ -136,16 +136,16 @@ void rpn_BankSection(Expression &expr, char const *sectionName) {
 	} else {
 		makeUnknown(expr, "Section \"", sectionName, "\"'s bank is not known");
 
-		size_t nameLen = strlen(sectionName) + 1; // Room for NUL!
+		size_t nameLen = sectionName.length() + 1; // Room for NUL!
 		uint8_t *ptr = reserveSpace(expr, nameLen + 1);
 
 		expr.rpnPatchSize += nameLen + 1;
 		*ptr++ = RPN_BANK_SECT;
-		memcpy(ptr, sectionName, nameLen);
+		memcpy(ptr, sectionName.data(), nameLen);
 	}
 }
 
-void rpn_SizeOfSection(Expression &expr, char const *sectionName) {
+void rpn_SizeOfSection(Expression &expr, std::string const &sectionName) {
 	initExpression(expr);
 
 	Section *section = sect_FindSectionByName(sectionName);
@@ -155,16 +155,16 @@ void rpn_SizeOfSection(Expression &expr, char const *sectionName) {
 	} else {
 		makeUnknown(expr, "Section \"", sectionName, "\"'s size is not known");
 
-		size_t nameLen = strlen(sectionName) + 1; // Room for NUL!
+		size_t nameLen = sectionName.length() + 1; // Room for NUL!
 		uint8_t *ptr = reserveSpace(expr, nameLen + 1);
 
 		expr.rpnPatchSize += nameLen + 1;
 		*ptr++ = RPN_SIZEOF_SECT;
-		memcpy(ptr, sectionName, nameLen);
+		memcpy(ptr, sectionName.data(), nameLen);
 	}
 }
 
-void rpn_StartOfSection(Expression &expr, char const *sectionName) {
+void rpn_StartOfSection(Expression &expr, std::string const &sectionName) {
 	initExpression(expr);
 
 	Section *section = sect_FindSectionByName(sectionName);
@@ -174,12 +174,12 @@ void rpn_StartOfSection(Expression &expr, char const *sectionName) {
 	} else {
 		makeUnknown(expr, "Section \"", sectionName, "\"'s start is not known");
 
-		size_t nameLen = strlen(sectionName) + 1; // Room for NUL!
+		size_t nameLen = sectionName.length() + 1; // Room for NUL!
 		uint8_t *ptr = reserveSpace(expr, nameLen + 1);
 
 		expr.rpnPatchSize += nameLen + 1;
 		*ptr++ = RPN_STARTOF_SECT;
-		memcpy(ptr, sectionName, nameLen);
+		memcpy(ptr, sectionName.data(), nameLen);
 	}
 }
 

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <string_view>
 
 #include "opmath.hpp"
 
@@ -50,7 +51,7 @@ void rpn_Number(Expression &expr, uint32_t val) {
 	expr.val = val;
 }
 
-void rpn_Symbol(Expression &expr, char const *symName) {
+void rpn_Symbol(Expression &expr, std::string const &symName) {
 	initExpression(expr);
 
 	Symbol *sym = sym_FindScopedSymbol(symName);
@@ -92,7 +93,7 @@ static void bankSelf(Expression &expr) {
 	}
 }
 
-void rpn_BankSymbol(Expression &expr, char const *symName) {
+void rpn_BankSymbol(Expression &expr, std::string const &symName) {
 	Symbol const *sym = sym_FindScopedSymbol(symName);
 
 	// The @ symbol is treated differently.

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -834,7 +834,7 @@ void sect_BinaryFile(std::string const &name, int32_t startPos) {
 	if (!checkcodesection())
 		return;
 
-	std::optional<std::string> fullPath = fstk_FindFile(name.c_str());
+	std::optional<std::string> fullPath = fstk_FindFile(name);
 	FILE *file = fullPath ? fopen(fullPath->c_str(), "rb") : nullptr;
 	if (!file) {
 		if (generatedMissingIncludes) {
@@ -902,7 +902,7 @@ void sect_BinaryFileSlice(std::string const &name, int32_t startPos, int32_t len
 	if (!reserveSpace(length))
 		return;
 
-	std::optional<std::string> fullPath = fstk_FindFile(name.c_str());
+	std::optional<std::string> fullPath = fstk_FindFile(name);
 	FILE *file = fullPath ? fopen(fullPath->c_str(), "rb") : nullptr;
 	if (!file) {
 		if (generatedMissingIncludes) {

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -109,7 +109,7 @@ attr_(warn_unused_result) static bool reserveSpace(uint32_t delta_size) {
 	       && (!currentLoadSection || currentLoadSection->size != UINT32_MAX);
 }
 
-Section *sect_FindSectionByName(char const *name) {
+Section *sect_FindSectionByName(std::string const &name) {
 	auto search = sectionMap.find(name);
 	return search != sectionMap.end() ? &sectionList[search->second] : nullptr;
 }
@@ -401,7 +401,7 @@ static Section *getSection(
 
 	// Check if another section exists with the same name; merge if yes, otherwise create one
 
-	Section *sect = sect_FindSectionByName(name.c_str());
+	Section *sect = sect_FindSectionByName(name);
 
 	if (sect) {
 		mergeSections(*sect, type, org, bank, alignment, alignOffset, mod);


### PR DESCRIPTION
To do:

- [x] Use `std::string` for most intermediate parsed strings. *[This works, but is slow!]*
- [x] Pass `std::string` references instead of `.c_str()` pointers to the parser's semantic functions. *[This works, but is still slow!]*
- [x] Use `std::string` for quoted string literals in the lexer, and remove out `String` struct. ***[This is not fully done!]***
- [ ] Symbol values, macro arguments, and so forth are still pointers to C-style strings with unclear ownership semantics (i.e. we still have "leaks as a feature").

Possible optimization opportunities:

- Complete get rid of the `String` struct, since it's 256 bytes large, and use `std::string` instead.
- Use `std::move` on large parser values whenever possible; avoid copying strings in general.
- Reserve space in strings before building them up.
- Pass `std::string_view`, not `const std::string &` (and create these from C string literals or `char const *` pointers-to-buffers)