### PR TITLE
Add test cases for SECTION UNION defining multiple identical labels

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -276,6 +276,7 @@ jobs:
           path: |
             test/gfx/randtilegen.exe
             test/gfx/rgbgfx_test.exe
+            test/link/unmangle.exe
 
   windows-mingw-testing:
     needs: windows-mingw-build
@@ -296,7 +297,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: testing-programs-mingw-win${{ matrix.bits }}
-          path: test/gfx
+          path: test
       - name: Extract binaries
         shell: bash
         run: |

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,9 @@ test/gfx/randtilegen: test/gfx/randtilegen.cpp
 test/gfx/rgbgfx_test: test/gfx/rgbgfx_test.cpp
 	$Q${CXX} ${REALLDFLAGS} ${PNGLDFLAGS} -o $@ $^ ${REALCXXFLAGS} ${PNGLDLIBS}
 
+test/link/unmangle: test/link/unmangle.cpp
+	$Q${CXX} ${REALLDFLAGS} -o $@ $^ ${REALCXXFLAGS}
+
 # Rules to process files
 
 # We want the Bison invocation to pass through our rules, not default ones
@@ -176,7 +179,7 @@ clean:
 	$Q${RM} rgbshim.sh
 	$Q${RM} src/asm/parser.cpp src/asm/parser.hpp src/asm/stack.hh
 	$Q${RM} src/link/script.cpp src/link/script.hpp src/link/stack.hh
-	$Q${RM} test/gfx/randtilegen test/gfx/rgbgfx_test
+	$Q${RM} test/gfx/randtilegen test/gfx/rgbgfx_test test/link/unmangle
 
 # Target used to install the binaries and man pages.
 
@@ -233,13 +236,13 @@ coverage:
 # install instructions instead.
 
 mingw32:
-	$Q${MAKE} all test/gfx/randtilegen test/gfx/rgbgfx_test \
+	$Q${MAKE} all test/gfx/randtilegen test/gfx/rgbgfx_test test/link/unmangle \
 		CXX=i686-w64-mingw32-g++ \
 		CXXFLAGS="-O3 -flto -DNDEBUG -static-libgcc -static-libstdc++" \
 		PKG_CONFIG="PKG_CONFIG_SYSROOT_DIR=/usr/i686-w64-mingw32 pkg-config"
 
 mingw64:
-	$Q${MAKE} all test/gfx/randtilegen test/gfx/rgbgfx_test \
+	$Q${MAKE} all test/gfx/randtilegen test/gfx/rgbgfx_test test/link/unmangle \
 		CXX=x86_64-w64-mingw32-g++ \
 		PKG_CONFIG="PKG_CONFIG_SYSROOT_DIR=/usr/x86_64-w64-mingw32 pkg-config"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,9 +2,15 @@
 
 add_executable(randtilegen gfx/randtilegen.cpp)
 add_executable(rgbgfx_test gfx/rgbgfx_test.cpp)
+add_executable(unmangle link/unmangle.cpp)
 
 install(TARGETS randtilegen rgbgfx_test
         DESTINATION ${rgbds_SOURCE_DIR}/test/gfx
+        COMPONENT "Test support programs"
+        EXCLUDE_FROM_ALL
+        )
+install(TARGETS unmangle
+        DESTINATION ${rgbds_SOURCE_DIR}/test/link
         COMPONENT "Test support programs"
         EXCLUDE_FROM_ALL
         )

--- a/test/link/.gitignore
+++ b/test/link/.gitignore
@@ -1,0 +1,2 @@
+# Test binaries
+/unmangle

--- a/test/link/section-union/same-export/a.asm
+++ b/test/link/section-union/same-export/a.asm
@@ -1,0 +1,5 @@
+SECTION UNION "test", WRAM0
+Same::
+	ds 1
+Foo::
+	ds 2

--- a/test/link/section-union/same-export/b.asm
+++ b/test/link/section-union/same-export/b.asm
@@ -1,0 +1,5 @@
+SECTION UNION "test", WRAM0
+Same::
+	ds 2
+Bar::
+	ds 1

--- a/test/link/section-union/same-export/out.err
+++ b/test/link/section-union/same-export/out.err
@@ -1,0 +1,1 @@
+error: "Same" both in section-union/same-export/a.o from section-union/same-export/a.asm(2) and in section-union/same-export/b.o from section-union/same-export/b.asm(2)

--- a/test/link/section-union/same-label/a.asm
+++ b/test/link/section-union/same-label/a.asm
@@ -1,0 +1,5 @@
+SECTION UNION "test", WRAM0
+Same:
+	ds 1
+Foo:
+	ds 2

--- a/test/link/section-union/same-label/b.asm
+++ b/test/link/section-union/same-label/b.asm
@@ -1,0 +1,5 @@
+SECTION UNION "test", WRAM0
+Same:
+	ds 2
+Bar:
+	ds 1

--- a/test/link/unmangle.cpp
+++ b/test/link/unmangle.cpp
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+/**
+ * MinGW mangles path names before passing them as command-line arguments.
+ * Some RGBLINK warning/error messages include those mangled paths on Windows.
+ * We need to see those mangled paths in test.sh to replace them with placeholders.
+ * This tool simply echoes each argument, which will be mangled iff they are paths.
+ * (For example, the "/tmp/foo" will be unmangled to something like
+ * "C:/Users/RUNNER~1/AppData/Local/Temp/foo".)
+ */
+
+int main(int argc, char *argv[]) {
+	for (int i = 1; i < argc; i++)
+		puts(argv[i]);
+	return 0;
+}


### PR DESCRIPTION
This is related to #1340, and is a blocker for PR #1341.

The easy part here was writing the tests. The hard part was fixing some Windows and macOS-specific issues with the test output:

- The error message for multiple identical exported labels, unusually, mention the object file names. Those are generated by `mktemp` in test.sh. On MinGW, they look like `"/tmp/foobar"` inside the bash shell, but that's just name mangling, and rgblink sees the unmangled `"C:/Users/RUNNER~1/ApData/Local/Temp/foobar"` path. So, I had to add an unmangle.cpp program (after trying alternatives like `echo` and `realpath`) so we can replace the arbitrary temp filename with `"section-union/the-test-case.o"` for comparison purposes.
- On macOS, I can't just do `sed -i 's|$objfile|the-test-case.o|g' "$outfile"`, because it uses BSD sed which demands a backup file prefix (or `''` for none). So we have to do `sed -i'' -e 's|$objfile|the-test-case.o|g' "$outfile"`.

In conclusion, I am sick of computers.