### PR TITLE
Fix CI builds for Ubuntu 22.04

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,9 +24,15 @@ jobs:
         shell: bash
         run: |
           ./.github/scripts/install_deps.sh ${{ matrix.os }}
+      # Ubuntu 22.04 provides LLVM 14, which links an ASan version incompatible with
+      # high-entropy ASLR in newer Linux kernels that GitHub Actions runners use.
+      # https://github.com/actions/runner-images/issues/9491
+      - name: Fix Ubuntu 22.04 ASLR for LLVM 14
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo sysctl vm.mmap_rnd_bits=28
       # Export `bison` to allow using the version we install from Homebrew,
-      # instead of the outdated one preinstalled on macOS (which doesn't
-      # even support `-Wall`...).
+      # instead of the outdated 2.3 one preinstalled on macOS.
       - name: Build & install using Make
         if: matrix.buildsys == 'make'
         run: |


### PR DESCRIPTION
Fixes #1358

This was the fault of https://github.com/actions/runner-images/issues/9491, we can remove this workaround when that's fixed.