### PR TITLE
Only restore parent context's `\@` value if it had one defined

### DIFF
--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -14,8 +14,6 @@
 
 #include "linkdefs.hpp"
 
-#include "asm/lexer.hpp"
-
 struct FileStackNode {
 	FileStackNodeType type;
 	std::variant<

--- a/test/asm/unique-id-include.asm
+++ b/test/asm/unique-id-include.asm
@@ -1,0 +1,27 @@
+REPT 2
+	println "Within REPT"
+	INCLUDE "unique-id-include.inc"
+	println "Outside INCLUDE: \@"
+ENDR
+
+MACRO m1
+	println "Within MACRO"
+	INCLUDE "unique-id-include.inc"
+	println "Outside INCLUDE: \@"
+ENDM
+	m1
+
+println
+
+REPT 2
+	println "Within REPT: \@"
+	INCLUDE "unique-id-include.inc"
+	println "Outside INCLUDE: \@"
+ENDR
+
+MACRO m2
+	println "Within MACRO: \@"
+	INCLUDE "unique-id-include.inc"
+	println "Outside INCLUDE: \@"
+ENDM
+	m2

--- a/test/asm/unique-id-include.inc
+++ b/test/asm/unique-id-include.inc
@@ -1,0 +1,1 @@
+println "Within INCLUDE: \@"

--- a/test/asm/unique-id-include.out
+++ b/test/asm/unique-id-include.out
@@ -1,0 +1,19 @@
+Within REPT
+Within INCLUDE: _u1
+Outside INCLUDE: _u1
+Within REPT
+Within INCLUDE: _u2
+Outside INCLUDE: _u2
+Within MACRO
+Within INCLUDE: _u3
+Outside INCLUDE: _u3
+
+Within REPT: _u4
+Within INCLUDE: _u4
+Outside INCLUDE: _u4
+Within REPT: _u5
+Within INCLUDE: _u5
+Outside INCLUDE: _u5
+Within MACRO: _u6
+Within INCLUDE: _u6
+Outside INCLUDE: _u6

--- a/test/asm/unique-id-nested.asm
+++ b/test/asm/unique-id-nested.asm
@@ -1,0 +1,33 @@
+MACRO m1
+	PRINTLN "Begin MACRO"
+	DEF nested EQUS """MACRO mm
+		PRINTLN "Within nested MACRO: \\@"
+		\n ENDM
+		mm"""
+	nested
+	PURGE nested, mm
+	PRINTLN "Within MACRO: \@"
+ENDM
+REPT 2
+	PRINTLN "Begin REPT"
+	m1
+	PRINTLN "Within REPT: \@"
+ENDR
+
+PRINTLN
+
+MACRO m2
+	PRINTLN "Begin MACRO: \@"
+	DEF nested EQUS """MACRO mm
+		PRINTLN "Within nested MACRO: \\@"
+		\n ENDM
+		mm"""
+	nested
+	PURGE nested, mm
+	PRINTLN "Within MACRO: \@"
+ENDM
+REPT 2
+	PRINTLN "Begin REPT: \@"
+	m2
+	PRINTLN "Within REPT: \@"
+ENDR

--- a/test/asm/unique-id-nested.out
+++ b/test/asm/unique-id-nested.out
@@ -1,0 +1,21 @@
+Begin REPT
+Begin MACRO
+Within nested MACRO: _u1
+Within MACRO: _u2
+Within REPT: _u3
+Begin REPT
+Begin MACRO
+Within nested MACRO: _u4
+Within MACRO: _u5
+Within REPT: _u6
+
+Begin REPT: _u7
+Begin MACRO: _u8
+Within nested MACRO: _u9
+Within MACRO: _u8
+Within REPT: _u7
+Begin REPT: _u10
+Begin MACRO: _u11
+Within nested MACRO: _u12
+Within MACRO: _u11
+Within REPT: _u10


### PR DESCRIPTION
This way, if a child context initializes `\@`, the parent won't reset it. And if the child context did not initialize `\@`, then resetting it would be redundant.

Fixes #1363
Replaces #1365