### PR TITLE
Use `std::get_if` instead of `std::visit`

### DIFF
--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -62,28 +62,27 @@ std::string const &FileStackNode::name() const {
 }
 
 std::string const &FileStackNode::dump(uint32_t curLineNo) const {
-	Visitor visitor{
-	    [this](std::vector<uint32_t> const &iters) -> std::string const & {
-		    assert(this->parent); // REPT nodes use their parent's name
-		    std::string const &lastName = this->parent->dump(this->lineNo);
-		    fprintf(stderr, " -> %s", lastName.c_str());
-		    for (uint32_t i = iters.size(); i--;)
-			    fprintf(stderr, "::REPT~%" PRIu32, iters[i]);
-		    return lastName;
-	    },
-	    [this](std::string const &name) -> std::string const & {
-		    if (this->parent) {
-			    this->parent->dump(this->lineNo);
-			    fprintf(stderr, " -> %s", name.c_str());
-		    } else {
-			    fputs(name.c_str(), stderr);
-		    }
-		    return name;
-	    },
-	};
-	std::string const &topName = std::visit(visitor, data);
-	fprintf(stderr, "(%" PRIu32 ")", curLineNo);
-	return topName;
+	if (std::holds_alternative<std::vector<uint32_t>>(data)) {
+		assert(parent); // REPT nodes use their parent's name
+		std::string const &lastName = parent->dump(lineNo);
+		fputs(" -> ", stderr);
+		fputs(lastName.c_str(), stderr);
+		std::vector<uint32_t> const &nodeIters = iters();
+		for (uint32_t i = nodeIters.size(); i--;) {
+			fprintf(stderr, "::REPT~%" PRIu32, nodeIters[i]);
+		}
+		fprintf(stderr, "(%" PRIu32 ")", curLineNo);
+		return lastName;
+	} else {
+		if (parent) {
+			parent->dump(lineNo);
+			fputs(" -> ", stderr);
+		}
+		std::string const &nodeName = name();
+		fputs(nodeName.c_str(), stderr);
+		fprintf(stderr, "(%" PRIu32 ")", curLineNo);
+		return nodeName;
+	}
 }
 
 void fstk_DumpCurrent() {

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -2689,14 +2689,12 @@ static std::string strfmt(
 		} else if (argIndex >= args.size()) {
 			// Will warn after formatting is done.
 			str += '%';
+		} else if (auto *n = std::get_if<uint32_t>(&args[argIndex]); n) {
+			str.append(fmt.formatNumber(*n));
 		} else {
-			str.append(std::visit(
-			    Visitor{
-			        [&fmt](uint32_t n) { return fmt.formatNumber(n); },
-			        [&fmt](std::string const &s) { return fmt.formatString(s); },
-			    },
-			    args[argIndex]
-			));
+			assert(std::holds_alternative<std::string>(args[argIndex]));
+			auto &s = std::get<std::string>(args[argIndex]);
+			str.append(fmt.formatString(s));
 		}
 
 		argIndex++;

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -61,21 +61,20 @@ static int32_t CallbackPC() {
 
 int32_t Symbol::getValue() const {
 	assert(std::holds_alternative<int32_t>(data) || std::holds_alternative<int32_t (*)()>(data));
-	if (int32_t const *value = std::get_if<int32_t>(&data); value) {
+	if (auto *value = std::get_if<int32_t>(&data); value) {
 		return type == SYM_LABEL ? *value + getSection()->org : *value;
 	}
 	return getOutputValue();
 }
 
 int32_t Symbol::getOutputValue() const {
-	return std::visit(
-	    Visitor{
-	        [](int32_t value) -> int32_t { return value; },
-	        [](int32_t (*callback)()) -> int32_t { return callback(); },
-	        [](auto &) -> int32_t { return 0; },
-	    },
-	    data
-	);
+	if (auto *value = std::get_if<int32_t>(&data); value) {
+		return *value;
+	} else if (auto *callback = std::get_if<int32_t (*)()>(&data); callback) {
+		return (*callback)();
+	} else {
+		return 0;
+	}
 }
 
 std::string_view *Symbol::getMacro() const {

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -564,7 +564,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID) {
 
 		if (symbol.type == SYMTYPE_EXPORT)
 			sym_AddSymbol(symbol);
-		if (Label *label = std::get_if<Label>(&symbol.data); label)
+		if (auto *label = std::get_if<Label>(&symbol.data); label)
 			nbSymPerSect[label->sectionID]++;
 	}
 
@@ -603,7 +603,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID) {
 
 	// Give symbols' section pointers to their sections
 	for (uint32_t i = 0; i < nbSymbols; i++) {
-		if (Label *label = std::get_if<Label>(&fileSymbols[i].data); label) {
+		if (auto *label = std::get_if<Label>(&fileSymbols[i].data); label) {
 			Section *section = fileSections[label->sectionID].get();
 
 			label->section = section;
@@ -620,7 +620,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID) {
 	// This has to run **after** all the `sect_AddSection()` calls,
 	// so that `sect_GetSection()` will work
 	for (uint32_t i = 0; i < nbSymbols; i++) {
-		if (Label *label = std::get_if<Label>(&fileSymbols[i].data); label) {
+		if (auto *label = std::get_if<Label>(&fileSymbols[i].data); label) {
 			if (Section *section = label->section; section->modifier != SECTION_NORMAL) {
 				if (section->modifier == SECTION_FRAGMENT)
 					// Add the fragment's offset to the symbol's

--- a/src/link/patch.cpp
+++ b/src/link/patch.cpp
@@ -218,7 +218,7 @@ static int32_t computeRPNExpr(Patch const &patch, std::vector<Symbol> const &fil
 				);
 				isError = true;
 				value = 1;
-			} else if (Label const *label = std::get_if<Label>(&symbol->data); label) {
+			} else if (auto *label = std::get_if<Label>(&symbol->data); label) {
 				value = label->section->bank;
 			} else {
 				error(
@@ -383,16 +383,11 @@ static int32_t computeRPNExpr(Patch const &patch, std::vector<Symbol> const &fil
 					    fileSymbols[value].name.c_str()
 					);
 					isError = true;
+				} else if (auto *label = std::get_if<Label>(&symbol->data); label) {
+					value = label->section->org + label->offset;
 				} else {
-					value = std::visit(
-					    Visitor{
-					        [](int32_t val) -> int32_t { return val; },
-					        [](Label label) -> int32_t {
-						        return label.section->org + label.offset;
-					        },
-					    },
-					    symbol->data
-					);
+					assert(std::holds_alternative<int32_t>(symbol->data));
+					value = std::get<int32_t>(symbol->data);
 				}
 			}
 			break;

--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -27,8 +27,8 @@ Label const &Symbol::label() const {
 
 void sym_AddSymbol(Symbol &symbol) {
 	Symbol *other = sym_GetSymbol(symbol.name);
-	int32_t const *symValue = std::get_if<int32_t>(&symbol.data);
-	int32_t const *otherValue = other ? std::get_if<int32_t>(&other->data) : nullptr;
+	auto *symValue = std::get_if<int32_t>(&symbol.data);
+	auto *otherValue = other ? std::get_if<int32_t>(&other->data) : nullptr;
 
 	// Check if the symbol already exists with a different value
 	if (other && !(symValue && otherValue && *symValue == *otherValue)) {


### PR DESCRIPTION
`std::visit` is arguably cleaner code, but older versions of gcc and clang (not very old; the ones packaged with Ubuntu 22.04 LTS) compile them as tables of function pointers, instead of efficient jump tables.