### PR TITLE
Fix some header `#include`s with `clangd` LSP

### DIFF
--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -5,6 +5,7 @@
 #ifndef RGBDS_ASM_FSTACK_H
 #define RGBDS_ASM_FSTACK_H
 
+#include <optional>
 #include <stdint.h>
 #include <stdio.h>
 #include <string>

--- a/include/asm/lexer.hpp
+++ b/include/asm/lexer.hpp
@@ -5,6 +5,7 @@
 
 #include <deque>
 #include <optional>
+#include <stdint.h>
 #include <string>
 #include <variant>
 #include <vector>

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 
+#include "asm/lexer.hpp"
+
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -11,7 +13,6 @@
 #include <limits.h>
 #include <math.h>
 #include <new>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -25,7 +26,6 @@
 #include "asm/fixpoint.hpp"
 #include "asm/format.hpp"
 #include "asm/fstack.hpp"
-#include "asm/lexer.hpp"
 #include "asm/macro.hpp"
 #include "asm/main.hpp"
 #include "asm/rpn.hpp"

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -2,10 +2,8 @@
 
 #include "asm/output.hpp"
 
-#include <algorithm>
 #include <assert.h>
 #include <deque>
-#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,8 +13,8 @@
 
 #include "error.hpp"
 
-#include "asm/charmap.hpp"
 #include "asm/fstack.hpp"
+#include "asm/lexer.hpp"
 #include "asm/main.hpp"
 #include "asm/rpn.hpp"
 #include "asm/section.hpp"

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -12,9 +12,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "error.hpp"
-
 #include "asm/fstack.hpp"
+#include "asm/lexer.hpp"
 #include "asm/main.hpp"
 #include "asm/output.hpp"
 #include "asm/rpn.hpp"

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -5,20 +5,17 @@
 #include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
-#include <limits.h>
 #include <new>
 #include <stdio.h>
 #include <unordered_map>
 
 #include "error.hpp"
 #include "helpers.hpp"
-#include "util.hpp"
 #include "version.hpp"
 
-#include "asm/fixpoint.hpp"
 #include "asm/fstack.hpp"
+#include "asm/lexer.hpp"
 #include "asm/macro.hpp"
-#include "asm/main.hpp"
 #include "asm/output.hpp"
 #include "asm/warning.hpp"
 

--- a/src/asm/warning.cpp
+++ b/src/asm/warning.cpp
@@ -3,7 +3,6 @@
 #include "asm/warning.hpp"
 
 #include <inttypes.h>
-#include <limits.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -14,6 +13,7 @@
 #include "itertools.hpp"
 
 #include "asm/fstack.hpp"
+#include "asm/lexer.hpp"
 #include "asm/main.hpp"
 
 unsigned int nbErrors = 0;


### PR DESCRIPTION
This extracts some refactoring from #1359 which was unrelated to its goal of replacing `struct String` with `std::shared_ptr<std::string>`. (Partly to make that PR easier to review as a unit.)