### PR TITLE
Use `std::shared_ptr` for fstack nodes

### DIFF
--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -5,6 +5,7 @@
 #ifndef RGBDS_ASM_FSTACK_H
 #define RGBDS_ASM_FSTACK_H
 
+#include <memory>
 #include <optional>
 #include <stdint.h>
 #include <stdio.h>
@@ -22,12 +23,10 @@ struct FileStackNode {
 	    >
 	    data;
 
-	FileStackNode *parent; // Pointer to parent node, for error reporting
+	std::shared_ptr<FileStackNode> parent; // Pointer to parent node, for error reporting
 	// Line at which the parent context was exited; meaningless for the root level
 	uint32_t lineNo;
 
-	// If referenced by a Symbol, Section, or Patch's `src`, don't `delete`!
-	bool referenced = false;
 	// Set only if referenced: ID within the object file, -1 if not output yet
 	uint32_t ID = -1;
 
@@ -50,7 +49,7 @@ extern size_t maxRecursionDepth;
 struct MacroArgs;
 
 void fstk_DumpCurrent();
-FileStackNode *fstk_GetFileStack();
+std::shared_ptr<FileStackNode> fstk_GetFileStack();
 
 void fstk_AddIncludePath(std::string const &path);
 void fstk_SetPreIncludeFile(std::string const &path);

--- a/include/asm/output.hpp
+++ b/include/asm/output.hpp
@@ -3,6 +3,7 @@
 #ifndef RGBDS_ASM_OUTPUT_H
 #define RGBDS_ASM_OUTPUT_H
 
+#include <memory>
 #include <stdint.h>
 #include <string>
 
@@ -13,8 +14,7 @@ struct FileStackNode;
 
 extern std::string objectName;
 
-void out_RegisterNode(FileStackNode *node);
-void out_ReplaceNode(FileStackNode *node);
+void out_RegisterNode(std::shared_ptr<FileStackNode> node);
 void out_SetFileName(std::string const &name);
 void out_CreatePatch(uint32_t type, Expression const &expr, uint32_t ofs, uint32_t pcShift);
 void out_CreateAssert(

--- a/include/asm/section.hpp
+++ b/include/asm/section.hpp
@@ -4,6 +4,7 @@
 #define RGBDS_SECTION_H
 
 #include <deque>
+#include <memory>
 #include <stdint.h>
 #include <string>
 #include <unordered_map>
@@ -18,7 +19,7 @@ struct FileStackNode;
 struct Section;
 
 struct Patch {
-	FileStackNode const *src;
+	std::shared_ptr<FileStackNode> src;
 	uint32_t lineNo;
 	uint32_t offset;
 	Section *pcSection;
@@ -31,8 +32,8 @@ struct Section {
 	std::string name;
 	SectionType type;
 	SectionModifier modifier;
-	FileStackNode const *src; // Where the section was defined
-	uint32_t fileLine;        // Line where the section was defined
+	std::shared_ptr<FileStackNode> src; // Where the section was defined
+	uint32_t fileLine;                  // Line where the section was defined
 	uint32_t size;
 	uint32_t org;
 	uint32_t bank;

--- a/include/asm/symbol.hpp
+++ b/include/asm/symbol.hpp
@@ -3,6 +3,7 @@
 #ifndef RGBDS_SYMBOL_H
 #define RGBDS_SYMBOL_H
 
+#include <memory>
 #include <optional>
 #include <stdint.h>
 #include <string.h>
@@ -31,8 +32,8 @@ struct Symbol {
 	bool isExported; // Whether the symbol is to be exported
 	bool isBuiltin;  // Whether the symbol is a built-in
 	Section *section;
-	FileStackNode *src; // Where the symbol was defined
-	uint32_t fileLine;  // Line where the symbol was defined
+	std::shared_ptr<FileStackNode> src; // Where the symbol was defined
+	uint32_t fileLine;                  // Line where the symbol was defined
 
 	std::variant<
 	    int32_t,            // If isNumeric()

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -6,7 +6,6 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>
-#include <new>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -97,15 +97,13 @@ static void dumpFilename(Symbol const &sym) {
 
 // Update a symbol's definition filename and line
 static void updateSymbolFilename(Symbol &sym) {
-	FileStackNode *oldSrc = sym.src;
-
+	std::shared_ptr<FileStackNode> oldSrc = std::move(sym.src);
 	sym.src = fstk_GetFileStack();
 	sym.fileLine = sym.src ? lexer_GetLineNo() : 0;
 
-	// If the old node was referenced, ensure the new one is
-	if (oldSrc && oldSrc->referenced && oldSrc->ID != (uint32_t)-1)
+	// If the old node was registered, ensure the new one is too
+	if (oldSrc && oldSrc->ID != (uint32_t)-1)
 		out_RegisterNode(sym.src);
-	// TODO: unref the old node, and use `out_ReplaceNode` instead of deleting it
 }
 
 // Create a new symbol by name


### PR DESCRIPTION
I was encouraged by the good performance of `std::shared_ptr` in #1359 to go ahead and use them for `FileStackNode`s, without worrying about passing `&`references or the `.get()` raw pointer (previously I'd been concerned about ARC overhead).

Note that we check `.use_count() > 1` to see whether to duplicate an existing `FileStackNode`. (Previously we checked `->referenced`.) We do not check `->ID != (uint32_t)-1`, because if a node is the parent of an unregistered node, it is nevertheless *referenced* by its child and should not be edited. (This is demonstrated by the test case where a previous `REPT` iteration defined a macro inside it, so the stack trace should be "`::REPT~<the previous iteration>::<the macro>`", not "`<the current iteration>`".