### PR TITLE
Use content-specific destructors for lexer state

### DIFF
--- a/include/asm/lexer.hpp
+++ b/include/asm/lexer.hpp
@@ -129,20 +129,18 @@ bool lexer_ReachedELSEBlock();
 void lexer_RunIFBlock();
 void lexer_ReachELSEBlock();
 
-struct CaptureBody {
-	uint32_t lineNo;
-	char const *body;
-	size_t size;
-
-	void startCapture();
-	void endCapture();
-};
-
 void lexer_CheckRecursionDepth();
 uint32_t lexer_GetLineNo();
 uint32_t lexer_GetColNo();
 void lexer_DumpStringExpansions();
-CaptureBody lexer_CaptureRept();
-CaptureBody lexer_CaptureMacroBody();
+
+struct Capture {
+	uint32_t lineNo;
+	char const *body;
+	size_t size;
+};
+
+Capture lexer_CaptureRept();
+Capture lexer_CaptureMacro();
 
 #endif // RGBDS_ASM_LEXER_H

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -245,8 +245,8 @@
 %token SECT_WRAM0 "WRAM0" SECT_WRAMX "WRAMX" SECT_HRAM "HRAM"
 %token SECT_VRAM "VRAM" SECT_SRAM "SRAM" SECT_OAM "OAM"
 
-%type <CaptureBody> capture_rept
-%type <CaptureBody> capture_macro
+%type <Capture> capture_rept
+%type <Capture> capture_macro
 
 %type <SectionModifier> sect_mod
 %type <std::shared_ptr<MacroArgs>> macro_args
@@ -926,7 +926,7 @@ def_macro:
 
 capture_macro:
 	%empty {
-		$$ = lexer_CaptureMacroBody();
+		$$ = lexer_CaptureMacro();
 	}
 ;
 


### PR DESCRIPTION
Also rename `LexerState` content structs from `*LexerState` to `*Content`