### PR TITLE
Make test built of 'libbet' reproducible with old Pillow versions

### DIFF
--- a/contrib/coverage.bash
+++ b/contrib/coverage.bash
@@ -5,11 +5,10 @@ set -e
 make coverage -j
 
 # Run the tests
-for dir in asm link fix gfx; do
-	pushd test/$dir
-	./test.sh
-	popd
-done
+pushd test
+./fetch-test-deps.sh
+./run-tests.sh
+popd
 
 # Generate coverage logs
 gcov src/**/*.cpp

--- a/test/patches/libbet.patch
+++ b/test/patches/libbet.patch
@@ -24,3 +24,16 @@ index 6513518..ba14638 100644
  	$(PY) $^ -o $@
  
  # Graphics conversion
+diff --git a/tools/makeborder.py b/tools/makeborder.py
+index b9fa3f1..dfe5789 100755
+--- a/tools/makeborder.py
++++ b/tools/makeborder.py
+@@ -88,7 +88,7 @@ def main(argv=None):
+     else:
+         iutmrows = b''.join(pb16.pb16(b''.join(utmrows)))
+ 
+-    palette = im.getpalette()[:48]
++    palette = im.getpalette()[:12]
+     palette.extend(bytes(48 - len(palette)))
+     snespalette = bytearray()
+     for i in range(0, 48, 3):


### PR DESCRIPTION
The Python Pillow image library gives different output for `Image.getcolors()` in version 9 than version 10. This causes libbet's SGB border to be built differently, giving a different ROM hash and technically failing the test script.

This patches libbet to only keep the known-good colors. It also adapts the coverage script to run all the tests, including building the third-party projects.