### PR TITLE
Use `std::variant` for RPN expression value

### DIFF
--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -30,9 +30,6 @@ struct Expression {
 
 	Expression &operator=(Expression &&) = default;
 
-	bool isKnown() const { return std::holds_alternative<int32_t>(data); }
-	int32_t value() const;
-
 	int32_t getConstVal() const;
 	Symbol const *symbolOf() const;
 	bool isDiffConstant(Symbol const *symName) const;

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -30,6 +30,9 @@ struct Expression {
 
 	Expression &operator=(Expression &&) = default;
 
+	bool isKnown() const { return std::holds_alternative<int32_t>(data); }
+	int32_t value() const;
+
 	int32_t getConstVal() const;
 	Symbol const *symbolOf() const;
 	bool isDiffConstant(Symbol const *symName) const;

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -244,15 +244,15 @@ static void initpatch(Patch &patch, uint32_t type, Expression const &expr, uint3
 	patch.pcSection = sect_GetSymbolSection();
 	patch.pcOffset = sect_GetSymbolOffset();
 
-	if (int32_t const *val = std::get_if<int32_t>(&expr.data); val) {
+	if (expr.isKnown()) {
 		// If the RPN expr's value is known, output a constant directly
-		uint32_t uval = *val;
+		uint32_t val = expr.value();
 		patch.rpn.resize(5);
 		patch.rpn[0] = RPN_CONST;
-		patch.rpn[1] = uval & 0xFF;
-		patch.rpn[2] = uval >> 8;
-		patch.rpn[3] = uval >> 16;
-		patch.rpn[4] = uval >> 24;
+		patch.rpn[1] = val & 0xFF;
+		patch.rpn[2] = val >> 8;
+		patch.rpn[3] = val >> 16;
+		patch.rpn[4] = val >> 24;
 	} else {
 		patch.rpn.resize(expr.rpnPatchSize);
 		writerpn(patch.rpn, expr.rpn);

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -244,15 +244,15 @@ static void initpatch(Patch &patch, uint32_t type, Expression const &expr, uint3
 	patch.pcSection = sect_GetSymbolSection();
 	patch.pcOffset = sect_GetSymbolOffset();
 
-	if (expr.isKnown()) {
+	if (int32_t const *val = std::get_if<int32_t>(&expr.data); val) {
 		// If the RPN expr's value is known, output a constant directly
-		uint32_t val = expr.value();
+		uint32_t uval = *val;
 		patch.rpn.resize(5);
 		patch.rpn[0] = RPN_CONST;
-		patch.rpn[1] = val & 0xFF;
-		patch.rpn[2] = val >> 8;
-		patch.rpn[3] = val >> 16;
-		patch.rpn[4] = val >> 24;
+		patch.rpn[1] = uval & 0xFF;
+		patch.rpn[2] = uval >> 8;
+		patch.rpn[3] = uval >> 16;
+		patch.rpn[4] = uval >> 24;
 	} else {
 		patch.rpn.resize(expr.rpnPatchSize);
 		writerpn(patch.rpn, expr.rpn);

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -244,14 +244,15 @@ static void initpatch(Patch &patch, uint32_t type, Expression const &expr, uint3
 	patch.pcSection = sect_GetSymbolSection();
 	patch.pcOffset = sect_GetSymbolOffset();
 
-	if (expr.isKnown) {
+	if (expr.isKnown()) {
 		// If the RPN expr's value is known, output a constant directly
+		uint32_t val = expr.value();
 		patch.rpn.resize(5);
 		patch.rpn[0] = RPN_CONST;
-		patch.rpn[1] = (uint32_t)expr.val & 0xFF;
-		patch.rpn[2] = (uint32_t)expr.val >> 8;
-		patch.rpn[3] = (uint32_t)expr.val >> 16;
-		patch.rpn[4] = (uint32_t)expr.val >> 24;
+		patch.rpn[1] = val & 0xFF;
+		patch.rpn[2] = val >> 8;
+		patch.rpn[3] = val >> 16;
+		patch.rpn[4] = val >> 24;
 	} else {
 		patch.rpn.resize(expr.rpnPatchSize);
 		writerpn(patch.rpn, expr.rpn);

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -711,16 +711,16 @@ assert_type:
 
 assert:
 	POP_ASSERT assert_type relocexpr {
-		if (!$3.isKnown()) {
+		if (int32_t *val = std::get_if<int32_t>(&$3.data); !val) {
 			out_CreateAssert($2, $3, "", sect_GetOutputOffset());
-		} else if ($3.value() == 0) {
+		} else if (*val == 0) {
 			failAssert($2);
 		}
 	}
 	| POP_ASSERT assert_type relocexpr COMMA string {
-		if (!$3.isKnown()) {
+		if (int32_t *val = std::get_if<int32_t>(&$3.data); !val) {
 			out_CreateAssert($2, $3, $5, sect_GetOutputOffset());
-		} else if ($3.value() == 0) {
+		} else if (*val == 0) {
 			failAssertMsg($2, $5);
 		}
 	}
@@ -1304,7 +1304,7 @@ relocexpr_no_str:
 		$$.makeLow();
 	}
 	| OP_ISCONST LPAREN relocexpr RPAREN {
-		$$.makeNumber($3.isKnown());
+		$$.makeNumber(std::holds_alternative<int32_t>($3.data));
 	}
 	| OP_BANK LPAREN scoped_anon_id RPAREN {
 		// '@' is also an ID; it is handled here
@@ -1846,7 +1846,7 @@ z80_ldio:
 c_ind:
 	  LBRACK MODE_C RBRACK
 	| LBRACK relocexpr OP_ADD MODE_C RBRACK {
-		if (!$2.isKnown() || $2.value() != 0xFF00)
+		if (int32_t *val = std::get_if<int32_t>(&$2.data); !val || *val != 0xFF00)
 			::error("Expected constant expression equal to $FF00 for \"$ff00+c\"\n");
 	}
 ;
@@ -2060,10 +2060,10 @@ z80_rrca:
 z80_rst:
 	Z80_RST reloc_8bit {
 		$2.makeCheckRST();
-		if (!$2.isKnown())
-			sect_RelByte($2, 0);
+		if (int32_t *val = std::get_if<int32_t>(&$2.data); val)
+			sect_AbsByte(0xC7 | *val);
 		else
-			sect_AbsByte(0xC7 | $2.value());
+			sect_RelByte($2, 0);
 	}
 ;
 

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -711,16 +711,16 @@ assert_type:
 
 assert:
 	POP_ASSERT assert_type relocexpr {
-		if (!$3.isKnown) {
+		if (!$3.isKnown()) {
 			out_CreateAssert($2, $3, "", sect_GetOutputOffset());
-		} else if ($3.val == 0) {
+		} else if ($3.value() == 0) {
 			failAssert($2);
 		}
 	}
 	| POP_ASSERT assert_type relocexpr COMMA string {
-		if (!$3.isKnown) {
+		if (!$3.isKnown()) {
 			out_CreateAssert($2, $3, $5, sect_GetOutputOffset());
-		} else if ($3.val == 0) {
+		} else if ($3.value() == 0) {
 			failAssertMsg($2, $5);
 		}
 	}
@@ -1304,7 +1304,7 @@ relocexpr_no_str:
 		$$.makeLow();
 	}
 	| OP_ISCONST LPAREN relocexpr RPAREN {
-		$$.makeNumber($3.isKnown);
+		$$.makeNumber($3.isKnown());
 	}
 	| OP_BANK LPAREN scoped_anon_id RPAREN {
 		// '@' is also an ID; it is handled here
@@ -1846,7 +1846,7 @@ z80_ldio:
 c_ind:
 	  LBRACK MODE_C RBRACK
 	| LBRACK relocexpr OP_ADD MODE_C RBRACK {
-		if (!$2.isKnown || $2.val != 0xFF00)
+		if (!$2.isKnown() || $2.value() != 0xFF00)
 			::error("Expected constant expression equal to $FF00 for \"$ff00+c\"\n");
 	}
 ;
@@ -2060,10 +2060,10 @@ z80_rrca:
 z80_rst:
 	Z80_RST reloc_8bit {
 		$2.makeCheckRST();
-		if (!$2.isKnown)
+		if (!$2.isKnown())
 			sect_RelByte($2, 0);
 		else
-			sect_AbsByte(0xC7 | $2.val);
+			sect_AbsByte(0xC7 | $2.value());
 	}
 ;
 

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -711,16 +711,16 @@ assert_type:
 
 assert:
 	POP_ASSERT assert_type relocexpr {
-		if (int32_t *val = std::get_if<int32_t>(&$3.data); !val) {
+		if (!$3.isKnown()) {
 			out_CreateAssert($2, $3, "", sect_GetOutputOffset());
-		} else if (*val == 0) {
+		} else if ($3.value() == 0) {
 			failAssert($2);
 		}
 	}
 	| POP_ASSERT assert_type relocexpr COMMA string {
-		if (int32_t *val = std::get_if<int32_t>(&$3.data); !val) {
+		if (!$3.isKnown()) {
 			out_CreateAssert($2, $3, $5, sect_GetOutputOffset());
-		} else if (*val == 0) {
+		} else if ($3.value() == 0) {
 			failAssertMsg($2, $5);
 		}
 	}
@@ -1304,7 +1304,7 @@ relocexpr_no_str:
 		$$.makeLow();
 	}
 	| OP_ISCONST LPAREN relocexpr RPAREN {
-		$$.makeNumber(std::holds_alternative<int32_t>($3.data));
+		$$.makeNumber($3.isKnown());
 	}
 	| OP_BANK LPAREN scoped_anon_id RPAREN {
 		// '@' is also an ID; it is handled here
@@ -1846,7 +1846,7 @@ z80_ldio:
 c_ind:
 	  LBRACK MODE_C RBRACK
 	| LBRACK relocexpr OP_ADD MODE_C RBRACK {
-		if (int32_t *val = std::get_if<int32_t>(&$2.data); !val || *val != 0xFF00)
+		if (!$2.isKnown() || $2.value() != 0xFF00)
 			::error("Expected constant expression equal to $FF00 for \"$ff00+c\"\n");
 	}
 ;
@@ -2060,10 +2060,10 @@ z80_rrca:
 z80_rst:
 	Z80_RST reloc_8bit {
 		$2.makeCheckRST();
-		if (int32_t *val = std::get_if<int32_t>(&$2.data); val)
-			sect_AbsByte(0xC7 | *val);
-		else
+		if (!$2.isKnown())
 			sect_RelByte($2, 0);
+		else
+			sect_AbsByte(0xC7 | $2.value());
 	}
 ;
 

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -19,11 +19,6 @@
 
 using namespace std::literals;
 
-int32_t Expression::value() const {
-	assert(std::holds_alternative<int32_t>(data));
-	return std::get<int32_t>(data);
-}
-
 void Expression::clear() {
 	data = 0;
 	isSymbol = false;
@@ -43,11 +38,10 @@ uint8_t *Expression::reserveSpace(uint32_t size, uint32_t patchSize) {
 }
 
 int32_t Expression::getConstVal() const {
-	if (!isKnown()) {
-		error("Expected constant expression: %s\n", std::get<std::string>(data).c_str());
-		return 0;
-	}
-	return value();
+	if (int32_t const *val = std::get_if<int32_t>(&data); val)
+		return *val;
+	error("Expected constant expression: %s\n", std::get<std::string>(data).c_str());
+	return 0;
 }
 
 Symbol const *Expression::symbolOf() const {
@@ -219,14 +213,15 @@ static int32_t tryConstMask(Expression const &lhs, Expression const &rhs) {
 
 	assert(sym.isNumeric());
 
-	if (!expr.isKnown())
+	int32_t const *val = std::get_if<int32_t>(&expr.data);
+	if (!val)
 		return -1;
-	// We can now safely use `expr.value()`
+
 	Section const &sect = *sym.getSection();
 	int32_t unknownBits = (1 << 16) - (1 << sect.align); // The max alignment is 16
 
 	// The mask must ignore all unknown bits
-	if ((expr.value() & unknownBits) != 0)
+	if ((*val & unknownBits) != 0)
 		return -1;
 
 	// `sym.getValue()` attempts to add the section's address, but that's "-1"
@@ -239,8 +234,8 @@ static int32_t tryConstMask(Expression const &lhs, Expression const &rhs) {
 
 void Expression::makeHigh() {
 	isSymbol = false;
-	if (isKnown()) {
-		data = (int32_t)((uint32_t)value() >> 8 & 0xFF);
+	if (int32_t *val = std::get_if<int32_t>(&data); val) {
+		data = (int32_t)((uint32_t)*val >> 8 & 0xFF);
 	} else {
 		uint8_t bytes[] = {RPN_CONST, 8, 0, 0, 0, RPN_SHR, RPN_CONST, 0xFF, 0, 0, 0, RPN_AND};
 
@@ -250,8 +245,8 @@ void Expression::makeHigh() {
 
 void Expression::makeLow() {
 	isSymbol = false;
-	if (isKnown()) {
-		data = value() & 0xFF;
+	if (int32_t *val = std::get_if<int32_t>(&data); val) {
+		data = *val & 0xFF;
 	} else {
 		uint8_t bytes[] = {RPN_CONST, 0xFF, 0, 0, 0, RPN_AND};
 
@@ -261,8 +256,8 @@ void Expression::makeLow() {
 
 void Expression::makeNeg() {
 	isSymbol = false;
-	if (isKnown()) {
-		data = (int32_t) - (uint32_t)value();
+	if (int32_t *val = std::get_if<int32_t>(&data); val) {
+		data = (int32_t) - (uint32_t)*val;
 	} else {
 		*reserveSpace(1) = RPN_NEG;
 	}
@@ -270,8 +265,8 @@ void Expression::makeNeg() {
 
 void Expression::makeNot() {
 	isSymbol = false;
-	if (isKnown()) {
-		data = ~value();
+	if (int32_t *val = std::get_if<int32_t>(&data); val) {
+		data = ~*val;
 	} else {
 		*reserveSpace(1) = RPN_NOT;
 	}
@@ -279,8 +274,8 @@ void Expression::makeNot() {
 
 void Expression::makeLogicNot() {
 	isSymbol = false;
-	if (isKnown()) {
-		data = !value();
+	if (int32_t *val = std::get_if<int32_t>(&data); val) {
+		data = !*val;
 	} else {
 		*reserveSpace(1) = RPN_LOGNOT;
 	}
@@ -289,94 +284,96 @@ void Expression::makeLogicNot() {
 void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const &src2) {
 	clear();
 	// First, check if the expression is known
-	if (src1.isKnown() && src2.isKnown()) {
+	int32_t const *lval = std::get_if<int32_t>(&src1.data);
+	int32_t const *rval = std::get_if<int32_t>(&src2.data);
+	if (lval && rval) {
 		// If both expressions are known, just compute the value
-		int32_t lval = src1.value(), rval = src2.value();
-
 		switch (op) {
 		case RPN_LOGOR:
-			data = lval || rval;
+			data = *lval || *rval;
 			break;
 		case RPN_LOGAND:
-			data = lval && rval;
+			data = *lval && *rval;
 			break;
 		case RPN_LOGEQ:
-			data = lval == rval;
+			data = *lval == *rval;
 			break;
 		case RPN_LOGGT:
-			data = lval > rval;
+			data = *lval > *rval;
 			break;
 		case RPN_LOGLT:
-			data = lval < rval;
+			data = *lval < *rval;
 			break;
 		case RPN_LOGGE:
-			data = lval >= rval;
+			data = *lval >= *rval;
 			break;
 		case RPN_LOGLE:
-			data = lval <= rval;
+			data = *lval <= *rval;
 			break;
 		case RPN_LOGNE:
-			data = lval != rval;
+			data = *lval != *rval;
 			break;
 		case RPN_ADD:
-			data = (int32_t)((uint32_t)lval + (uint32_t)rval);
+			data = (int32_t)((uint32_t)*lval + (uint32_t)*rval);
 			break;
 		case RPN_SUB:
-			data = (int32_t)((uint32_t)lval - (uint32_t)rval);
+			data = (int32_t)((uint32_t)*lval - (uint32_t)*rval);
 			break;
 		case RPN_XOR:
-			data = lval ^ rval;
+			data = *lval ^ *rval;
 			break;
 		case RPN_OR:
-			data = lval | rval;
+			data = *lval | *rval;
 			break;
 		case RPN_AND:
-			data = lval & rval;
+			data = *lval & *rval;
 			break;
 		case RPN_SHL:
-			if (rval < 0)
+			if (*rval < 0)
 				warning(
-				    WARNING_SHIFT_AMOUNT, "Shifting left by negative amount %" PRId32 "\n", rval
+				    WARNING_SHIFT_AMOUNT, "Shifting left by negative amount %" PRId32 "\n", *rval
 				);
 
-			if (rval >= 32)
-				warning(WARNING_SHIFT_AMOUNT, "Shifting left by large amount %" PRId32 "\n", rval);
+			if (*rval >= 32)
+				warning(WARNING_SHIFT_AMOUNT, "Shifting left by large amount %" PRId32 "\n", *rval);
 
-			data = op_shift_left(lval, rval);
+			data = op_shift_left(*lval, *rval);
 			break;
 		case RPN_SHR:
-			if (lval < 0)
-				warning(WARNING_SHIFT, "Shifting right negative value %" PRId32 "\n", lval);
+			if (*lval < 0)
+				warning(WARNING_SHIFT, "Shifting right negative value %" PRId32 "\n", *lval);
 
-			if (rval < 0)
+			if (*rval < 0)
 				warning(
-				    WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32 "\n", rval
+				    WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32 "\n", *rval
 				);
 
-			if (rval >= 32)
-				warning(WARNING_SHIFT_AMOUNT, "Shifting right by large amount %" PRId32 "\n", rval);
+			if (*rval >= 32)
+				warning(WARNING_SHIFT_AMOUNT, "Shifting right by large amount %" PRId32 "\n", *rval);
 
-			data = op_shift_right(lval, rval);
+			data = op_shift_right(*lval, *rval);
 			break;
 		case RPN_USHR:
-			if (rval < 0)
+			if (*rval < 0)
 				warning(
-				    WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32 "\n", rval
+				    WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32 "\n", *rval
 				);
 
-			if (rval >= 32)
-				warning(WARNING_SHIFT_AMOUNT, "Shifting right by large amount %" PRId32 "\n", rval);
+			if (*rval >= 32)
+				warning(
+				    WARNING_SHIFT_AMOUNT, "Shifting right by large amount %" PRId32 "\n", *rval
+				);
 
-			data = op_shift_right_unsigned(lval, rval);
+			data = op_shift_right_unsigned(*lval, *rval);
 			break;
 		case RPN_MUL:
-			data = (int32_t)((uint32_t)lval * (uint32_t)rval);
+			data = (int32_t)((uint32_t)*lval * (uint32_t)*rval);
 			break;
 		case RPN_DIV:
-			if (rval == 0)
+			if (*rval == 0)
 				fatalerror("Division by zero\n");
 
-			if (lval == INT32_MIN && rval == -1) {
+			if (*lval == INT32_MIN && *rval == -1) {
 				warning(
 				    WARNING_DIV,
 				    "Division of %" PRId32 " by -1 yields %" PRId32 "\n",
@@ -385,23 +382,23 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 				);
 				data = INT32_MIN;
 			} else {
-				data = op_divide(lval, rval);
+				data = op_divide(*lval, *rval);
 			}
 			break;
 		case RPN_MOD:
-			if (rval == 0)
+			if (*rval == 0)
 				fatalerror("Modulo by zero\n");
 
-			if (lval == INT32_MIN && rval == -1)
+			if (*lval == INT32_MIN && *rval == -1)
 				data = 0;
 			else
-				data = op_modulo(lval, rval);
+				data = op_modulo(*lval, *rval);
 			break;
 		case RPN_EXP:
-			if (rval < 0)
+			if (*rval < 0)
 				fatalerror("Exponentiation by negative power\n");
 
-			data = op_exponent(lval, rval);
+			data = op_exponent(*lval, *rval);
 			break;
 
 		case RPN_NEG:
@@ -428,14 +425,14 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 		// If it's not known, start computing the RPN expression
 
 		// Convert the left-hand expression if it's constant
-		if (src1.isKnown()) {
-			uint32_t lval = src1.value();
+		if (lval) {
+			uint32_t uval = *lval;
 			uint8_t bytes[] = {
 			    RPN_CONST,
-			    (uint8_t)lval,
-			    (uint8_t)(lval >> 8),
-			    (uint8_t)(lval >> 16),
-			    (uint8_t)(lval >> 24),
+			    (uint8_t)uval,
+			    (uint8_t)(uval >> 8),
+			    (uint8_t)(uval >> 16),
+			    (uint8_t)(uval >> 24),
 			};
 			rpn.clear();
 			rpnPatchSize = 0;
@@ -451,15 +448,15 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 		}
 
 		// Now, merge the right expression into the left one
-		if (src2.isKnown()) {
+		if (rval) {
 			// If the right expression is constant, append a shim instead
-			uint32_t rval = src2.value();
+			uint32_t uval = *rval;
 			uint8_t bytes[] = {
 			    RPN_CONST,
-			    (uint8_t)rval,
-			    (uint8_t)(rval >> 8),
-			    (uint8_t)(rval >> 16),
-			    (uint8_t)(rval >> 24),
+			    (uint8_t)uval,
+			    (uint8_t)(uval >> 8),
+			    (uint8_t)(uval >> 16),
+			    (uint8_t)(uval >> 24),
 			};
 			uint8_t *ptr = reserveSpace(sizeof(bytes) + 1, sizeof(bytes) + 1);
 			memcpy(ptr, bytes, sizeof(bytes));
@@ -478,25 +475,25 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 
 void Expression::makeCheckHRAM() {
 	isSymbol = false;
-	if (!isKnown()) {
+	if (int32_t *val = std::get_if<int32_t>(&data); !val) {
 		*reserveSpace(1) = RPN_HRAM;
-	} else if (int32_t val = value(); val >= 0xFF00 && val <= 0xFFFF) {
+	} else if (*val >= 0xFF00 && *val <= 0xFFFF) {
 		// That range is valid, but only keep the lower byte
-		data = val & 0xFF;
-	} else if (val < 0 || val > 0xFF) {
-		error("Source address $%" PRIx32 " not between $FF00 to $FFFF\n", val);
+		data = *val & 0xFF;
+	} else if (*val < 0 || *val > 0xFF) {
+		error("Source address $%" PRIx32 " not between $FF00 to $FFFF\n", *val);
 	}
 }
 
 void Expression::makeCheckRST() {
-	if (!isKnown()) {
+	if (int32_t *val = std::get_if<int32_t>(&data); !val) {
 		*reserveSpace(1) = RPN_RST;
-	} else if (int32_t val = value(); val & ~0x38) {
+	} else if (*val & ~0x38) {
 		// A valid RST address must be masked with 0x38
-		error("Invalid address $%" PRIx32 " for RST\n", val);
+		error("Invalid address $%" PRIx32 " for RST\n", *val);
 	} else {
 		// The target is in the "0x38" bits, all other bits are set
-		data = val | 0xC7;
+		data = *val | 0xC7;
 	}
 }
 
@@ -505,10 +502,10 @@ void Expression::checkNBit(uint8_t n) const {
 	assert(n != 0);                     // That doesn't make sense
 	assert(n < CHAR_BIT * sizeof(int)); // Otherwise `1 << n` is UB
 
-	if (isKnown()) {
-		if (int32_t val = value(); val < -(1 << n) || val >= 1 << n)
+	if (int32_t const *val = std::get_if<int32_t>(&data); val) {
+		if (*val < -(1 << n) || *val >= 1 << n)
 			warning(WARNING_TRUNCATION_1, "Expression must be %u-bit\n", n);
-		else if (val < -(1 << (n - 1)))
+		else if (*val < -(1 << (n - 1)))
 			warning(WARNING_TRUNCATION_2, "Expression must be %u-bit\n", n);
 	}
 }

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -734,11 +734,11 @@ void sect_RelByte(Expression &expr, uint32_t pcShift) {
 	if (!reserveSpace(1))
 		return;
 
-	if (int32_t *val = std::get_if<int32_t>(&expr.data); val) {
-		writebyte(*val);
-	} else {
+	if (!expr.isKnown()) {
 		createPatch(PATCHTYPE_BYTE, expr, pcShift);
 		writebyte(0);
+	} else {
+		writebyte(expr.value());
 	}
 }
 
@@ -753,11 +753,11 @@ void sect_RelBytes(uint32_t n, std::vector<Expression> &exprs) {
 	for (uint32_t i = 0; i < n; i++) {
 		Expression &expr = exprs[i % exprs.size()];
 
-		if (int32_t *val = std::get_if<int32_t>(&expr.data); val) {
-			writebyte(*val);
-		} else {
+		if (!expr.isKnown()) {
 			createPatch(PATCHTYPE_BYTE, expr, i);
 			writebyte(0);
+		} else {
+			writebyte(expr.value());
 		}
 	}
 }
@@ -770,11 +770,11 @@ void sect_RelWord(Expression &expr, uint32_t pcShift) {
 	if (!reserveSpace(2))
 		return;
 
-	if (int32_t *val = std::get_if<int32_t>(&expr.data); val) {
-		writeword(*val);
-	} else {
+	if (!expr.isKnown()) {
 		createPatch(PATCHTYPE_WORD, expr, pcShift);
 		writeword(0);
+	} else {
+		writeword(expr.value());
 	}
 }
 
@@ -786,11 +786,11 @@ void sect_RelLong(Expression &expr, uint32_t pcShift) {
 	if (!reserveSpace(2))
 		return;
 
-	if (int32_t *val = std::get_if<int32_t>(&expr.data); val) {
-		writelong(*val);
-	} else {
+	if (!expr.isKnown()) {
 		createPatch(PATCHTYPE_LONG, expr, pcShift);
 		writelong(0);
+	} else {
+		writelong(expr.value());
 	}
 }
 

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -734,11 +734,11 @@ void sect_RelByte(Expression &expr, uint32_t pcShift) {
 	if (!reserveSpace(1))
 		return;
 
-	if (!expr.isKnown) {
+	if (!expr.isKnown()) {
 		createPatch(PATCHTYPE_BYTE, expr, pcShift);
 		writebyte(0);
 	} else {
-		writebyte(expr.val);
+		writebyte(expr.value());
 	}
 }
 
@@ -753,11 +753,11 @@ void sect_RelBytes(uint32_t n, std::vector<Expression> &exprs) {
 	for (uint32_t i = 0; i < n; i++) {
 		Expression &expr = exprs[i % exprs.size()];
 
-		if (!expr.isKnown) {
+		if (!expr.isKnown()) {
 			createPatch(PATCHTYPE_BYTE, expr, i);
 			writebyte(0);
 		} else {
-			writebyte(expr.val);
+			writebyte(expr.value());
 		}
 	}
 }
@@ -770,11 +770,11 @@ void sect_RelWord(Expression &expr, uint32_t pcShift) {
 	if (!reserveSpace(2))
 		return;
 
-	if (!expr.isKnown) {
+	if (!expr.isKnown()) {
 		createPatch(PATCHTYPE_WORD, expr, pcShift);
 		writeword(0);
 	} else {
-		writeword(expr.val);
+		writeword(expr.value());
 	}
 }
 
@@ -786,11 +786,11 @@ void sect_RelLong(Expression &expr, uint32_t pcShift) {
 	if (!reserveSpace(2))
 		return;
 
-	if (!expr.isKnown) {
+	if (!expr.isKnown()) {
 		createPatch(PATCHTYPE_LONG, expr, pcShift);
 		writelong(0);
 	} else {
-		writelong(expr.val);
+		writelong(expr.value());
 	}
 }
 

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -734,11 +734,11 @@ void sect_RelByte(Expression &expr, uint32_t pcShift) {
 	if (!reserveSpace(1))
 		return;
 
-	if (!expr.isKnown()) {
+	if (int32_t *val = std::get_if<int32_t>(&expr.data); val) {
+		writebyte(*val);
+	} else {
 		createPatch(PATCHTYPE_BYTE, expr, pcShift);
 		writebyte(0);
-	} else {
-		writebyte(expr.value());
 	}
 }
 
@@ -753,11 +753,11 @@ void sect_RelBytes(uint32_t n, std::vector<Expression> &exprs) {
 	for (uint32_t i = 0; i < n; i++) {
 		Expression &expr = exprs[i % exprs.size()];
 
-		if (!expr.isKnown()) {
+		if (int32_t *val = std::get_if<int32_t>(&expr.data); val) {
+			writebyte(*val);
+		} else {
 			createPatch(PATCHTYPE_BYTE, expr, i);
 			writebyte(0);
-		} else {
-			writebyte(expr.value());
 		}
 	}
 }
@@ -770,11 +770,11 @@ void sect_RelWord(Expression &expr, uint32_t pcShift) {
 	if (!reserveSpace(2))
 		return;
 
-	if (!expr.isKnown()) {
+	if (int32_t *val = std::get_if<int32_t>(&expr.data); val) {
+		writeword(*val);
+	} else {
 		createPatch(PATCHTYPE_WORD, expr, pcShift);
 		writeword(0);
-	} else {
-		writeword(expr.value());
 	}
 }
 
@@ -786,11 +786,11 @@ void sect_RelLong(Expression &expr, uint32_t pcShift) {
 	if (!reserveSpace(2))
 		return;
 
-	if (!expr.isKnown()) {
+	if (int32_t *val = std::get_if<int32_t>(&expr.data); val) {
+		writelong(*val);
+	} else {
 		createPatch(PATCHTYPE_LONG, expr, pcShift);
 		writelong(0);
-	} else {
-		writelong(expr.value());
 	}
 }
 


### PR DESCRIPTION
Note that although this is a semantically-sensible refactoring, it does decrease performance a little. I'm planning to fix that up for all `std::variant`s at once, possibly with some refactoring, possibly with a similarly-behaved custom generic class, possibly by just using tagged `union`s with `assert`s.

Note: I tried using only `std::get_if`, not `std::get`, but that did not decrease the runtime.