### PR TITLE
Replace `assert` with `assume` for release build optimization

### DIFF
--- a/include/file.hpp
+++ b/include/file.hpp
@@ -3,7 +3,6 @@
 #ifndef RGBDS_FILE_HPP
 #define RGBDS_FILE_HPP
 
-#include <assert.h>
 #include <fcntl.h>
 #include <fstream>
 #include <ios>
@@ -13,6 +12,7 @@
 #include <string>
 #include <variant>
 
+#include "helpers.hpp" // assume
 #include "platform.hpp"
 
 #include "gfx/main.hpp"
@@ -33,7 +33,7 @@ public:
 		if (path != "-") {
 			return _file.emplace<std::filebuf>().open(path, mode) ? this : nullptr;
 		} else if (mode & std::ios_base::in) {
-			assert(!(mode & std::ios_base::out));
+			assume(!(mode & std::ios_base::out));
 			_file.emplace<std::streambuf *>(std::cin.rdbuf());
 			if (setmode(STDIN_FILENO, (mode & std::ios_base::binary) ? O_BINARY : O_TEXT) == -1) {
 				fatal(
@@ -43,7 +43,7 @@ public:
 				);
 			}
 		} else {
-			assert(mode & std::ios_base::out);
+			assume(mode & std::ios_base::out);
 			_file.emplace<std::streambuf *>(std::cout.rdbuf());
 		}
 		return this;

--- a/include/linkdefs.hpp
+++ b/include/linkdefs.hpp
@@ -3,9 +3,10 @@
 #ifndef RGBDS_LINKDEFS_H
 #define RGBDS_LINKDEFS_H
 
-#include <assert.h>
 #include <stdint.h>
 #include <string>
+
+#include "helpers.hpp" // assume
 
 #define RGBDS_OBJECT_VERSION_STRING "RGBA"
 #define RGBDS_OBJECT_REV            10U
@@ -93,7 +94,7 @@ extern struct SectionTypeInfo {
  * @return `true` if the section's definition includes data
  */
 static inline bool sect_HasData(SectionType type) {
-	assert(type != SECTTYPE_INVALID);
+	assume(type != SECTTYPE_INVALID);
 	return type == SECTTYPE_ROM0 || type == SECTTYPE_ROMX;
 }
 

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -3,7 +3,6 @@
 #include "asm/fstack.hpp"
 #include <sys/stat.h>
 
-#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <memory>
@@ -50,28 +49,28 @@ static std::vector<std::string> includePaths = {""};
 static std::string preIncludeName;
 
 std::vector<uint32_t> &FileStackNode::iters() {
-	assert(std::holds_alternative<std::vector<uint32_t>>(data));
+	assume(std::holds_alternative<std::vector<uint32_t>>(data));
 	return std::get<std::vector<uint32_t>>(data);
 }
 
 std::vector<uint32_t> const &FileStackNode::iters() const {
-	assert(std::holds_alternative<std::vector<uint32_t>>(data));
+	assume(std::holds_alternative<std::vector<uint32_t>>(data));
 	return std::get<std::vector<uint32_t>>(data);
 }
 
 std::string &FileStackNode::name() {
-	assert(std::holds_alternative<std::string>(data));
+	assume(std::holds_alternative<std::string>(data));
 	return std::get<std::string>(data);
 }
 
 std::string const &FileStackNode::name() const {
-	assert(std::holds_alternative<std::string>(data));
+	assume(std::holds_alternative<std::string>(data));
 	return std::get<std::string>(data);
 }
 
 std::string const &FileStackNode::dump(uint32_t curLineNo) const {
 	if (std::holds_alternative<std::vector<uint32_t>>(data)) {
-		assert(parent); // REPT nodes use their parent's name
+		assume(parent); // REPT nodes use their parent's name
 		std::string const &lastName = parent->dump(lineNo);
 		fputs(" -> ", stderr);
 		fputs(lastName.c_str(), stderr);
@@ -270,7 +269,7 @@ static void newMacroContext(Symbol const &macro, std::shared_ptr<MacroArgs> macr
 	fileInfoName.append(macro.name);
 
 	auto fileInfo = std::make_shared<FileStackNode>(NODE_MACRO, fileInfoName);
-	assert(!contextStack.empty()); // The top level context cannot be a MACRO
+	assume(!contextStack.empty()); // The top level context cannot be a MACRO
 	fileInfo->parent = oldContext.fileInfo;
 	fileInfo->lineNo = lexer_GetLineNo();
 
@@ -295,7 +294,7 @@ static Context &newReptContext(int32_t reptLineNo, ContentSpan const &span, uint
 	}
 
 	auto fileInfo = std::make_shared<FileStackNode>(NODE_REPT, fileInfoIters);
-	assert(!contextStack.empty()); // The top level context cannot be a REPT
+	assume(!contextStack.empty()); // The top level context cannot be a REPT
 	fileInfo->parent = oldContext.fileInfo;
 	fileInfo->lineNo = reptLineNo;
 

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -2,7 +2,6 @@
 
 #include "asm/output.hpp"
 
-#include <assert.h>
 #include <deque>
 #include <inttypes.h>
 #include <stdio.h>
@@ -12,7 +11,7 @@
 #include <vector>
 
 #include "error.hpp"
-#include "helpers.hpp" // Defer
+#include "helpers.hpp" // assume, Defer
 
 #include "asm/fstack.hpp"
 #include "asm/lexer.hpp"
@@ -75,7 +74,7 @@ static uint32_t getSectIDIfAny(Section *sect) {
 
 // Write a patch to a file
 static void writepatch(Patch const &patch, FILE *file) {
-	assert(patch.src->ID != (uint32_t)-1);
+	assume(patch.src->ID != (uint32_t)-1);
 	putlong(patch.src->ID, file);
 	putlong(patch.lineNo, file);
 	putlong(patch.offset, file);
@@ -117,7 +116,7 @@ static void writesymbol(Symbol const &sym, FILE *file) {
 	if (!sym.isDefined()) {
 		putc(SYMTYPE_IMPORT, file);
 	} else {
-		assert(sym.src->ID != (uint32_t)-1);
+		assume(sym.src->ID != (uint32_t)-1);
 
 		putc(sym.isExported ? SYMTYPE_EXPORT : SYMTYPE_LOCAL, file);
 		putlong(sym.src->ID, file);

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -2542,7 +2542,7 @@ static std::string strfmt(
 		} else if (auto *n = std::get_if<uint32_t>(&args[argIndex]); n) {
 			fmt.appendNumber(str, *n);
 		} else {
-			assert(std::holds_alternative<std::string>(args[argIndex]));
+			assume(std::holds_alternative<std::string>(args[argIndex]));
 			auto &s = std::get<std::string>(args[argIndex]);
 			fmt.appendString(str, s);
 		}

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -3,7 +3,6 @@
 #include "asm/section.hpp"
 
 #include <algorithm>
-#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <optional>
@@ -125,7 +124,7 @@ Section *sect_FindSectionByName(std::string const &name) {
 static unsigned int mergeSectUnion(
     Section &sect, SectionType type, uint32_t org, uint8_t alignment, uint16_t alignOffset
 ) {
-	assert(alignment < 16); // Should be ensured by the caller
+	assume(alignment < 16); // Should be ensured by the caller
 	unsigned int nbSectErrors = 0;
 
 	// Unionized sections only need "compatible" constraints, and they end up with the strictest
@@ -177,7 +176,7 @@ static unsigned int mergeSectUnion(
 
 static unsigned int
     mergeFragments(Section &sect, uint32_t org, uint8_t alignment, uint16_t alignOffset) {
-	assert(alignment < 16); // Should be ensured by the caller
+	assume(alignment < 16); // Should be ensured by the caller
 	unsigned int nbSectErrors = 0;
 
 	// Fragments only need "compatible" constraints, and they end up with the strictest

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -2,12 +2,12 @@
 
 #include "asm/symbol.hpp"
 
-#include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <unordered_map>
 
 #include "error.hpp"
+#include "helpers.hpp" // assume
 #include "version.hpp"
 
 #include "asm/fstack.hpp"
@@ -55,7 +55,7 @@ static int32_t CallbackPC() {
 }
 
 int32_t Symbol::getValue() const {
-	assert(std::holds_alternative<int32_t>(data) || std::holds_alternative<int32_t (*)()>(data));
+	assume(std::holds_alternative<int32_t>(data) || std::holds_alternative<int32_t (*)()>(data));
 	if (auto *value = std::get_if<int32_t>(&data); value) {
 		return type == SYM_LABEL ? *value + getSection()->org : *value;
 	}
@@ -73,12 +73,12 @@ int32_t Symbol::getOutputValue() const {
 }
 
 ContentSpan const &Symbol::getMacro() const {
-	assert((std::holds_alternative<ContentSpan>(data)));
+	assume((std::holds_alternative<ContentSpan>(data)));
 	return std::get<ContentSpan>(data);
 }
 
 std::shared_ptr<std::string> Symbol::getEqus() const {
-	assert(std::holds_alternative<std::shared_ptr<std::string>>(data));
+	assume(std::holds_alternative<std::shared_ptr<std::string>>(data));
 	return std::get<std::shared_ptr<std::string>>(data);
 }
 
@@ -361,7 +361,7 @@ Symbol *sym_AddVar(std::string const &symName, int32_t value) {
  * @return The created symbol
  */
 static Symbol *addLabel(std::string const &symName) {
-	assert(!symName.starts_with('.')); // The symbol name must have been expanded prior
+	assume(!symName.starts_with('.')); // The symbol name must have been expanded prior
 	Symbol *sym = sym_FindExactSymbol(symName);
 
 	if (!sym) {
@@ -390,11 +390,11 @@ static Symbol *addLabel(std::string const &symName) {
 // Add a local (`.name` or `Parent.name`) relocatable symbol
 Symbol *sym_AddLocalLabel(std::string const &symName) {
 	// Assuming no dots in `labelScope` if defined
-	assert(!labelScope.has_value() || labelScope->find('.') == std::string::npos);
+	assume(!labelScope.has_value() || labelScope->find('.') == std::string::npos);
 
 	size_t dotPos = symName.find('.');
 
-	assert(dotPos != std::string::npos); // There should be at least one dot in `symName`
+	assume(dotPos != std::string::npos); // There should be at least one dot in `symName`
 
 	// Check for something after the dot
 	if (dotPos == symName.length() - 1) {

--- a/src/fix/main.cpp
+++ b/src/fix/main.cpp
@@ -3,7 +3,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include <assert.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdarg.h>
@@ -774,7 +773,7 @@ static uint8_t maxTitleLen() {
 
 static ssize_t readBytes(int fd, uint8_t *buf, size_t len) {
 	// POSIX specifies that lengths greater than SSIZE_MAX yield implementation-defined results
-	assert(len <= SSIZE_MAX);
+	assume(len <= SSIZE_MAX);
 
 	ssize_t total = 0;
 
@@ -799,7 +798,7 @@ static ssize_t readBytes(int fd, uint8_t *buf, size_t len) {
 
 static ssize_t writeBytes(int fd, uint8_t *buf, size_t len) {
 	// POSIX specifies that lengths greater than SSIZE_MAX yield implementation-defined results
-	assert(len <= SSIZE_MAX);
+	assume(len <= SSIZE_MAX);
 
 	ssize_t total = 0;
 
@@ -869,9 +868,9 @@ static void overwriteBytes(
 static void processFile(int input, int output, char const *name, off_t fileSize) {
 	// Both of these should be true for seekable files, and neither otherwise
 	if (input == output)
-		assert(fileSize != 0);
+		assume(fileSize != 0);
 	else
-		assert(fileSize == 0);
+		assume(fileSize == 0);
 
 	uint8_t rom0[BANK_SIZE];
 	ssize_t rom0Len = readBytes(input, rom0, sizeof(rom0));
@@ -1037,9 +1036,9 @@ static void processFile(int input, int output, char const *name, off_t fileSize)
 			}
 			nbBanks = 2;
 		} else {
-			assert(rom0Len == sizeof(rom0));
+			assume(rom0Len == sizeof(rom0));
 		}
-		assert(nbBanks >= 2);
+		assume(nbBanks >= 2);
 		// Alter number of banks to reflect required value
 		// x&(x-1) is zero iff x is a power of 2, or 0; we know for sure it's non-zero,
 		// so this is true (non-zero) when we don't have a power of 2
@@ -1063,7 +1062,7 @@ static void processFile(int input, int output, char const *name, off_t fileSize)
 
 	if (fixSpec & (FIX_GLOBAL_SUM | TRASH_GLOBAL_SUM)) {
 		// Computation of the global checksum does not include the checksum bytes
-		assert(rom0Len >= 0x14E);
+		assume(rom0Len >= 0x14E);
 		for (uint16_t i = 0; i < 0x14E; i++)
 			globalSum += rom0[i];
 		for (uint16_t i = 0x150; i < rom0Len; i++)

--- a/src/gfx/main.cpp
+++ b/src/gfx/main.cpp
@@ -3,7 +3,6 @@
 #include "gfx/main.hpp"
 
 #include <algorithm>
-#include <assert.h>
 #include <ctype.h>
 #include <inttypes.h>
 #include <ios>
@@ -17,6 +16,7 @@
 
 #include "extern/getopt.hpp"
 #include "file.hpp"
+#include "helpers.hpp" // assume
 #include "platform.hpp"
 #include "version.hpp"
 
@@ -633,7 +633,7 @@ int main(int argc, char *argv[]) {
 
 		if (musl_optind != curArgc) {
 			// This happens if `--` is passed, process the remaining arg(s) as positional
-			assert(musl_optind < curArgc);
+			assume(musl_optind < curArgc);
 			for (int i = musl_optind; i < curArgc; ++i) {
 				registerInput(argv[i]);
 			}
@@ -845,7 +845,7 @@ int main(int argc, char *argv[]) {
 
 void Palette::addColor(uint16_t color) {
 	for (size_t i = 0; true; ++i) {
-		assert(i < colors.size()); // The packing should guarantee this
+		assume(i < colors.size()); // The packing should guarantee this
 		if (colors[i] == color) {  // The color is already present
 			break;
 		} else if (colors[i] == UINT16_MAX) { // Empty slot

--- a/src/gfx/pal_packing.cpp
+++ b/src/gfx/pal_packing.cpp
@@ -3,7 +3,6 @@
 #include "gfx/pal_packing.hpp"
 
 #include <algorithm>
-#include <assert.h>
 #include <deque>
 #include <inttypes.h>
 #include <optional>
@@ -107,7 +106,7 @@ private:
 			return it;
 		}
 		reference operator*() const {
-			assert((*_iter).has_value());
+			assume((*_iter).has_value());
 			return **_iter;
 		}
 		pointer operator->() const {
@@ -308,7 +307,7 @@ static void decant(
 			// Build up the "component"...
 			colors.clear();
 			members.clear();
-			assert(members.empty()); // Compiler optimization hint
+			assume(members.empty()); // Compiler optimization hint
 			do {
 				ProtoPalette const &protoPal = protoPalettes[attrs->protoPalIndex];
 				// If this is the first proto-pal, or if at least one color matches, add it

--- a/src/gfx/pal_sorting.cpp
+++ b/src/gfx/pal_sorting.cpp
@@ -3,7 +3,6 @@
 #include "gfx/pal_sorting.hpp"
 
 #include <algorithm>
-#include <assert.h>
 
 #include "helpers.hpp"
 
@@ -55,7 +54,7 @@ void grayscale(
 
 	// This method is only applicable if there are at most as many colors as colors per palette, so
 	// we should only have a single palette.
-	assert(palettes.size() == 1);
+	assume(palettes.size() == 1);
 
 	Palette &palette = palettes[0];
 	std::fill(RANGE(palette.colors), Rgba::transparent);

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -3,7 +3,6 @@
 #include "gfx/pal_spec.hpp"
 
 #include <algorithm>
-#include <assert.h>
 #include <charconv>
 #include <fstream>
 #include <inttypes.h>
@@ -26,13 +25,13 @@ using namespace std::string_view_literals;
 
 constexpr uint8_t nibble(char c) {
 	if (c >= 'a') {
-		assert(c <= 'f');
+		assume(c <= 'f');
 		return c - 'a' + 10;
 	} else if (c >= 'A') {
-		assert(c <= 'F');
+		assume(c <= 'F');
 		return c - 'A' + 10;
 	} else {
-		assert(c >= '0' && c <= '9');
+		assume(c >= '0' && c <= '9');
 		return c - '0';
 	}
 }
@@ -59,8 +58,8 @@ void parseInlinePalSpec(char const * const rawArg) {
 
 	auto parseError = [&rawArg, &arg](size_type ofs, size_type len, char const *msg) {
 		(void)arg; // With NDEBUG, `arg` is otherwise not used
-		assert(ofs <= arg.length());
-		assert(len <= arg.length());
+		assume(ofs <= arg.length());
+		assume(len <= arg.length());
 
 		errorMessage(msg);
 		fprintf(
@@ -178,7 +177,7 @@ void parseInlinePalSpec(char const * const rawArg) {
  */
 template<size_t n>
 static bool readMagic(std::filebuf &file, char const *magic) {
-	assert(strlen(magic) == n);
+	assume(strlen(magic) == n);
 
 	char magicBuf[n];
 	return file.sgetn(magicBuf, n) == n && memcmp(magicBuf, magic, n);

--- a/src/gfx/proto_palette.cpp
+++ b/src/gfx/proto_palette.cpp
@@ -3,7 +3,6 @@
 #include "gfx/proto_palette.hpp"
 
 #include <algorithm>
-#include <assert.h>
 
 #include "helpers.hpp"
 
@@ -41,8 +40,8 @@ bool ProtoPalette::add(uint16_t color) {
 
 ProtoPalette::ComparisonResult ProtoPalette::compare(ProtoPalette const &other) const {
 	// This works because the sets are sorted numerically
-	assert(std::is_sorted(RANGE(_colorIndices)));
-	assert(std::is_sorted(RANGE(other._colorIndices)));
+	assume(std::is_sorted(RANGE(_colorIndices)));
+	assume(std::is_sorted(RANGE(other._colorIndices)));
 
 	auto ours = _colorIndices.begin(), theirs = other._colorIndices.begin();
 	bool weBigger = true, theyBigger = true;

--- a/src/gfx/reverse.cpp
+++ b/src/gfx/reverse.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <array>
-#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <optional>
@@ -14,6 +13,7 @@
 
 #include "defaultinitalloc.hpp"
 #include "file.hpp"
+#include "helpers.hpp" // assume
 #include "itertools.hpp"
 
 #include "gfx/main.hpp"
@@ -42,7 +42,7 @@ static DefaultInitVec<uint8_t> readInto(std::string const &path) {
 
 		// Arbitrary, but if you got a better idea...
 		size_t newSize = oldSize != data.capacity() ? data.capacity() : oldSize * 2;
-		assert(oldSize != newSize);
+		assume(oldSize != newSize);
 		data.resize(newSize);
 	}
 
@@ -343,9 +343,9 @@ void reverse() {
 				tileID =
 				    (*tilemap)[index] - options.baseTileIDs[bank] + bank * options.maxNbTiles[0];
 			}
-			assert(tileID < nbTileInstances); // Should have been checked earlier
+			assume(tileID < nbTileInstances); // Should have been checked earlier
 			size_t palID = palmap ? (*palmap)[index] : attribute & 0b111;
-			assert(palID < palettes.size()); // Should be ensured on data read
+			assume(palID < palettes.size()); // Should be ensured on data read
 
 			// We do not have data for tiles trimmed with `-x`, so assume they are "blank"
 			static std::array<uint8_t, 16> const trimmedTile{

--- a/src/gfx/rgba.cpp
+++ b/src/gfx/rgba.cpp
@@ -3,9 +3,10 @@
 #include "gfx/rgba.hpp"
 
 #include <algorithm>
-#include <assert.h>
 #include <math.h>
 #include <stdint.h>
+
+#include "helpers.hpp" // assume
 
 #include "gfx/main.hpp" // options
 
@@ -37,7 +38,7 @@ uint16_t Rgba::cgbColor() const {
 	if (isTransparent()) {
 		return transparent;
 	}
-	assert(isOpaque());
+	assume(isOpaque());
 
 	uint8_t r = red, g = green, b = blue;
 	if (options.useColorCurve) {
@@ -56,7 +57,7 @@ uint16_t Rgba::cgbColor() const {
 }
 
 uint8_t Rgba::grayIndex() const {
-	assert(isGray());
+	assume(isGray());
 	// Convert from [0; 256[ to [0; maxOpaqueColors[
 	return static_cast<uint16_t>(255 - red) * options.maxOpaqueColors() / 256;
 }

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -3,7 +3,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include <assert.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <stdarg.h>
@@ -12,6 +11,7 @@
 
 #include "error.hpp"
 #include "extern/getopt.hpp"
+#include "helpers.hpp" // assume
 #include "itertools.hpp"
 #include "platform.hpp"
 #include "script.hpp"
@@ -46,28 +46,28 @@ FILE *linkerScript;
 static uint32_t nbErrors = 0;
 
 std::vector<uint32_t> &FileStackNode::iters() {
-	assert(std::holds_alternative<std::vector<uint32_t>>(data));
+	assume(std::holds_alternative<std::vector<uint32_t>>(data));
 	return std::get<std::vector<uint32_t>>(data);
 }
 
 std::vector<uint32_t> const &FileStackNode::iters() const {
-	assert(std::holds_alternative<std::vector<uint32_t>>(data));
+	assume(std::holds_alternative<std::vector<uint32_t>>(data));
 	return std::get<std::vector<uint32_t>>(data);
 }
 
 std::string &FileStackNode::name() {
-	assert(std::holds_alternative<std::string>(data));
+	assume(std::holds_alternative<std::string>(data));
 	return std::get<std::string>(data);
 }
 
 std::string const &FileStackNode::name() const {
-	assert(std::holds_alternative<std::string>(data));
+	assume(std::holds_alternative<std::string>(data));
 	return std::get<std::string>(data);
 }
 
 std::string const &FileStackNode::dump(uint32_t curLineNo) const {
 	if (std::holds_alternative<std::vector<uint32_t>>(data)) {
-		assert(parent); // REPT nodes use their parent's name
+		assume(parent); // REPT nodes use their parent's name
 		std::string const &lastName = parent->dump(lineNo);
 		fputs(" -> ", stderr);
 		fputs(lastName.c_str(), stderr);
@@ -223,7 +223,7 @@ static void parseScrambleSpec(char const *spec) {
 	// indicating their scramble limit.
 	while (spec) {
 		// Invariant: we should not be pointing at whitespace at this point
-		assert(*spec != ' ' && *spec != '\t');
+		assume(*spec != ' ' && *spec != '\t');
 
 		// Remember where the region's name begins and ends
 		char const *regionName = spec;
@@ -232,7 +232,7 @@ static void parseScrambleSpec(char const *spec) {
 		int regionNamePrintLen = regionNameLen > INT_MAX ? INT_MAX : (int)regionNameLen;
 		ScrambledRegion region = SCRAMBLE_UNK;
 
-		// If this trips, `spec` must be pointing at a ',' or '=' (or NUL) due to the assert
+		// If this trips, `spec` must be pointing at a ',' or '=' (or NUL) due to the assumption
 		if (regionNameLen == 0) {
 			argErr('S', "Missing region name");
 
@@ -322,7 +322,7 @@ static void parseScrambleSpec(char const *spec) {
 
 next: // Can't `continue` a `for` loop with this nontrivial iteration logic
 		if (spec) {
-			assert(*spec == ',' || *spec == '\0');
+			assume(*spec == ',' || *spec == '\0');
 			if (*spec == ',')
 				spec += 1 + strspn(&spec[1], " \t");
 			if (*spec == '\0')

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -3,7 +3,6 @@
 #include "link/output.hpp"
 
 #include <algorithm>
-#include <assert.h>
 #include <deque>
 #include <inttypes.h>
 #include <stdio.h>
@@ -162,7 +161,7 @@ static void
 
 	if (bankSections) {
 		for (Section const *section : *bankSections) {
-			assert(section->offset == 0);
+			assume(section->offset == 0);
 			// Output padding up to the next SECTION
 			while (offset + baseOffset < section->org) {
 				putc(overlayFile ? getc(overlayFile) : padValue, outputFile);
@@ -407,7 +406,7 @@ static void writeMapBank(SortedSections const &sectList, SectionType type, uint3
 		Section const *sect = *pickedSection;
 
 		used += sect->size;
-		assert(sect->offset == 0);
+		assume(sect->offset == 0);
 
 		writeEmptySpace(prevEndAddr, sect->org);
 

--- a/src/link/patch.cpp
+++ b/src/link/patch.cpp
@@ -2,13 +2,13 @@
 
 #include "link/patch.hpp"
 
-#include <assert.h>
 #include <deque>
 #include <inttypes.h>
 #include <stdint.h>
 #include <variant>
 #include <vector>
 
+#include "helpers.hpp" // assume
 #include "linkdefs.hpp"
 #include "opmath.hpp"
 
@@ -54,7 +54,7 @@ static uint32_t getRPNByte(uint8_t const *&expression, int32_t &size, Patch cons
 }
 
 static Symbol const *getSymbol(std::vector<Symbol> const &symbolList, uint32_t index) {
-	assert(index != (uint32_t)-1); // PC needs to be handled specially, not here
+	assume(index != (uint32_t)-1); // PC needs to be handled specially, not here
 	Symbol const &symbol = symbolList[index];
 
 	// If the symbol is defined elsewhere...
@@ -297,7 +297,7 @@ static int32_t computeRPNExpr(Patch const &patch, std::vector<Symbol> const &fil
 				isError = true;
 				value = 1;
 			} else {
-				assert(sect->offset == 0);
+				assume(sect->offset == 0);
 				value = sect->org;
 			}
 			break;
@@ -377,7 +377,7 @@ static int32_t computeRPNExpr(Patch const &patch, std::vector<Symbol> const &fil
 				} else if (auto *label = std::get_if<Label>(&symbol->data); label) {
 					value = label->section->org + label->offset;
 				} else {
-					assert(std::holds_alternative<int32_t>(symbol->data));
+					assume(std::holds_alternative<int32_t>(symbol->data));
 					value = std::get<int32_t>(symbol->data);
 				}
 			}

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -15,7 +15,6 @@
 %code {
 	#include <algorithm>
 	#include <array>
-	#include <assert.h>
 	#include <bit>
 	#include <fstream>
 	#include <inttypes.h>
@@ -329,7 +328,7 @@ yy::parser::symbol_type yylex() {
 		std::string ident;
 		auto strUpperCmp = [](char cmp, char ref) {
 			// `locale::classic()` yields the "C" locale.
-			assert(!std::use_facet<std::ctype<char>>(std::locale::classic())
+			assume(!std::use_facet<std::ctype<char>>(std::locale::classic())
 			            .is(std::ctype_base::lower, ref));
 			return std::use_facet<std::ctype<char>>(std::locale::classic()).toupper(cmp) == ref;
 		};
@@ -522,7 +521,7 @@ static void alignTo(uint32_t alignment, uint32_t alignOfs) {
 			return;
 		}
 
-		assert(pc >= typeInfo.startAddr);
+		assume(pc >= typeInfo.startAddr);
 		length %= alignSize;
 	}
 
@@ -556,7 +555,7 @@ static void pad(uint32_t length) {
 	auto const &typeInfo = sectionTypeInfo[activeType];
 	auto &pc = curAddr[activeType][activeBankIdx];
 
-	assert(pc >= typeInfo.startAddr);
+	assume(pc >= typeInfo.startAddr);
 	if (uint16_t offset = pc - typeInfo.startAddr; length + offset > typeInfo.size) {
 		scriptError(
 		    context,
@@ -588,7 +587,7 @@ static void placeSection(std::string const &name, bool isOptional) {
 	}
 
 	auto const &typeInfo = sectionTypeInfo[activeType];
-	assert(section->offset == 0);
+	assume(section->offset == 0);
 	// Check that the linker script doesn't contradict what the code says.
 	if (section->type == SECTTYPE_INVALID) {
 		// SDCC areas don't have a type assigned yet, so the linker script is used to give them one.

--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -2,7 +2,6 @@
 
 #include "link/section.hpp"
 
-#include <assert.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
@@ -183,7 +182,7 @@ static void mergeSections(Section &target, std::unique_ptr<Section> &&other, Sec
 			for (Patch &patch : other->patches)
 				patch.pcOffset += other->offset;
 		} else if (!target.data.empty()) {
-			assert(other->size == 0);
+			assume(other->size == 0);
 		}
 		break;
 

--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -5,18 +5,20 @@
 #include <stdlib.h>
 #include <unordered_map>
 
+#include "helpers.hpp" // assume
+
 #include "link/main.hpp"
 #include "link/section.hpp"
 
 std::unordered_map<std::string, Symbol *> symbols;
 
 Label &Symbol::label() {
-	assert(std::holds_alternative<Label>(data));
+	assume(std::holds_alternative<Label>(data));
 	return std::get<Label>(data);
 }
 
 Label const &Symbol::label() const {
-	assert(std::holds_alternative<Label>(data));
+	assume(std::holds_alternative<Label>(data));
 	return std::get<Label>(data);
 }
 


### PR DESCRIPTION
Debug builds will still `assert`, but release builds should truly assume these conditions cannot occur and optimize accordingly. I think this will be particularly helpful for `std::variant` access.