### PR TITLE
Update some error messages

### DIFF
--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -817,7 +817,11 @@ void sect_PCRelByte(Expression &expr, uint32_t pcShift) {
 			offset = sym->getValue() - (pc->getValue() + 1);
 
 		if (offset < -128 || offset > 127) {
-			error("jr target out of reach (expected -129 < %" PRId16 " < 128)\n", offset);
+			error(
+			    "jr target must be between -128 and 127 bytes away, not %" PRId16
+			    "; use jp instead\n",
+			    offset
+			);
 			writebyte(0);
 		} else {
 			writebyte(offset);

--- a/src/link/patch.cpp
+++ b/src/link/patch.cpp
@@ -461,7 +461,8 @@ static void applyFilePatches(Section &section, Section &dataSection) {
 				error(
 				    patch.src,
 				    patch.lineNo,
-				    "jr target out of reach (expected -129 < %" PRId16 " < 128)",
+				    "jr target must be between -128 and 127 bytes away, not %" PRId16
+				    "; use jp instead\n",
 				    jumpOffset
 				);
 			dataSection.data[offset] = jumpOffset & 0xFF;

--- a/test/asm/ff00+c-bad.err
+++ b/test/asm/ff00+c-bad.err
@@ -1,5 +1,7 @@
 error: ff00+c-bad.asm(8):
-    Expected constant expression equal to $FF00 for "$ff00+c"
+    Base value must be equal to $FF00 for $FF00+C
 error: ff00+c-bad.asm(9):
-    Expected constant expression equal to $FF00 for "$ff00+c"
-error: Assembly aborted (2 errors)!
+    Expected constant expression: 'xyz' is not constant at assembly time
+error: ff00+c-bad.asm(9):
+    Base value must be equal to $FF00 for $FF00+C
+error: Assembly aborted (3 errors)!

--- a/test/asm/invalid-instructions.err
+++ b/test/asm/invalid-instructions.err
@@ -5,11 +5,11 @@ error: invalid-instructions.asm(2):
 error: invalid-instructions.asm(3):
     Base value must be equal to $FF00 for $FF00+C
 error: invalid-instructions.asm(4):
-    Destination operand must be A
+    syntax error, unexpected c, expecting hl
 error: invalid-instructions.asm(5):
-    Destination operand must be A
+    syntax error, unexpected bc, expecting hl
 error: invalid-instructions.asm(6):
-    Destination operand must be A
+    syntax error, unexpected number, expecting hl
 error: invalid-instructions.asm(7):
     Bit number must be between 0 and 7, not 8
 error: invalid-instructions.asm(8):

--- a/test/asm/invalid-instructions.err
+++ b/test/asm/invalid-instructions.err
@@ -1,9 +1,9 @@
 error: invalid-instructions.asm(1):
     Address $10000 is not 16-bit
 error: invalid-instructions.asm(2):
-    LD [HL],[HL] not a valid instruction
+    LD [HL], [HL] is not a valid instruction
 error: invalid-instructions.asm(3):
-    Expected constant expression equal to $FF00 for "$ff00+c"
+    Base value must be equal to $FF00 for $FF00+C
 error: invalid-instructions.asm(4):
     Destination operand must be A
 error: invalid-instructions.asm(5):
@@ -11,7 +11,7 @@ error: invalid-instructions.asm(5):
 error: invalid-instructions.asm(6):
     Destination operand must be A
 error: invalid-instructions.asm(7):
-    Immediate value must be 3-bit
+    Bit number must be between 0 and 7, not 8
 error: invalid-instructions.asm(8):
     Invalid address $40 for RST
 error: Assembly aborted (8 errors)!

--- a/test/asm/invalid-jr.err
+++ b/test/asm/invalid-jr.err
@@ -1,3 +1,3 @@
 error: invalid-jr.asm(3):
-    jr target out of reach (expected -129 < -258 < 128)
+    jr target must be between -128 and 127 bytes away, not -258; use jp instead
 error: Assembly aborted (1 error)!


### PR DESCRIPTION
1. "Immediate value must be 3-bit" becomes "Bit number must be between 0 and 7, not *X*", to avoid the "immediate value" jargon and to match "Alignment must be between 0 and 16, not *X*"
    - It's also renamed from `const_3bit` to `bit_const`, to match `opt_q_arg` being a 5-bit constant
3. "Fixed-point precision must be between 1 and 31" now adds ", not *X*", to match "Alignment must be between 0 and 16, not *X*"
4. 'Expected constant expression equal to $FF00 for "$ff00+c"' becomes "Base value must be equal to $FF00 for $FF00+C":
    - to match the other "*P* must be *Q*" error messages
    - to match other unquoted capitals like "LD [HL], [HL] is not a valid instruction" or "Destination operand must be A"
    - it calls `.getConstVal()` to also show the standard "Expected constant expression: ..." error message for unknown values
5. Factor out a `shift_const`, to match `rs_uconst`, and to avoid repeating the "Cannot shift macro arguments outside of a macro" error message
6. "jr target out of reach (expected -129 < *X* < 128)" becomes "jr target must be between -128 and 127 bytes away, not *X*; use jp instead":
    - to match the other "*N* must be between *A* and *B*" error messages
    - to avoid showing a mathematically untrue and confusing "-129 < *X* < 128" expression
    - to suggest a fix, since this often gets asked about
8. "Destination operand must be A" is removed because it's now a syntax error