### PR TITLE
Use the standard stream buffer size for the lexer buffer

### DIFF
--- a/include/asm/lexer.hpp
+++ b/include/asm/lexer.hpp
@@ -7,13 +7,14 @@
 #include <memory>
 #include <optional>
 #include <stdint.h>
+#include <stdio.h> // BUFSIZ
 #include <string>
 #include <variant>
 #include <vector>
 
 #include "platform.hpp" // SSIZE_MAX
 
-#define LEXER_BUF_SIZE 128
+#define LEXER_BUF_SIZE BUFSIZ
 // The buffer needs to be large enough for the maximum `lexerState->peek()` lookahead distance
 static_assert(LEXER_BUF_SIZE > 1, "Lexer buffer size is too small");
 // This caps the size of buffer reads, and according to POSIX, passing more than SSIZE_MAX is UB

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -11,7 +11,6 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <math.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unordered_map>


### PR DESCRIPTION
[`BUFSIZ`](https://en.cppreference.com/w/c/io#:~:text=BUFSIZ) is likely to be a performant value for thus buffer.