### PR TITLE
`X && 0`, `X & 0`, and `X * 0` are constant 0; `X || 1` is constant 1

### DIFF
--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -317,10 +317,9 @@ and
 .Sq || .
 .Pp
 The operators
-.Sq && ,
-.Sq & ,
-or
-.Sq *
+.Sq &&
+and
+.Sq &
 with a zero constant as either operand will be constant 0, and
 .Sq ||
 with a non-zero constant as either operand will be constant 1, even if the other operand is non-constant.

--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -218,6 +218,9 @@ knows its value.
 This is generally always the case, unless a label is involved, as explained in the
 .Sx SYMBOLS
 section.
+However, some operators can be constant even with non-constant operands, as explained in
+.Sx Operators
+further below.
 .Pp
 The instructions in the macro-language generally require constant expressions.
 .Ss Numeric formats
@@ -306,12 +309,21 @@ equivalent to multiplying and dividing by 2 to the power of b, respectively.
 .Pp
 Comparison operators return 0 if the comparison is false, and 1 otherwise.
 .Pp
-Unlike in a lot of languages, and for technical reasons,
+Unlike in many other languages, and for technical reasons,
 .Nm
 still evaluates both operands of
 .Sq &&
 and
 .Sq || .
+.Pp
+The operators
+.Sq && ,
+.Sq & ,
+or
+.Sq *
+with a zero constant as either operand will be constant 0, and
+.Sq ||
+with a non-zero constant as either operand will be constant 1, even if the other operand is non-constant.
 .Pp
 .Ic \&!
 returns 1 if the operand was 0, and 0 otherwise.

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -432,7 +432,7 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 		}
 	} else if (op == RPN_SUB && src1.isDiffConstant(src2.symbolOf())) {
 		data = src1.symbolOf()->getValue() - src2.symbolOf()->getValue();
-	} else if ((op == RPN_LOGAND || op == RPN_AND || op == RPN_MUL) && tryConstZero(src1, src2)) {
+	} else if ((op == RPN_LOGAND || op == RPN_AND) && tryConstZero(src1, src2)) {
 		data = 0;
 	} else if (op == RPN_LOGOR && tryConstNonzero(src1, src2)) {
 		data = 1;

--- a/test/asm/const-zero.asm
+++ b/test/asm/const-zero.asm
@@ -25,8 +25,5 @@ ENDM
 
 SECTION "Test arithmetic", ROM0
 Floating:
-	println Floating * 0
 	println Floating & 0
-	println 0 * Floating
 	println 0 & Floating
-	println Floating * 1 ; Not constant

--- a/test/asm/const-zero.asm
+++ b/test/asm/const-zero.asm
@@ -1,0 +1,32 @@
+MACRO test_and
+	if DEF(foo) && foo == 42
+		println "Life, the Universe, and Everything!"
+	else
+		println "What do you get if you multiply six by seven?"
+	endc
+ENDM
+	test_and
+	DEF foo = 42
+	test_and
+
+
+MACRO test_or
+	if DEF(DEBUG) || @ == $4567
+		println "Here we are!"
+	else
+		println "Where are we?"
+	endc
+ENDM
+	SECTION "Test OR", ROMX
+	test_or ; Not constant
+	DEF DEBUG EQU 1
+	test_or
+
+
+SECTION "Test arithmetic", ROM0
+Floating:
+	println Floating * 0
+	println Floating & 0
+	println 0 * Floating
+	println 0 & Floating
+	println Floating * 1 ; Not constant

--- a/test/asm/const-zero.err
+++ b/test/asm/const-zero.err
@@ -1,0 +1,5 @@
+error: const-zero.asm(21) -> const-zero.asm::test_or(14):
+    Expected constant expression: PC is not constant at assembly time
+error: const-zero.asm(32):
+    Expected constant expression: 'Floating' is not constant at assembly time
+error: Assembly aborted (2 errors)!

--- a/test/asm/const-zero.err
+++ b/test/asm/const-zero.err
@@ -1,5 +1,3 @@
 error: const-zero.asm(21) -> const-zero.asm::test_or(14):
     Expected constant expression: PC is not constant at assembly time
-error: const-zero.asm(32):
-    Expected constant expression: 'Floating' is not constant at assembly time
-error: Assembly aborted (2 errors)!
+error: Assembly aborted (1 error)!

--- a/test/asm/const-zero.out
+++ b/test/asm/const-zero.out
@@ -4,6 +4,3 @@ Where are we?
 Here we are!
 $0
 $0
-$0
-$0
-$0

--- a/test/asm/const-zero.out
+++ b/test/asm/const-zero.out
@@ -1,0 +1,9 @@
+What do you get if you multiply six by seven?
+Life, the Universe, and Everything!
+Where are we?
+Here we are!
+$0
+$0
+$0
+$0
+$0

--- a/test/asm/isconst.asm
+++ b/test/asm/isconst.asm
@@ -6,7 +6,7 @@ MACRO test_expr
 
 	DEF IS_CONST = ISCONST(\1)
 	PRINTLN "Test #{d:TEST_NUM}: ISCONST reports {IS_CONST}"
-	IF (\1) || 1 ; Only test if the expression can be evaluated
+	IF (\1) || IS_CONST ; Only test if the expression can be evaluated
 		WARN "Test #{d:TEST_NUM}: Compile-time constant"
 	ENDC
 ENDM


### PR DESCRIPTION
The original issue which inspired this, #977, only mentioned the `*` and `&` operators. However, it's even more useful for `&&` and `||`, since it allows single-line build-time conditionals without even needing the `(cond * foo) + (!cond * bar)` workaround.

One of the test scripts previously did `IF (\1) || 1`, and I was surprised that would ever *not* execute, despite understanding why it didn't. This PR fixes that, and you can still use `IF ISCONST(\1)` for the same condition check.