### PR TITLE
Allow a suffix (e.g. the version) to be added when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ Q		:= @
 PREFIX		:= /usr/local
 bindir		:= ${PREFIX}/bin
 mandir		:= ${PREFIX}/share/man
+SUFFIX		:=
 STRIP		:= -s
 BINMODE		:= 755
 MANMODE		:= 644
@@ -185,7 +186,10 @@ clean:
 
 install: all
 	$Qinstall -d ${DESTDIR}${bindir}/ ${DESTDIR}${mandir}/man1/ ${DESTDIR}${mandir}/man5/ ${DESTDIR}${mandir}/man7/
-	$Qinstall ${STRIP} -m ${BINMODE} rgbasm rgblink rgbfix rgbgfx ${DESTDIR}${bindir}/
+	$Qinstall ${STRIP} -m ${BINMODE} rgbasm ${DESTDIR}${bindir}/rgbasm${SUFFIX}
+	$Qinstall ${STRIP} -m ${BINMODE} rgblink ${DESTDIR}${bindir}/rgblink${SUFFIX}
+	$Qinstall ${STRIP} -m ${BINMODE} rgbfix ${DESTDIR}${bindir}/rgbfix${SUFFIX}
+	$Qinstall ${STRIP} -m ${BINMODE} rgbgfx ${DESTDIR}${bindir}/rgbgfx${SUFFIX}
 	$Qinstall -m ${MANMODE} man/rgbasm.1 man/rgblink.1 man/rgbfix.1 man/rgbgfx.1 ${DESTDIR}${mandir}/man1/
 	$Qinstall -m ${MANMODE} man/rgbds.5 man/rgbasm.5 man/rgblink.5 ${DESTDIR}${mandir}/man5/
 	$Qinstall -m ${MANMODE} man/rgbds.7 man/gbz80.7 ${DESTDIR}${mandir}/man7/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ cmake --build build
 cmake --install build
 ```
 
+Two parameters available when building are a prefix (e.g. to put the executables in a directory)
+and a suffix (e.g. to append the version number or commit ID).
+
+```sh
+make
+sudo make install PREFIX=install_dir/ SUFFIX=-$(git rev-parse --short HEAD)
+```
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DSUFFIX=-$(git rev-parse --short HEAD)
+cmake --build build
+cmake --install build --prefix install_dir
+```
+
+(If you set a `SUFFIX`, it should include the `.exe` extension on Windows.)
+
 ## 2. RGBDS Folder Organization
 
 The RGBDS source code file structure is as follows:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,9 @@ foreach(PROG "asm" "fix" "gfx" "link")
                  ${rgb${PROG}_src}
                  ${common_src}
                  )
+  if(SUFFIX)
+    set_target_properties(rgb${PROG} PROPERTIES SUFFIX ${SUFFIX})
+  endif()
   install(TARGETS rgb${PROG} RUNTIME DESTINATION bin)
 endforeach()
 


### PR DESCRIPTION
Fixes #1090

@mid-kid does this match your expectation for that issue?

```console
$ make -j
$ ls rgb*
rgbasm  rgbfix  rgbgfx  rgblink
$ make install PREFIX=install_dir/ SUFFIX=-0.8.0
$ ls install_dir/bin
rgbasm-0.8.0  rgbfix-0.8.0  rgbgfx-0.8.0  rgblink-0.8.0
```

```console
$ cmake -S . -B build -DSUFFIX=-0.8.0
$ cmake --build build -j
$ ls build/src/rgb*
build/src/rgbasm-0.8.0  build/src/rgbfix-0.8.0  build/src/rgbgfx-0.8.0  build/src/rgblink-0.8.0
$ cmake --install build --prefix install_dir
$ ls install_dir/bin
rgbasm-0.8.0  rgbfix-0.8.0  rgbgfx-0.8.0  rgblink-0.8.0
```

Note that this does not rely on `CMAKE_EXECUTABLE_SUFFIX`; that's a separate feature meant for adding the `.exe` suffix on Windows.