### PR TITLE
Remove unsupported macOS 11 from CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,13 +7,11 @@ jobs:
   unix:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12]
         cxx: [g++, clang++]
         buildsys: [make, cmake]
         exclude:
           # Don't use `g++` on macOS; it's just an alias to `clang++`.
-          - os: macos-11
-            cxx: g++
           - os: macos-12
             cxx: g++
       fail-fast: false


### PR DESCRIPTION
GitHub has started failing Actions on macOS 11 and will be removing them this month: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/