### PR TITLE
Keep the object version as RGB9; only increment the revision to 10

### DIFF
--- a/include/linkdefs.hpp
+++ b/include/linkdefs.hpp
@@ -8,7 +8,7 @@
 
 #include "helpers.hpp" // assume
 
-#define RGBDS_OBJECT_VERSION_STRING "RGBA"
+#define RGBDS_OBJECT_VERSION_STRING "RGB9"
 #define RGBDS_OBJECT_REV            10U
 
 enum AssertionType { ASSERT_WARN, ASSERT_ERROR, ASSERT_FATAL };

--- a/man/rgbds.5
+++ b/man/rgbds.5
@@ -54,7 +54,7 @@ References to other object files are made by imports (symbols), by name (section
 .Ss Header
 .Bl -tag -width Ds -compact
 .It Cm BYTE Ar Magic[4]
-"RGBA"
+"RGB9"
 .It Cm LONG Ar RevisionNumber
 The format's revision number this file uses.
 .Pq This is always in the same place in all revisions.


### PR DESCRIPTION
After this merges, https://github.com/gbdev/rgbds-obj/pull/2 should be updated correspondingly.