### PR TITLE
Fix bison.sh for patch-less bison versions

### DIFF
--- a/src/bison.sh
+++ b/src/bison.sh
@@ -5,7 +5,7 @@ OUTPUT_CPP="${1:?}"
 INPUT_Y="${2:?}"
 
 BISON_MAJOR=$(bison -V | sed -E 's/^.+ ([0-9]+)\..*$/\1/g;q')
-BISON_MINOR=$(bison -V | sed -E 's/^.+ [0-9]+\.([0-9]+)\..*$/\1/g;q')
+BISON_MINOR=$(bison -V | sed -E 's/^.+ [0-9]+\.([0-9]+)(\..*)?$/\1/g;q')
 
 if [ "$BISON_MAJOR" -lt 3 ]; then
 	echo "Bison $BISON_MAJOR.$BISON_MINOR is not supported" 1>&2


### PR DESCRIPTION
I built bison from source to use on macOS 11.7.10, and it printed a `MAJOR.MINOR` version only, no `.PATCH`.

```console
% bison --version
bison (GNU Bison) 3.8
Written by Robert Corbett and Richard Stallman.

Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

This was getting mis-parsed by bison.sh.