### PR TITLE
Deprecate treating multi-unit strings as numbers

### DIFF
--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -70,7 +70,7 @@
 
 	yy::parser::symbol_type yylex(); // Provided by lexer.cpp
 
-	static uint32_t str2int2(std::vector<int32_t> const &s);
+	static uint32_t strToNum(std::vector<int32_t> const &s);
 	static void errorInvalidUTF8Byte(uint8_t byte, char const *functionName);
 	static size_t strlenUTF8(std::string const &str);
 	static std::string strsubUTF8(std::string const &str, uint32_t pos, uint32_t len);
@@ -1261,7 +1261,7 @@ relocexpr:
 	}
 	| string {
 		std::vector<int32_t> output = charmap_Convert($1);
-		$$.makeNumber(str2int2(output));
+		$$.makeNumber(strToNum(output));
 	}
 ;
 
@@ -2378,7 +2378,7 @@ void yy::parser::error(std::string const &str) {
 	::error("%s\n", str.c_str());
 }
 
-static uint32_t str2int2(std::vector<int32_t> const &s) {
+static uint32_t strToNum(std::vector<int32_t> const &s) {
 	uint32_t length = s.size();
 
 	if (length == 1) {
@@ -2387,22 +2387,12 @@ static uint32_t str2int2(std::vector<int32_t> const &s) {
 		return (uint32_t)s[0];
 	}
 
+	warning(WARNING_OBSOLETE, "Treating multi-unit strings as numbers is deprecated\n");
+
 	for (int32_t v : s) {
 		if (!checkNBit(v, 8, "All character units"))
 			break;
 	}
-
-	if (length > 4)
-		warning(
-		    WARNING_NUMERIC_STRING_1,
-		    "Treating string as a number ignores first %" PRIu32 " byte%s\n",
-		    length - 4,
-		    length == 5 ? "" : "s"
-		);
-	else if (length > 1)
-		warning(
-		    WARNING_NUMERIC_STRING_2, "Treating %" PRIu32 "-byte string as a number\n", length
-		);
 
 	uint32_t r = 0;
 

--- a/src/asm/warning.cpp
+++ b/src/asm/warning.cpp
@@ -37,7 +37,7 @@ static WarningState const defaultWarnings[ARRAY_SIZE(warningStates)] = {
     WARNING_DISABLED, // WARNING_SHIFT_AMOUNT
     WARNING_ENABLED,  // WARNING_USER
 
-    WARNING_ENABLED,  // WARNING_NUMERIC_STRING_1
+    WARNING_DISABLED, // WARNING_NUMERIC_STRING_1
     WARNING_DISABLED, // WARNING_NUMERIC_STRING_2
     WARNING_ENABLED,  // WARNING_TRUNCATION_1
     WARNING_DISABLED, // WARNING_TRUNCATION_2
@@ -114,7 +114,10 @@ static bool tryProcessParamWarning(char const *flag, uint8_t param, WarningState
 	for (size_t i = 0; i < ARRAY_SIZE(paramWarnings); i++) {
 		uint8_t maxParam = paramWarnings[i].nbLevels;
 
-		if (!strcmp(paramWarnings[i].name, flag)) { // Match!
+		if (!strcmp(flag, paramWarnings[i].name)) { // Match!
+			if (!strcmp(flag, "numeric-string"))
+				warning(WARNING_OBSOLETE, "Treating multi-unit strings as numbers is deprecated\n");
+
 			// If making the warning an error but param is 0, set to the maximum
 			// This accommodates `-Werror=flag`, but also `-Werror=flag=0`, which is
 			// thus filtered out by the caller.
@@ -158,7 +161,6 @@ static uint8_t const _wallCommands[] = {
     WARNING_LARGE_CONSTANT,
     WARNING_NESTED_COMMENT,
     WARNING_OBSOLETE,
-    WARNING_NUMERIC_STRING_1,
     WARNING_UNMAPPED_CHAR_1,
     META_WARNING_DONE,
 };
@@ -169,7 +171,6 @@ static uint8_t const _wextraCommands[] = {
     WARNING_MACRO_SHIFT,
     WARNING_NESTED_COMMENT,
     WARNING_OBSOLETE,
-    WARNING_NUMERIC_STRING_2,
     WARNING_TRUNCATION_1,
     WARNING_TRUNCATION_2,
     WARNING_UNMAPPED_CHAR_1,
@@ -191,8 +192,6 @@ static uint8_t const _weverythingCommands[] = {
     WARNING_OBSOLETE,
     WARNING_SHIFT,
     WARNING_SHIFT_AMOUNT,
-    WARNING_NUMERIC_STRING_1,
-    WARNING_NUMERIC_STRING_2,
     WARNING_TRUNCATION_1,
     WARNING_TRUNCATION_2,
     WARNING_UNMAPPED_CHAR_1,

--- a/test/asm/db-dw-dl-string.err
+++ b/test/asm/db-dw-dl-string.err
@@ -1,6 +1,6 @@
-warning: db-dw-dl-string.asm(15): [-Wnumeric-string]
-    Treating 4-byte string as a number
-warning: db-dw-dl-string.asm(16): [-Wnumeric-string]
-    Treating 4-byte string as a number
-warning: db-dw-dl-string.asm(17): [-Wnumeric-string]
-    Treating 4-byte string as a number
+warning: db-dw-dl-string.asm(15): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: db-dw-dl-string.asm(16): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: db-dw-dl-string.asm(17): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated

--- a/test/asm/empty-strings.err
+++ b/test/asm/empty-strings.err
@@ -1,0 +1,2 @@
+warning: empty-strings.asm(5): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated

--- a/test/asm/multiple-charmaps.err
+++ b/test/asm/multiple-charmaps.err
@@ -1,15 +1,15 @@
-warning: multiple-charmaps.asm(46) -> multiple-charmaps.asm::print_mapped(34): [-Wnumeric-string]
-    Treating 2-byte string as a number
-warning: multiple-charmaps.asm(54) -> multiple-charmaps.asm::print_mapped(34): [-Wnumeric-string]
-    Treating 2-byte string as a number
-warning: multiple-charmaps.asm(73) -> multiple-charmaps.asm::print_mapped(34): [-Wnumeric-string]
-    Treating 2-byte string as a number
-warning: multiple-charmaps.asm(95) -> multiple-charmaps.asm::print_mapped(34): [-Wnumeric-string]
-    Treating 2-byte string as a number
-warning: multiple-charmaps.asm(96) -> multiple-charmaps.asm::print_mapped(34): [-Wnumeric-string]
-    Treating 2-byte string as a number
-warning: multiple-charmaps.asm(104) -> multiple-charmaps.asm::print_mapped(34): [-Wnumeric-string]
-    Treating 2-byte string as a number
+warning: multiple-charmaps.asm(46) -> multiple-charmaps.asm::print_mapped(34): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: multiple-charmaps.asm(54) -> multiple-charmaps.asm::print_mapped(34): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: multiple-charmaps.asm(73) -> multiple-charmaps.asm::print_mapped(34): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: multiple-charmaps.asm(95) -> multiple-charmaps.asm::print_mapped(34): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: multiple-charmaps.asm(96) -> multiple-charmaps.asm::print_mapped(34): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: multiple-charmaps.asm(104) -> multiple-charmaps.asm::print_mapped(34): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
 error: multiple-charmaps.asm(106) -> multiple-charmaps.asm::new_(9):
     Charmap 'map1' already exists
 error: multiple-charmaps.asm(108) -> multiple-charmaps.asm::set_(15):

--- a/test/asm/multivalue-charmap.err
+++ b/test/asm/multivalue-charmap.err
@@ -2,13 +2,13 @@ warning: multivalue-charmap.asm(11): [-Wtruncation]
     All character units must be 8-bit
 warning: multivalue-charmap.asm(22): [-Wtruncation]
     All character units must be 8-bit
-warning: multivalue-charmap.asm(27): [-Wnumeric-string]
-    Treating 4-byte string as a number
-warning: multivalue-charmap.asm(28): [-Wnumeric-string]
-    Treating 4-byte string as a number
+warning: multivalue-charmap.asm(27): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: multivalue-charmap.asm(28): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: multivalue-charmap.asm(33): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
 warning: multivalue-charmap.asm(33): [-Wtruncation]
     All character units must be 8-bit
-warning: multivalue-charmap.asm(33): [-Wnumeric-string]
-    Treating 4-byte string as a number
 warning: multivalue-charmap.asm(34): [-Wtruncation]
     All character units must be 8-bit

--- a/test/asm/warn-numeric-string.err
+++ b/test/asm/warn-numeric-string.err
@@ -1,38 +1,84 @@
-warning: warn-numeric-string.asm(20) -> warn-numeric-string.asm::try(12): [-Wnumeric-string]
-    Treating string as a number ignores first 1 byte
-warning: warn-numeric-string.asm(20) -> warn-numeric-string.asm::try(13): [-Wnumeric-string]
-    Treating string as a number ignores first 1 byte
-warning: warn-numeric-string.asm(20) -> warn-numeric-string.asm::try(13): [-Wnumeric-string]
-    Treating string as a number ignores first 2 bytes
-warning: warn-numeric-string.asm(22) -> warn-numeric-string.asm::try(12): [-Wnumeric-string]
-    Treating string as a number ignores first 1 byte
-warning: warn-numeric-string.asm(22) -> warn-numeric-string.asm::try(13): [-Wnumeric-string]
-    Treating string as a number ignores first 1 byte
-warning: warn-numeric-string.asm(22) -> warn-numeric-string.asm::try(13): [-Wnumeric-string]
-    Treating string as a number ignores first 2 bytes
-warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(12): [-Wnumeric-string]
-    Treating string as a number ignores first 1 byte
-warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(13): [-Wnumeric-string]
-    Treating string as a number ignores first 1 byte
-warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(13): [-Wnumeric-string]
-    Treating string as a number ignores first 2 bytes
-warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(15): [-Wnumeric-string]
-    Treating 2-byte string as a number
-warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(16): [-Wnumeric-string]
-    Treating 3-byte string as a number
-error: warn-numeric-string.asm(24) -> warn-numeric-string.asm::try(12): [-Werror=numeric-string]
-    Treating string as a number ignores first 1 byte
-error: warn-numeric-string.asm(24) -> warn-numeric-string.asm::try(13): [-Werror=numeric-string]
-    Treating string as a number ignores first 1 byte
-error: warn-numeric-string.asm(24) -> warn-numeric-string.asm::try(13): [-Werror=numeric-string]
-    Treating string as a number ignores first 2 bytes
-error: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(12): [-Werror=numeric-string]
-    Treating string as a number ignores first 1 byte
-error: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(13): [-Werror=numeric-string]
-    Treating string as a number ignores first 1 byte
-error: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(13): [-Werror=numeric-string]
-    Treating string as a number ignores first 2 bytes
-error: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(15): [-Werror=numeric-string]
-    Treating 2-byte string as a number
-error: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(16): [-Werror=numeric-string]
-    Treating 3-byte string as a number
+warning: warn-numeric-string.asm(19) -> warn-numeric-string.asm::try(7): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(19) -> warn-numeric-string.asm::try(12): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(19) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(19) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(19) -> warn-numeric-string.asm::try(15): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(19) -> warn-numeric-string.asm::try(16): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(20) -> warn-numeric-string.asm::try(7): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(20) -> warn-numeric-string.asm::try(12): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(20) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(20) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(20) -> warn-numeric-string.asm::try(15): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(20) -> warn-numeric-string.asm::try(16): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(21) -> warn-numeric-string.asm::try(7): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(21) -> warn-numeric-string.asm::try(12): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(21) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(21) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(21) -> warn-numeric-string.asm::try(15): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(21) -> warn-numeric-string.asm::try(16): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(22) -> warn-numeric-string.asm::try(7): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(22) -> warn-numeric-string.asm::try(12): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(22) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(22) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(22) -> warn-numeric-string.asm::try(15): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(22) -> warn-numeric-string.asm::try(16): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(7): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(12): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(15): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(23) -> warn-numeric-string.asm::try(16): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(24) -> warn-numeric-string.asm::try(7): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(24) -> warn-numeric-string.asm::try(12): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(24) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(24) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(24) -> warn-numeric-string.asm::try(15): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(24) -> warn-numeric-string.asm::try(16): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(7): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(12): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(13): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(15): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated
+warning: warn-numeric-string.asm(25) -> warn-numeric-string.asm::try(16): [-Wobsolete]
+    Treating multi-unit strings as numbers is deprecated


### PR DESCRIPTION
Follow-up to #1429.

If you were using this for something like FourCC codes, e.g.:

```asm
charmap "R", $11
charmap "I", $22
charmap "F", $33
assert "RIFF" == $11223333
dl ("RIFF") ; not the same as `dl "RIFF"`!?
```

Instead you can use a single 32-bit charmap unit:

```asm
charmap "RIFF", $11223333
assert "RIFF" == $11223333
dl "RIFF" ; the same as `dl "RIFF"` :)
```