### PR TITLE
Remove redundant "unknown option" error messages

### DIFF
--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -281,7 +281,6 @@ int main(int argc, char *argv[]) {
 
 		// Unrecognized options
 		default:
-			fprintf(stderr, "FATAL: unknown option '%c'\n", ch);
 			printUsage();
 			exit(1);
 		}

--- a/src/fix/main.cpp
+++ b/src/fix/main.cpp
@@ -1372,7 +1372,6 @@ int main(int argc, char *argv[]) {
 			break;
 
 		default:
-			fprintf(stderr, "FATAL: unknown option '%c'\n", ch);
 			printUsage();
 			exit(1);
 		}

--- a/src/gfx/main.cpp
+++ b/src/gfx/main.cpp
@@ -588,7 +588,6 @@ static char *parseArgv(int argc, char *argv[]) {
 			}
 			break;
 		default:
-			fprintf(stderr, "FATAL: unknown option '%c'\n", ch);
 			printUsage();
 			exit(1);
 		}

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -412,7 +412,6 @@ int main(int argc, char *argv[]) {
 			is32kMode = true;
 			break;
 		default:
-			fprintf(stderr, "FATAL: unknown option '%c'\n", ch);
 			printUsage();
 			exit(1);
 		}


### PR DESCRIPTION
`getopt` already prints "unrecognized option", and the "unknown option" always showed up as "?":

```console
$ rgbasm -A
rgbasm: unrecognized option: A
FATAL: unknown option '?'
```