### PR TITLE
Support 'cmake export' to make RGBDS usable with `find_package()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ endif()
 option(SANITIZERS "Build with sanitizers enabled" OFF) # Ignored on MSVC
 option(MORE_WARNINGS "Turn on more warnings" OFF) # Ignored on MSVC
 
+include(GNUInstallDirs)
+if(NOT DEFINED CMAKE_INSTALL_BINDIR)
+  set(CMAKE_INSTALL_BINDIR lib)
+endif()
+
 if(MSVC)
   # MSVC's own standard library triggers warning C5105,
   # "macro expansion producing 'defined' has undefined behavior".
@@ -130,3 +135,5 @@ foreach(SECTION "man1" "man5" "man7")
   set(DEST "${MANDIR}/${SECTION}")
   install(FILES ${${SECTION}} DESTINATION ${DEST})
 endforeach()
+
+install(EXPORT RGBDS DESTINATION "${CMAKE_INSTALL_BINDIR}/cmake/rgbds")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,8 +94,10 @@ foreach(PROG "asm" "fix" "gfx" "link")
   if(SUFFIX)
     set_target_properties(rgb${PROG} PROPERTIES SUFFIX ${SUFFIX})
   endif()
-  install(TARGETS rgb${PROG} RUNTIME DESTINATION bin)
 endforeach()
+install(TARGETS rgbasm rgbfix rgbgfx rgblink
+        EXPORT RGBDS
+        RUNTIME DESTINATION bin)
 
 if(LIBPNG_FOUND) # pkg-config
   target_include_directories(rgbgfx PRIVATE ${LIBPNG_INCLUDE_DIRS})


### PR DESCRIPTION
Fixes #828

(I haven't tested this and am sure I've missed something, but the CMake docs sound like this is close to what we want. I could use some help with it.)

The goal is for another project to be able to do `find_package(RGBDS 0.8.0 REQUIRED)` and thereafter be able to use the installed `rgbasm`, `rgblink`, `rgbfix`, and `rgbgfx` executables.)