### PR TITLE
Build “fat binaries” for macOS

### DIFF
--- a/.github/scripts/build_libpng.sh
+++ b/.github/scripts/build_libpng.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+pngver=1.6.43
+
+## Grab sources and check them
+
+curl -LOJ "http://prdownloads.sourceforge.net/libpng/libpng-$pngver.tar.xz?download"
+# Brew doesn't provide any sha256sum, so we're making do with `sha2` instead.
+if [ "$(sha2 -q -256 libpng-$pngver.tar.xz)" != 6a5ca0652392a2d7c9db2ae5b40210843c0bbc081cbd410825ab00cc59f14a6c ]; then
+	sha2 -256 libpng-$pngver.tar.xz
+	echo Checksum mismatch! Aborting. >&2
+	exit 1
+fi
+
+## Extract sources and patch them
+
+tar -xvf libpng-$pngver.tar.xz
+
+## Start building!
+
+mkdir -p build
+cd build
+../libpng-$pngver/configure --disable-shared --enable-static \
+	CFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9 -arch x86_64 -arch arm64 -fno-exceptions"
+make -kj
+make install prefix="$PWD/../libpng-staging"

--- a/.github/scripts/build_libpng.sh
+++ b/.github/scripts/build_libpng.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -e
+#!/bin/bash
+set -euo pipefail
 
 pngver=1.6.43
 

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 case "${1%-*}" in
 	ubuntu)
@@ -8,8 +8,10 @@ case "${1%-*}" in
 		;;
 	macos)
 		brew install bison libpng pkg-config md5sha1sum
-		# For the version check below exclusively, re-do this before building
-		export PATH="/opt/homebrew/opt/bison/bin:/usr/local/opt/bison/bin:$PATH"
+		# Export `bison` to allow using the version we install from Homebrew,
+		# instead of the outdated one preinstalled on macOS (which doesn't even support `-Wall`...)
+		export PATH="/opt/homebrew/opt/bison/bin:$PATH"
+		printf 'PATH=%s\n' "$PATH" >>"$GITHUB_ENV" # Make it available to later CI steps tpp
 		;;
 	*)
 		echo "WARNING: Cannot install deps for OS '$1'"

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -7,11 +7,11 @@ case "${1%-*}" in
 		sudo apt-get install -yq bison libpng-dev pkg-config
 		;;
 	macos)
-		brew install bison libpng pkg-config md5sha1sum
+		brew install bison sha2 md5sha1sum
 		# Export `bison` to allow using the version we install from Homebrew,
 		# instead of the outdated one preinstalled on macOS (which doesn't even support `-Wall`...)
 		export PATH="/opt/homebrew/opt/bison/bin:$PATH"
-		printf 'PATH=%s\n' "$PATH" >>"$GITHUB_ENV" # Make it available to later CI steps tpp
+		printf 'PATH=%s\n' "$PATH" >>"$GITHUB_ENV" # Make it available to later CI steps too
 		;;
 	*)
 		echo "WARNING: Cannot install deps for OS '$1'"

--- a/.github/scripts/mingw-w64-libpng-dev.sh
+++ b/.github/scripts/mingw-w64-libpng-dev.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -e
+#!/bin/bash
+set -euo pipefail
 
 pngver=1.6.43
 arch="$1"
@@ -27,7 +27,7 @@ cd build
 	--prefix="/usr/$arch" \
 	--enable-shared --disable-static \
 	CPPFLAGS="-D_FORTIFY_SOURCE=2" \
-	CFLAGS="-O2 -pipe -fno-plt -fexceptions --param=ssp-buffer-size=4" \
+	CFLAGS="-O2 -pipe -fno-plt -fno-exceptions --param=ssp-buffer-size=4" \
 	LDFLAGS="-Wl,-O1,--sort-common,--as-needed -fstack-protector"
 make -kj
-make install
+sudo make install

--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -79,10 +79,13 @@ jobs:
         shell: bash
         run: |
           ./.github/scripts/install_deps.sh macos
+      - name: Build libpng
+        run: |
+          ./.github/scripts/build_libpng.sh
       # We force linking libpng statically; the other libs are provided by macOS itself
       - name: Build binaries
         run: |
-          make -kj CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9 -arch x86_64 -arch arm64" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
+          make -kj CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9 -arch x86_64 -arch arm64" PNGCFLAGS="-I libpng-staging/include" PNGLDLIBS="libpng-staging/lib/libpng.a -lz" Q=
           strip rgb{asm,link,fix,gfx}
       - name: Package binaries
         run: |

--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -82,7 +82,6 @@ jobs:
       # We force linking libpng statically; the other libs are provided by macOS itself
       - name: Build binaries
         run: |
-          export PATH="/usr/local/opt/bison/bin:$PATH"
           make -kj CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
           strip rgb{asm,link,fix,gfx}
       - name: Package binaries

--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: macos
-          path: rgbds-${{ env.version }}-macos-x86_64.zip
+          path: rgbds-${{ env.version }}-macos.zip
 
   linux:
     runs-on: ubuntu-20.04 # Oldest supported, for best glibc compatibility.

--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -82,7 +82,7 @@ jobs:
       # We force linking libpng statically; the other libs are provided by macOS itself
       - name: Build binaries
         run: |
-          make -kj CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
+          make -kj CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9 -arch x86_64 -arch arm64" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
           strip rgb{asm,link,fix,gfx}
       - name: Package binaries
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -82,7 +82,7 @@ jobs:
           ./.github/scripts/install_deps.sh macos
       - name: Build & install
         run: |
-          make -kj CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
+          make -kj CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9 -arch x86_64 -arch arm64" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
       - name: Package binaries
         run: |
           mkdir bins

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,18 +22,14 @@ jobs:
         shell: bash
         run: |
           ./.github/scripts/install_deps.sh ${{ matrix.os }}
-      # Export `bison` to allow using the version we install from Homebrew,
-      # instead of the outdated 2.3 one preinstalled on macOS.
       - name: Build & install using Make
         if: matrix.buildsys == 'make'
         run: |
-          export PATH="/opt/homebrew/opt/bison/bin:/usr/local/opt/bison/bin:$PATH"
           make develop -kj Q= CXX=${{ matrix.cxx }}
           sudo make install -j Q=
       - name: Build & install using CMake
         if: matrix.buildsys == 'cmake'
         run: |
-          export PATH="/opt/homebrew/opt/bison/bin:/usr/local/opt/bison/bin:$PATH"
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DSANITIZERS=ON -DMORE_WARNINGS=ON
           cmake --build build -j --verbose
           cp build/src/rgb{asm,link,fix,gfx} .
@@ -84,12 +80,8 @@ jobs:
         shell: bash
         run: |
           ./.github/scripts/install_deps.sh macos
-      # Export `bison` to allow using the version we install from Homebrew,
-      # instead of the outdated one preinstalled on macOS (which doesn't
-      # even support `-Wall`...).
       - name: Build & install
         run: |
-          export PATH="/opt/homebrew/opt/bison/bin:/usr/local/opt/bison/bin:$PATH"
           make -kj CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
       - name: Package binaries
         run: |
@@ -238,7 +230,7 @@ jobs:
       - name: Install deps
         shell: bash
         run: |
-          ./.github/scripts/install_deps.sh ${{ matrix.os }}
+          ./.github/scripts/install_deps.sh ubuntu
       - name: Install MinGW
         run: | # dpkg-dev is apparently required for pkg-config for cross-building
           sudo apt-get install g++-mingw-w64-${{ matrix.arch }}-win32 mingw-w64-tools libz-mingw-w64-dev dpkg-dev

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -80,9 +80,12 @@ jobs:
         shell: bash
         run: |
           ./.github/scripts/install_deps.sh macos
+      - name: Build libpng
+        run: |
+          ./.github/scripts/build_libpng.sh
       - name: Build & install
         run: |
-          make -kj CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9 -arch x86_64 -arch arm64" PKG_CONFIG="pkg-config --static" PNGLDLIBS="$(pkg-config --static --libs-only-L libpng | cut -c 3-)/libpng.a $(pkg-config --static --libs-only-l libpng | sed s/-lpng[0-9]*//g)" Q=
+          make -kj CXXFLAGS="-O3 -flto -DNDEBUG -mmacosx-version-min=10.9 -arch x86_64 -arch arm64" PNGCFLAGS="-I libpng-staging/include" PNGLDLIBS="libpng-staging/lib/libpng.a -lz" Q=
       - name: Package binaries
         run: |
           mkdir bins

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -239,7 +239,7 @@ jobs:
           sudo apt-get install g++-mingw-w64-${{ matrix.arch }}-win32 mingw-w64-tools libz-mingw-w64-dev dpkg-dev
       - name: Install libpng dev headers for MinGW
         run: |
-          sudo ./.github/scripts/mingw-w64-libpng-dev.sh ${{ matrix.triplet }}
+          ./.github/scripts/mingw-w64-libpng-dev.sh ${{ matrix.triplet }}
       - name: Cross-build Windows binaries
         run: |
           make mingw${{ matrix.bits }} -kj Q=


### PR DESCRIPTION
Now that ARM Macs have become more commonplace, this is actually becoming relevant.
Plus this turns out to use less of a hack to link against libpng, which should make it more future-proof :)

CC @LIJI32 for review, having become the de-facto on-call macOS support guy for RGBDS~
(And thank you for the suggestion! Turned out to be quite painless, in the end.)