### PR TITLE
Comment the parsers better

### DIFF
--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -212,7 +212,7 @@ static std::unordered_map<std::string, int, CaseInsensitive, CaseInsensitive> ke
 
     {"FRAGMENT",      T_(POP_FRAGMENT)     },
     {"BANK",          T_(OP_BANK)          },
-    {"ALIGN",         T_(OP_ALIGN)         },
+    {"ALIGN",         T_(POP_ALIGN)        },
 
     {"SIZEOF",        T_(OP_SIZEOF)        },
     {"STARTOF",       T_(OP_STARTOF)       },

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -51,6 +51,8 @@
 	};
 }
 
+/******************** Tokens and data types ********************/
+
 %token YYEOF 0 "end of file"
 %token newline
 %token COMMA ","
@@ -77,6 +79,8 @@
 %type <bool> optional;
 
 %%
+
+/******************** Parser rules ********************/
 
 lines:
 	  %empty
@@ -147,7 +151,7 @@ optional:
 	    context.lineNo __VA_OPT__(, ) __VA_ARGS__ \
 	)
 
-// Lexer.
+/******************** Lexer ********************/
 
 struct LexerStackEntry {
 	std::filebuf file;
@@ -366,7 +370,7 @@ yy::parser::symbol_type yylex() {
 	// Not marking as unreachable; this will generate a warning if any codepath forgets to return.
 }
 
-// Semantic actions.
+/******************** Semantic actions ********************/
 
 static std::array<std::vector<uint16_t>, SECTTYPE_INVALID> curAddr;
 static SectionType activeType; // Index into curAddr
@@ -677,7 +681,7 @@ static void placeSection(std::string const &name, bool isOptional) {
 	}
 }
 
-// External API.
+/******************** External API ********************/
 
 void script_ProcessScript(char const *path) {
 	activeType = SECTTYPE_INVALID;


### PR DESCRIPTION
Fixes #866

Much of the necessary work had already been done during the C-to-C++ conversion. This just adds some more heading comments and organizes the tokens and types better.

This also renames `OP_ALIGN` to `POP_ALIGN`, because it *can* be used as a primary statement, even though it's also an operand of `SECTION`.

The parser rules are *mostly* organized already (note the heading comments, e.g. `// CPU commands.`.) Possibly some could be shuffled around, but I'm not going to agonize over it. :P