### PR TITLE
Multiple bugfixes for linking with SDCC object files

### DIFF
--- a/man/rgblink.5
+++ b/man/rgblink.5
@@ -86,6 +86,22 @@ If the bank has never been active thus far, the
 .Dq current address
 defaults to the beginning of the bank
 .Pq e.g. Ad $4000 No for Ic ROMX No sections .
+.Pp
+Instead of giving a bank number, the keyword
+.Ic FLOATING
+can be used instead; this sets the type of the subsequent sections without binding them to a particular bank.
+(If the type only allows a single bank, e.g.
+.Ic ROM0 ,
+then
+.Ic FLOATING
+is valid but redundant and has no effect.)
+Since no particular section is active, the
+.Dq current address
+is made floating (as if by a
+.Ql Ic FLOATING
+directive), and
+.Ic ORG
+is not allowed.
 .It Changing the current address
 A bank must be active for any of these directives to be used.
 .Pp
@@ -104,6 +120,7 @@ causes all sections between it and the next
 .Ic ORG
 or bank specification to be placed at addresses automatically determined by
 .Nm .
+.Pq It is, however, compatible with Ic ALIGN No below.
 .Pp
 .Ql Ic ALIGN Ar addr , Ar offset
 increases the

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -354,7 +354,11 @@ static void readSection(
 	tryGetc(
 	    uint8_t, byte, file, "%s: Cannot read \"%s\"'s type: %s", fileName, section.name.c_str()
 	);
-	section.type = (SectionType)(byte & 0x3F);
+	if (uint8_t type = byte & 0x3F; type >= SECTTYPE_INVALID) {
+		errx("\"%s\" has unknown section type 0x%02x", section.name.c_str(), type);
+	} else {
+		section.type = SectionType(type);
+	}
 	if (byte >> 7)
 		section.modifier = SECTION_UNION;
 	else if (byte >> 6)

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -625,7 +625,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID) {
 		if (auto *label = std::get_if<Label>(&fileSymbols[i].data); label) {
 			if (Section *section = label->section; section->modifier != SECTION_NORMAL) {
 				if (section->modifier == SECTION_FRAGMENT)
-					// Add the fragment's offset to the symbol's
+					// Add the fragment's offset to the symbol's (`section->offset` is computed by `sect_AddSection`)
 					label->offset += section->offset;
 				// Associate the symbol with the main section, not the "component" one
 				label->section = sect_GetSection(section->name);

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -241,7 +241,7 @@ yy::parser::symbol_type yylex() {
 	}
 	// Then, skip a comment if applicable.
 	if (c == ';') {
-		while (!isNewline(c)) {
+		while (c != EOF && !isNewline(c)) {
 			c = context.file.sbumpc();
 		}
 	}

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -37,6 +37,7 @@ static int
 retry:
 	++lineNo;
 	int firstChar = getc(file);
+	lineBuf.clear();
 
 	switch (firstChar) {
 	case EOF:

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -223,6 +223,7 @@ void sdobj_ReadFile(FileStackNode const &where, FILE *file, std::vector<Symbol> 
 
 	getToken(nullptr, "'H' line is too short");
 	uint32_t expectedNbSymbols = parseNumber(where, lineNo, token, numberType);
+	fileSymbols.reserve(expectedNbSymbols);
 
 	expectToken("global", 'H');
 
@@ -343,13 +344,15 @@ void sdobj_ReadFile(FileStackNode const &where, FILE *file, std::vector<Symbol> 
 		}
 
 		case 'S': {
-			if (fileSymbols.size() == expectedNbSymbols)
-				warning(
+			if (fileSymbols.size() == expectedNbSymbols) {
+				error(
 				    &where,
 				    lineNo,
 				    "Got more 'S' lines than the expected %" PRIu32,
 				    expectedNbSymbols
 				);
+				break; // Refuse processing the line further.
+			}
 			Symbol &symbol = fileSymbols.emplace_back();
 
 			// Init other members

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -136,7 +136,8 @@ enum RelocFlags {
 };
 
 void sdobj_ReadFile(FileStackNode const &where, FILE *file, std::vector<Symbol> &fileSymbols) {
-	std::vector<char> line(256);
+	std::vector<char> line;
+	line.reserve(256);
 	char const *token;
 
 #define getToken(ptr, ...) \

--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -229,7 +229,9 @@ Section *sect_GetSection(std::string const &name) {
 static void doSanityChecks(Section &section) {
 	// Sanity check the section's type
 	if (section.type < 0 || section.type >= SECTTYPE_INVALID) {
-		error(nullptr, 0, "Section \"%s\" has an invalid type", section.name.c_str());
+		// This is trapped early in RGBDS objects (because then the format is not parseable),
+		// which leaves SDAS objects.
+		error(nullptr, 0, "Section \"%s\" has not been assigned a type by a linker script", section.name.c_str());
 		return;
 	}
 

--- a/test/link/script-syntax-error.out
+++ b/test/link/script-syntax-error.out
@@ -1,3 +1,3 @@
 error: script-syntax-error.link(2): syntax error, unexpected ORG, expecting newline or OPTIONAL
-error: script-syntax-error.link(5): syntax error, unexpected string, expecting newline or number
+error: script-syntax-error.link(5): syntax error, unexpected string, expecting newline or FLOATING or number
 Linking failed with 2 errors


### PR DESCRIPTION
First commit fixes a bug which caused the fatal error: Unkown endianness type ''.
Second commit fixes a bug were clearing the line buffer of the object file was forgotten when filling up the next one.

Fixes #1466