### PR TITLE
Allow mirroring only the X or Y axes

### DIFF
--- a/contrib/bash_compl/_rgbgfx.bash
+++ b/contrib/bash_compl/_rgbgfx.bash
@@ -13,6 +13,8 @@ _rgbgfx_completions() {
 		[O]="group-outputs:normal"
 		[u]="unique-tiles:normal"
 		[v]="verbose:normal"
+		[X]="mirror-x:normal"
+		[Y]="mirror-y:normal"
 		[Z]="columns:normal"
 		[a]="attr-map:glob-*.attrmap"
 		[A]="auto-attr-map:normal"

--- a/contrib/zsh_compl/_rgbgfx
+++ b/contrib/zsh_compl/_rgbgfx
@@ -22,6 +22,8 @@ local args=(
 	'(-t --tilemap -T --auto-tilemap)'{-T,--auto-tilemap}'[Shortcut for -t <file>.tilemap]'
 	'(-u --unique-tiles)'{-u,--unique-tiles}'[Eliminate redundant tiles]'
 	{-v,--verbose}'[Enable verbose output]'
+	'(-X --mirror-x)'{-X,--mirror-x}'[Eliminate horizontally mirrored tiles from output]'
+	'(-Y --mirror-y)'{-Y,--mirror-y}'[Eliminate vertically mirrored tiles from output]'
 	'(-Z --columns)'{-Z,--columns}'[Read the image in column-major order]'
 
 	'(-a --attr-map -A --auto-attr-map)'{-a,--attr-map}'+[Generate a map of tile attributes (mirroring)]:attrmap file:_files'

--- a/include/gfx/main.hpp
+++ b/include/gfx/main.hpp
@@ -13,11 +13,12 @@
 #include "gfx/rgba.hpp"
 
 struct Options {
-	bool useColorCurve = false;  // -C
-	bool allowMirroring = false; // -m
-	bool allowDedup = false;     // -u
-	bool columnMajor = false;    // -Z, previously -h
-	uint8_t verbosity = 0;       // -v
+	bool useColorCurve = false;   // -C
+	bool allowDedup = false;      // -u
+	bool allowMirroringX = false; // -X, -m
+	bool allowMirroringY = false; // -Y, -m
+	bool columnMajor = false;     // -Z
+	uint8_t verbosity = 0;        // -v
 
 	std::string attrmap{};                    // -a, -A
 	std::array<uint8_t, 2> baseTileIDs{0, 0}; // -b

--- a/src/gfx/main.cpp
+++ b/src/gfx/main.cpp
@@ -144,14 +144,16 @@ static option const longopts[] = {
     {"unique-tiles",     no_argument,       nullptr, 'u'},
     {"version",          no_argument,       nullptr, 'V'},
     {"verbose",          no_argument,       nullptr, 'v'},
+    {"mirror-x",         no_argument,       nullptr, 'X'},
     {"trim-end",         required_argument, nullptr, 'x'},
+    {"mirror-y",         no_argument,       nullptr, 'Y'},
     {"columns",          no_argument,       nullptr, 'Z'},
     {nullptr,            no_argument,       nullptr, 0  }
 };
 
 static void printUsage() {
 	fputs(
-	    "Usage: rgbgfx [-r stride] [-CmOuVZ] [-v [-v ...]] [-a <attr_map> | -A]\n"
+	    "Usage: rgbgfx [-r stride] [-CmOuVXYZ] [-v [-v ...]] [-a <attr_map> | -A]\n"
 	    "       [-b <base_ids>] [-c <colors>] [-d <depth>] [-L <slice>] [-N <nb_tiles>]\n"
 	    "       [-n <nb_pals>] [-o <out_file>] [-p <pal_file> | -P] [-q <pal_map> | -Q]\n"
 	    "       [-s <nb_colors>] [-t <tile_map> | -T] [-x <nb_tiles>] <file>\n"
@@ -466,8 +468,9 @@ static char *parseArgv(int argc, char *argv[]) {
 			}
 			break;
 		case 'm':
-			options.allowMirroring = true;
-			[[fallthrough]]; // Imply `-u`
+			options.allowMirroringX = true; // Imply `-X`
+			options.allowMirroringY = true; // Imply `-Y`
+			[[fallthrough]];                // Imply `-u`
 		case 'u':
 			options.allowDedup = true;
 			break;
@@ -581,6 +584,14 @@ static char *parseArgv(int argc, char *argv[]) {
 			if (*arg != '\0') {
 				error("Tile trim (-x) argument must be a valid number, not \"%s\"", musl_optarg);
 			}
+			break;
+		case 'X':
+			options.allowMirroringX = true;
+			options.allowDedup = true; // Imply `-u`
+			break;
+		case 'Y':
+			options.allowMirroringY = true;
+			options.allowDedup = true; // Imply `-u`
 			break;
 		case 'Z':
 			options.columnMajor = true;
@@ -757,10 +768,12 @@ int main(int argc, char *argv[]) {
 		fputs("Options:\n", stderr);
 		if (options.columnMajor)
 			fputs("\tVisit image in column-major order\n", stderr);
-		if (options.allowMirroring)
-			fputs("\tAllow mirroring tiles\n", stderr);
 		if (options.allowDedup)
 			fputs("\tAllow deduplicating tiles\n", stderr);
+		if (options.allowMirroringX)
+			fputs("\tAllow deduplicating horizontally mirrored tiles\n", stderr);
+		if (options.allowMirroringY)
+			fputs("\tAllow deduplicating vertically mirrored tiles\n", stderr);
 		if (options.useColorCurve)
 			fputs("\tUse color curve\n", stderr);
 		fprintf(stderr, "\tBit depth: %" PRIu8 "bpp\n", options.bitDepth);


### PR DESCRIPTION
Part of #575 (a `-B #ABCDEF` option to omit all solid #ABCDEF tiles is the other half of closing that issue)

This just needs tests!