### PR TITLE
Use a custom generic tagged union `Either` instead of `std::variant` for efficiency

### DIFF
--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -10,16 +10,16 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string>
-#include <variant>
 #include <vector>
 
+#include "either.hpp"
 #include "linkdefs.hpp"
 
 #include "asm/lexer.hpp"
 
 struct FileStackNode {
 	FileStackNodeType type;
-	std::variant<
+	Either<
 	    std::vector<uint32_t>, // NODE_REPT
 	    std::string            // NODE_FILE, NODE_MACRO
 	    >
@@ -34,13 +34,13 @@ struct FileStackNode {
 	uint32_t ID = -1;
 
 	// REPT iteration counts since last named node, in reverse depth order
-	std::vector<uint32_t> &iters();
-	std::vector<uint32_t> const &iters() const;
+	std::vector<uint32_t> &iters() { return data.get<std::vector<uint32_t>>(); }
+	std::vector<uint32_t> const &iters() const { return data.get<std::vector<uint32_t>>(); }
 	// File name for files, file::macro name for macros
-	std::string &name();
-	std::string const &name() const;
+	std::string &name() { return data.get<std::string>(); }
+	std::string const &name() const { return data.get<std::string>(); }
 
-	FileStackNode(FileStackNodeType type_, std::variant<std::vector<uint32_t>, std::string> data_)
+	FileStackNode(FileStackNodeType type_, Either<std::vector<uint32_t>, std::string> data_)
 	    : type(type_), data(data_){};
 
 	std::string const &dump(uint32_t curLineNo) const;

--- a/include/asm/lexer.hpp
+++ b/include/asm/lexer.hpp
@@ -8,9 +8,9 @@
 #include <optional>
 #include <stdint.h>
 #include <string>
-#include <variant>
 #include <vector>
 
+#include "either.hpp"
 #include "platform.hpp" // SSIZE_MAX
 
 // This value is a compromise between `LexerState` allocation performance when `mmap` works, and
@@ -98,7 +98,7 @@ struct LexerState {
 	bool expandStrings;
 	std::deque<Expansion> expansions; // Front is the innermost current expansion
 
-	std::variant<std::monostate, ViewedContent, BufferedContent> content;
+	Either<ViewedContent, BufferedContent> content;
 
 	~LexerState();
 

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -5,18 +5,19 @@
 
 #include <stdint.h>
 #include <string>
-#include <variant>
 #include <vector>
 
+#include "either.hpp"
 #include "linkdefs.hpp"
 
 struct Symbol;
 
 struct Expression {
-	std::variant<
-		int32_t,    // If the expression's value is known, it's here
-		std::string // Why the expression is not known, if it isn't
-	> data = 0;
+	Either<
+	    int32_t,    // If the expression's value is known, it's here
+	    std::string // Why the expression is not known, if it isn't
+	    >
+	    data = 0;
 	bool isSymbol = false; // Whether the expression represents a symbol suitable for const diffing
 	std::vector<uint8_t> rpn{}; // Bytes serializing the RPN expression
 	uint32_t rpnPatchSize = 0;  // Size the expression will take in the object file
@@ -30,8 +31,12 @@ struct Expression {
 
 	Expression &operator=(Expression &&) = default;
 
-	bool isKnown() const { return std::holds_alternative<int32_t>(data); }
-	int32_t value() const;
+	bool isKnown() const {
+		return data.holds<int32_t>();
+	}
+	int32_t value() const {
+		return data.get<int32_t>();
+	}
 
 	int32_t getConstVal() const;
 	Symbol const *symbolOf() const;

--- a/include/either.hpp
+++ b/include/either.hpp
@@ -1,0 +1,157 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef RGBDS_EITHER_HPP
+#define RGBDS_EITHER_HPP
+
+#include <assert.h>
+#include <type_traits>
+#include <utility>
+
+template<typename T1, typename T2>
+union Either {
+	typedef T1 type1;
+	typedef T2 type2;
+
+private:
+	template<typename T, bool V>
+	struct Field {
+		constexpr static bool tag_value = V;
+
+		bool tag = tag_value;
+		T value;
+
+		Field() : value() {}
+		Field(T &value_) : value(value_) {}
+		Field(T const &value_) : value(value_) {}
+		Field(T &&value_) : value(std::move(value_)) {}
+	};
+
+	// The `_tag` unifies with the first `tag` member of each `struct`.
+	bool _tag;
+	Field<T1, false> _t1;
+	Field<T2, true> _t2;
+
+	// Value accessors; the function parameters are dummies for overload resolution.
+	// Only used to implement `field()` below.
+	auto &pick(T1 *) { return _t1; }
+	auto const &pick(T1 *) const { return _t1; }
+	auto &pick(T2 *) { return _t2; }
+	auto const &pick(T2 *) const { return _t2; }
+
+	// Generic field accessors; for internal use only.
+	template<typename T>
+	auto &field() {
+		return pick((T *)nullptr);
+	}
+	template<typename T>
+	auto const &field() const {
+		return pick((T *)nullptr);
+	}
+
+public:
+	// Types should be chosen so `T1` is cheaper to construct.
+	Either() : _t1() {}
+	// These constructors cannot be generic over the value type, because that would prevent
+	// constructible values from being inferred, e.g. a `const char *` string literal for an
+	// `std::string` field value.
+	Either(T1 &value) : _t1(value) {}
+	Either(T2 &value) : _t2(value) {}
+	Either(T1 const &value) : _t1(value) {}
+	Either(T2 const &value) : _t2(value) {}
+	Either(T1 &&value) : _t1(std::move(value)) {}
+	Either(T2 &&value) : _t2(std::move(value)) {}
+
+	// Destructor manually calls the appropriate value destructor.
+	~Either() {
+		if (_tag) {
+			_t2.value.~T2();
+		} else {
+			_t1.value.~T1();
+		}
+	}
+
+	// Copy assignment operators for each possible value.
+	Either &operator=(T1 const &value) {
+		_t1.tag = _t1.tag_value;
+		new (&_t1.value) T1(value);
+		return *this;
+	}
+	Either &operator=(T2 const &value) {
+		_t2.tag = _t2.tag_value;
+		new (&_t2.value) T2(value);
+		return *this;
+	}
+
+	// Move assignment operators for each possible value.
+	Either &operator=(T1 &&value) {
+		_t1.tag = _t1.tag_value;
+		new (&_t1.value) T1(std::move(value));
+		return *this;
+	}
+	Either &operator=(T2 &&value) {
+		_t2.tag = _t2.tag_value;
+		new (&_t2.value) T2(std::move(value));
+		return *this;
+	}
+
+	// Copy assignment operator from another `Either`.
+	Either &operator=(Either other) {
+		if (other._tag) {
+			*this = other._t2.value;
+		} else {
+			*this = other._t1.value;
+		}
+		return *this;
+	}
+
+	// Copy constructor from another `Either`; implemented in terms of value assignment operators.
+	Either(Either const &other) {
+		if (other._tag) {
+			*this = other._t2.value;
+		} else {
+			*this = other._t1.value;
+		}
+	}
+
+	// Move constructor from another `Either`; implemented in terms of value assignment operators.
+	Either(Either &&other) {
+		if (other._tag) {
+			*this = std::move(other._t2.value);
+		} else {
+			*this = std::move(other._t1.value);
+		}
+	}
+
+	// Equivalent of `.emplace<T>()` for `std::variant`s.
+	template<typename T, typename... Args>
+	void emplace(Args &&...args) {
+		this->~Either();
+		if constexpr (std::is_same_v<T, T2>) {
+			_t2.tag = _t2.tag_value;
+			new (&_t2.value) T2(std::forward<Args>(args)...);
+		} else {
+			_t1.tag = _t1.tag_value;
+			new (&_t1.value) T1(std::forward<Args>(args)...);
+		}
+	}
+
+	// Equivalent of `std::holds_alternative<T>()` for `std::variant`s.
+	template<typename T>
+	bool holds() const {
+		return _tag == std::is_same_v<T, T2>;
+	}
+
+	// Equivalent of `std::get<T>()` for `std::variant`s.
+	template<typename T>
+	auto &get() {
+		assume(holds<T>());
+		return field<T>().value;
+	}
+	template<typename T>
+	auto const &get() const {
+		assume(holds<T>());
+		return field<T>().value;
+	}
+};
+
+#endif // RGBDS_EITHER_HPP

--- a/include/either.hpp
+++ b/include/either.hpp
@@ -3,9 +3,10 @@
 #ifndef RGBDS_EITHER_HPP
 #define RGBDS_EITHER_HPP
 
-#include <assert.h>
 #include <type_traits>
 #include <utility>
+
+#include "helpers.hpp" // assume
 
 template<typename T1, typename T2>
 union Either {

--- a/include/file.hpp
+++ b/include/file.hpp
@@ -10,8 +10,8 @@
 #include <streambuf>
 #include <string.h>
 #include <string>
-#include <variant>
 
+#include "either.hpp"
 #include "helpers.hpp" // assume
 #include "platform.hpp"
 
@@ -19,7 +19,7 @@
 
 class File {
 	// Construct a `std::streambuf *` by default, since it's probably lighter than a `filebuf`.
-	std::variant<std::streambuf *, std::filebuf> _file;
+	Either<std::streambuf *, std::filebuf> _file;
 
 public:
 	File() {}
@@ -31,7 +31,8 @@ public:
 	 */
 	File *open(std::string const &path, std::ios_base::openmode mode) {
 		if (path != "-") {
-			return _file.emplace<std::filebuf>().open(path, mode) ? this : nullptr;
+			_file.emplace<std::filebuf>();
+			return _file.get<std::filebuf>().open(path, mode) ? this : nullptr;
 		} else if (mode & std::ios_base::in) {
 			assume(!(mode & std::ios_base::out));
 			_file.emplace<std::streambuf *>(std::cin.rdbuf());
@@ -49,8 +50,8 @@ public:
 		return this;
 	}
 	std::streambuf &operator*() {
-		auto *file = std::get_if<std::filebuf>(&_file);
-		return file ? *file : *std::get<std::streambuf *>(_file);
+		return _file.holds<std::filebuf>() ? _file.get<std::filebuf>()
+		                                   : *_file.get<std::streambuf *>();
 	}
 	std::streambuf const &operator*() const {
 		// The non-`const` version does not perform any modifications, so it's okay.
@@ -63,22 +64,23 @@ public:
 	}
 
 	File *close() {
-		if (auto *file = std::get_if<std::filebuf>(&_file); file) {
+		if (_file.holds<std::filebuf>()) {
 			// This is called by the destructor, and an explicit `close` shouldn't close twice.
+			std::filebuf fileBuf = std::move(_file.get<std::filebuf>());
 			_file.emplace<std::streambuf *>(nullptr);
-			if (file->close() != nullptr) {
+			if (fileBuf.close() != nullptr) {
 				return this;
 			}
-		} else if (std::get<std::streambuf *>(_file) != nullptr) {
+		} else if (_file.get<std::streambuf *>() != nullptr) {
 			return this;
 		}
 		return nullptr;
 	}
 
 	char const *c_str(std::string const &path) const {
-		return std::holds_alternative<std::filebuf>(_file)             ? path.c_str()
-		       : std::get<std::streambuf *>(_file) == std::cin.rdbuf() ? "<stdin>"
-		                                                               : "<stdout>";
+		return _file.holds<std::filebuf>()                         ? path.c_str()
+		       : _file.get<std::streambuf *>() == std::cin.rdbuf() ? "<stdin>"
+		                                                           : "<stdout>";
 	}
 };
 

--- a/include/link/main.hpp
+++ b/include/link/main.hpp
@@ -6,9 +6,9 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string>
-#include <variant>
 #include <vector>
 
+#include "either.hpp"
 #include "linkdefs.hpp"
 
 // Variables related to CLI options
@@ -38,8 +38,7 @@ extern bool disablePadding;
 
 struct FileStackNode {
 	FileStackNodeType type;
-	std::variant<
-	    std::monostate,        // Default constructed; `.type` and `.data` must be set manually
+	Either<
 	    std::vector<uint32_t>, // NODE_REPT
 	    std::string            // NODE_FILE, NODE_MACRO
 	    >
@@ -50,11 +49,11 @@ struct FileStackNode {
 	uint32_t lineNo;
 
 	// REPT iteration counts since last named node, in reverse depth order
-	std::vector<uint32_t> &iters();
-	std::vector<uint32_t> const &iters() const;
+	std::vector<uint32_t> &iters() { return data.get<std::vector<uint32_t>>(); }
+	std::vector<uint32_t> const &iters() const { return data.get<std::vector<uint32_t>>(); }
 	// File name for files, file::macro name for macros
-	std::string &name();
-	std::string const &name() const;
+	std::string &name() { return data.get<std::string>(); }
+	std::string const &name() const { return data.get<std::string>(); }
 
 	std::string const &dump(uint32_t curLineNo) const;
 };

--- a/include/link/symbol.hpp
+++ b/include/link/symbol.hpp
@@ -7,8 +7,8 @@
 
 #include <stdint.h>
 #include <string>
-#include <variant>
 
+#include "either.hpp"
 #include "linkdefs.hpp"
 
 struct FileStackNode;
@@ -28,14 +28,14 @@ struct Symbol {
 	char const *objFileName;
 	FileStackNode const *src;
 	int32_t lineNo;
-	std::variant<
+	Either<
 	    int32_t, // Constants just have a numeric value
 	    Label    // Label values refer to an offset within a specific section
 	    >
 	    data;
 
-	Label &label();
-	Label const &label() const;
+	Label &label() { return data.get<Label>(); }
+	Label const &label() const { return data.get<Label>(); }
 };
 
 void sym_ForEach(void (*callback)(Symbol &));

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -48,28 +48,8 @@ static std::vector<std::string> includePaths = {""};
 
 static std::string preIncludeName;
 
-std::vector<uint32_t> &FileStackNode::iters() {
-	assume(std::holds_alternative<std::vector<uint32_t>>(data));
-	return std::get<std::vector<uint32_t>>(data);
-}
-
-std::vector<uint32_t> const &FileStackNode::iters() const {
-	assume(std::holds_alternative<std::vector<uint32_t>>(data));
-	return std::get<std::vector<uint32_t>>(data);
-}
-
-std::string &FileStackNode::name() {
-	assume(std::holds_alternative<std::string>(data));
-	return std::get<std::string>(data);
-}
-
-std::string const &FileStackNode::name() const {
-	assume(std::holds_alternative<std::string>(data));
-	return std::get<std::string>(data);
-}
-
 std::string const &FileStackNode::dump(uint32_t curLineNo) const {
-	if (std::holds_alternative<std::vector<uint32_t>>(data)) {
+	if (data.holds<std::vector<uint32_t>>()) {
 		assume(parent); // REPT nodes use their parent's name
 		std::string const &lastName = parent->dump(lineNo);
 		fputs(" -> ", stderr);

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -19,11 +19,6 @@
 
 using namespace std::literals;
 
-int32_t Expression::value() const {
-	assume(std::holds_alternative<int32_t>(data));
-	return std::get<int32_t>(data);
-}
-
 void Expression::clear() {
 	data = 0;
 	isSymbol = false;
@@ -44,7 +39,7 @@ uint8_t *Expression::reserveSpace(uint32_t size, uint32_t patchSize) {
 
 int32_t Expression::getConstVal() const {
 	if (!isKnown()) {
-		error("Expected constant expression: %s\n", std::get<std::string>(data).c_str());
+		error("Expected constant expression: %s\n", data.get<std::string>().c_str());
 		return 0;
 	}
 	return value();

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -46,28 +46,8 @@ FILE *linkerScript;
 
 static uint32_t nbErrors = 0;
 
-std::vector<uint32_t> &FileStackNode::iters() {
-	assume(std::holds_alternative<std::vector<uint32_t>>(data));
-	return std::get<std::vector<uint32_t>>(data);
-}
-
-std::vector<uint32_t> const &FileStackNode::iters() const {
-	assume(std::holds_alternative<std::vector<uint32_t>>(data));
-	return std::get<std::vector<uint32_t>>(data);
-}
-
-std::string &FileStackNode::name() {
-	assume(std::holds_alternative<std::string>(data));
-	return std::get<std::string>(data);
-}
-
-std::string const &FileStackNode::name() const {
-	assume(std::holds_alternative<std::string>(data));
-	return std::get<std::string>(data);
-}
-
 std::string const &FileStackNode::dump(uint32_t curLineNo) const {
-	if (std::holds_alternative<std::vector<uint32_t>>(data)) {
+	if (data.holds<std::vector<uint32_t>>()) {
 		assume(parent); // REPT nodes use their parent's name
 		std::string const &lastName = parent->dump(lineNo);
 		fputs(" -> ", stderr);

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -503,7 +503,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID) {
 		// object file. It's better than nothing.
 		nodes[fileID].push_back({
 		    .type = NODE_FILE,
-		    .data = fileName,
+		    .data = Either<std::vector<uint32_t>, std::string>(fileName),
 		    .parent = nullptr,
 		    .lineNo = 0,
 		});

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -564,16 +564,16 @@ static void writeSym() {
 	constants.clear();
 	sym_ForEach([](Symbol &sym) {
 		// Symbols are already limited to the exported ones
-		if (std::holds_alternative<int32_t>(sym.data))
+		if (sym.data.holds<int32_t>())
 			constants.push_back(&sym);
 	});
 	// Numeric constants are ordered by value, then by name
 	std::sort(RANGE(constants), [](Symbol *sym1, Symbol *sym2) -> bool {
-		int32_t val1 = std::get<int32_t>(sym1->data), val2 = std::get<int32_t>(sym2->data);
+		int32_t val1 = sym1->data.get<int32_t>(), val2 = sym2->data.get<int32_t>();
 		return val1 != val2 ? val1 < val2 : sym1->name < sym2->name;
 	});
 	for (Symbol *sym : constants) {
-		int32_t val = std::get<int32_t>(sym->data);
+		int32_t val = sym->data.get<int32_t>();
 		int width = val < 0x100 ? 2 : val < 0x10000 ? 4 : 8;
 		fprintf(symFile, "%0*" PRIx32 " %s\n", width, val, sym->name.c_str());
 	}

--- a/src/link/patch.cpp
+++ b/src/link/patch.cpp
@@ -5,7 +5,6 @@
 #include <deque>
 #include <inttypes.h>
 #include <stdint.h>
-#include <variant>
 #include <vector>
 
 #include "helpers.hpp" // assume, clz, ctz

--- a/src/link/patch.cpp
+++ b/src/link/patch.cpp
@@ -230,8 +230,8 @@ static int32_t computeRPNExpr(Patch const &patch, std::vector<Symbol> const &fil
 				);
 				isError = true;
 				value = 1;
-			} else if (auto *label = std::get_if<Label>(&symbol->data); label) {
-				value = label->section->bank;
+			} else if (symbol->data.holds<Label>()) {
+				value = symbol->data.get<Label>().section->bank;
 			} else {
 				error(
 				    patch.src,
@@ -390,11 +390,11 @@ static int32_t computeRPNExpr(Patch const &patch, std::vector<Symbol> const &fil
 					    fileSymbols[value].name.c_str()
 					);
 					isError = true;
-				} else if (auto *label = std::get_if<Label>(&symbol->data); label) {
-					value = label->section->org + label->offset;
+				} else if (symbol->data.holds<Label>()) {
+					Label const &label = symbol->data.get<Label>();
+					value = label.section->org + label.offset;
 				} else {
-					assume(std::holds_alternative<int32_t>(symbol->data));
-					value = std::get<int32_t>(symbol->data);
+					value = symbol->data.get<int32_t>();
 				}
 			}
 			break;

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -8,7 +8,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <tuple>
-#include <variant>
 
 #include "helpers.hpp" // assume
 #include "linkdefs.hpp"

--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -12,16 +12,6 @@
 
 std::unordered_map<std::string, Symbol *> symbols;
 
-Label &Symbol::label() {
-	assume(std::holds_alternative<Label>(data));
-	return std::get<Label>(data);
-}
-
-Label const &Symbol::label() const {
-	assume(std::holds_alternative<Label>(data));
-	return std::get<Label>(data);
-}
-
 void sym_ForEach(void (*callback)(Symbol &)) {
 	for (auto &it : symbols)
 		callback(*it.second);
@@ -29,8 +19,9 @@ void sym_ForEach(void (*callback)(Symbol &)) {
 
 void sym_AddSymbol(Symbol &symbol) {
 	Symbol *other = sym_GetSymbol(symbol.name);
-	auto *symValue = std::get_if<int32_t>(&symbol.data);
-	auto *otherValue = other ? std::get_if<int32_t>(&other->data) : nullptr;
+	int32_t *symValue = symbol.data.holds<int32_t>() ? &symbol.data.get<int32_t>() : nullptr;
+	int32_t *otherValue =
+	    other && other->data.holds<int32_t>() ? &other->data.get<int32_t>() : nullptr;
 
 	// Check if the symbol already exists with a different value
 	if (other && !(symValue && otherValue && *symValue == *otherValue)) {


### PR DESCRIPTION
We has already [avoided using `std::visit`](https://bitbashing.io/std-visit.html) in #1367, but using `std::variant` at all is [slower](https://www.reddit.com/r/cpp/comments/kst2pu/with_stdvariant_you_choose_either_performance_or/) than a manual tagged union.

The only use of `std::variant` left here is the four-variant `Symbol` data (which can be a number, number callback, macro, or string).

This ends up saving around 0.15 seconds total to build pokecrystal, going from 4.90s to 4.75s (a 3% savings). (That sounds low, but was an atypically significant amount while optimizing for the 0.7.0 release.)

It also reduces the rgbasm executable file size from 367 KB to 343 KB bytes (a 7% savings).