### PR TITLE
Implement `INCLUDE_ONCE` directive

### DIFF
--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -17,6 +17,12 @@
 
 #include "asm/lexer.hpp"
 
+enum IncludeType {
+	INCLUDE_NORMAL,
+	INCLUDE_PRE,
+	INCLUDE_ONCE
+};
+
 struct FileStackNode {
 	FileStackNodeType type;
 	Either<
@@ -64,8 +70,7 @@ void fstk_SetPreIncludeFile(std::string const &path);
 std::optional<std::string> fstk_FindFile(std::string const &path);
 
 bool yywrap();
-void fstk_RunInclude(std::string const &path, bool updateStateNow);
-void fstk_RunIncludeOnce(std::string const &path);
+void fstk_RunInclude(std::string const &path, IncludeType type);
 void fstk_RunMacro(std::string const &macroName, std::shared_ptr<MacroArgs> macroArgs);
 void fstk_RunRept(uint32_t count, int32_t reptLineNo, ContentSpan const &span);
 void fstk_RunFor(

--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -65,6 +65,7 @@ std::optional<std::string> fstk_FindFile(std::string const &path);
 
 bool yywrap();
 void fstk_RunInclude(std::string const &path, bool updateStateNow);
+void fstk_RunIncludeOnce(std::string const &path);
 void fstk_RunMacro(std::string const &macroName, std::shared_ptr<MacroArgs> macroArgs);
 void fstk_RunRept(uint32_t count, int32_t reptLineNo, ContentSpan const &span);
 void fstk_RunFor(

--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -2158,6 +2158,15 @@ calls infinitely (or until you run out of memory, whichever comes first).
     INCLUDE "irq.inc"
 .Ed
 .Pp
+You may also ensure a file only gets included once by using
+.Ic INCLUDE_ONCE
+instead of
+.Ic INCLUDE .
+This will skip including a file if its exact path has already been included before (with
+.Ic INCLUDE
+or
+.Ic INCLUDE_ONCE ) .
+.Pp
 You may also implicitly
 .Ic INCLUDE
 a file before the source file with the

--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -2162,12 +2162,13 @@ You may also ensure a file only gets included once by using
 .Ic INCLUDE_ONCE
 instead of
 .Ic INCLUDE .
-This will skip including a file if its exact path has already been included before (with
-.Ic INCLUDE
+This will skip including a file if it has already been included before (with
+.Ic INCLUDE ,
+.Ic INCLUDE_ONCE ,
 or
-.Ic INCLUDE_ONCE ) .
+.Fl P ) .
 .Pp
-You may also implicitly
+You can implicitly
 .Ic INCLUDE
 a file before the source file with the
 .Fl P

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -256,6 +256,7 @@ static std::unordered_map<std::string, int, CaseInsensitive, CaseInsensitive> ke
     {"INCHARMAP",     T_(OP_INCHARMAP)     },
 
     {"INCLUDE",       T_(POP_INCLUDE)      },
+    {"INCLUDE_ONCE",  T_(POP_INCLUDE_ONCE) },
     {"PRINT",         T_(POP_PRINT)        },
     {"PRINTLN",       T_(POP_PRINTLN)      },
     {"EXPORT",        T_(POP_EXPORT)       },

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -1142,7 +1142,7 @@ export_def:
 
 include:
 	label POP_INCLUDE string endofline {
-		fstk_RunInclude($3, false);
+		fstk_RunInclude($3, INCLUDE_NORMAL);
 		if (failedOnMissingInclude)
 			YYACCEPT;
 	}
@@ -1150,7 +1150,7 @@ include:
 
 include_once:
 	label POP_INCLUDE_ONCE string endofline {
-		fstk_RunIncludeOnce($3);
+		fstk_RunInclude($3, INCLUDE_ONCE);
 		if (failedOnMissingInclude)
 			YYACCEPT;
 	}

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -236,6 +236,7 @@
 %token POP_IF "IF"
 %token POP_INCBIN "INCBIN"
 %token POP_INCLUDE "INCLUDE"
+%token POP_INCLUDE_ONCE "INCLUDE_ONCE"
 %token POP_LOAD "LOAD"
 %token POP_MACRO "MACRO"
 %token POP_NEWCHARMAP "NEWCHARMAP"
@@ -464,6 +465,7 @@ line_directive:
 	| for
 	| break
 	| include
+	| include_once
 	| if
 	// It's important that all of these require being at line start for `skipIfBlock`
 	| elif
@@ -1141,6 +1143,14 @@ export_def:
 include:
 	label POP_INCLUDE string endofline {
 		fstk_RunInclude($3, false);
+		if (failedOnMissingInclude)
+			YYACCEPT;
+	}
+;
+
+include_once:
+	label POP_INCLUDE_ONCE string endofline {
+		fstk_RunIncludeOnce($3);
 		if (failedOnMissingInclude)
 			YYACCEPT;
 	}

--- a/test/asm/include-once.asm
+++ b/test/asm/include-once.asm
@@ -1,0 +1,2 @@
+INCLUDE_ONCE "include-once.inc"
+INCLUDE_ONCE "include-once.inc"

--- a/test/asm/include-once.asm
+++ b/test/asm/include-once.asm
@@ -1,2 +1,3 @@
 INCLUDE_ONCE "include-once.inc"
 INCLUDE_ONCE "include-once.inc"
+INCLUDE_ONCE "include-link.inc"

--- a/test/asm/include-once.inc
+++ b/test/asm/include-once.inc
@@ -1,0 +1,1 @@
+DEF HELLO EQU 1

--- a/test/asm/test.sh
+++ b/test/asm/test.sh
@@ -11,9 +11,12 @@ input="$(mktemp)"
 output="$(mktemp)"
 errput="$(mktemp)"
 
+# Create a symbolic link for the `include-once.asm` test case.
+ln include-once.inc include-link.inc
+
 # Immediate expansion is the desired behavior.
 # shellcheck disable=SC2064
-trap "rm -f ${o@Q} ${gb@Q} ${input@Q} ${output@Q} ${errput@Q}" EXIT
+trap "rm -f ${o@Q} ${gb@Q} ${input@Q} ${output@Q} ${errput@Q} include-link.inc" EXIT
 
 tests=0
 failed=0


### PR DESCRIPTION
Fixes #1478.

This behaves like regular `include` the first time a file is included, except the name of the file is added to a list. The next time using `INCLUDE_ONCE` on that file, the file will not be included. `INCLUDE_ONCE` does not take symlinks into account. The string that is registered, is the one entered into the directive.

This is effectively an include guard, not unlike C/C++ `#PRAGMA ONCE`.