### PR TITLE
Report any section overflows at the end of assembly

### DIFF
--- a/include/asm/section.hpp
+++ b/include/asm/section.hpp
@@ -78,6 +78,8 @@ uint32_t sect_GetOutputOffset();
 uint32_t sect_GetAlignBytes(uint8_t alignment, uint16_t offset);
 void sect_AlignPC(uint8_t alignment, uint16_t offset);
 
+void sect_CheckSizes();
+
 void sect_StartUnion();
 void sect_NextUnionMember();
 void sect_EndUnion();

--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -381,6 +381,7 @@ int main(int argc, char *argv[]) {
 		nbErrors = 1;
 
 	sect_CheckUnionClosed();
+	sect_CheckSizes();
 
 	if (nbErrors != 0)
 		errx("Assembly aborted (%u error%s)!", nbErrors, nbErrors == 1 ? "" : "s");

--- a/test/asm/incbin-empty-bad.err
+++ b/test/asm/incbin-empty-bad.err
@@ -1,3 +1,3 @@
 error: incbin-empty-bad.asm(3):
-    Specified range in INCBIN is out of bounds (0 + 1 > 0)
+    Specified range in INCBIN file 'empty.bin' is out of bounds (0 + 1 > 0)
 error: Assembly aborted (1 error)!

--- a/test/asm/incbin-end-bad.err
+++ b/test/asm/incbin-end-bad.err
@@ -1,3 +1,3 @@
 error: incbin-end-bad.asm(3):
-    Specified range in INCBIN is out of bounds (123 + 1 > 123)
+    Specified range in INCBIN file 'data.bin' is out of bounds (123 + 1 > 123)
 error: Assembly aborted (1 error)!

--- a/test/asm/load-overflow.asm
+++ b/test/asm/load-overflow.asm
@@ -1,25 +1,25 @@
 SECTION "Overflow", ROM0
 	ds $6000
 LOAD "oops",WRAM0
-	; We might get an error for "oops", but it can also make sense to no-op the directive
-	ds $2001
-	; We shouldn't get any more errors for "Overflow" nor "oops"
+	ds $2000
+	db
 	db
 ENDL
 
 SECTION "Moar overflow", ROM0
-	ds $6001
+	ds $4000
+	ds $4000
 LOAD "hmm", WRAM0
 	ds $2000
-	; Since the `ds` overflows "Moar overflow", it could be no-op'd, making this `db` not error
-	db
+	ds $2000
 ENDL
+	ds $1000
 
 SECTION "Not overflowing", ROM0
-	ds $5FFF
+	ds $800
 LOAD "lol", WRAM0
-	ds $2000
-	db
-	; Since the LOAD block is overflowed, this may be no-op'd, not affecting the "parent"
+	ds $1000
+	ds $1000
+	ds $1000
 ENDL
-	dw ; This, however...
+	ds $800

--- a/test/asm/load-overflow.err
+++ b/test/asm/load-overflow.err
@@ -1,11 +1,15 @@
-error: load-overflow.asm(5):
-    Section 'Overflow' grew too big (max size = 0x8000 bytes, reached 0x8001).
-error: load-overflow.asm(5):
-    Section 'oops' grew too big (max size = 0x2000 bytes, reached 0x2001).
-error: load-overflow.asm(13):
-    Section 'Moar overflow' grew too big (max size = 0x8000 bytes, reached 0x8001).
-error: load-overflow.asm(22):
-    Section 'lol' grew too big (max size = 0x2000 bytes, reached 0x2001).
-error: load-overflow.asm(25):
-    Section 'Not overflowing' grew too big (max size = 0x8000 bytes, reached 0x8001).
+warning: load-overflow.asm(5): [-Wempty-data-directive]
+    DB directive without data in ROM
+warning: load-overflow.asm(6): [-Wempty-data-directive]
+    DB directive without data in ROM
+error: load-overflow.asm(26):
+    Section 'Overflow' grew too big (max size = 0x8000 bytes, reached 0x8002).
+error: load-overflow.asm(26):
+    Section 'oops' grew too big (max size = 0x2000 bytes, reached 0x2002).
+error: load-overflow.asm(26):
+    Section 'Moar overflow' grew too big (max size = 0x8000 bytes, reached 0xD000).
+error: load-overflow.asm(26):
+    Section 'hmm' grew too big (max size = 0x2000 bytes, reached 0x4000).
+error: load-overflow.asm(26):
+    Section 'lol' grew too big (max size = 0x2000 bytes, reached 0x3000).
 error: Assembly aborted (5 errors)!


### PR DESCRIPTION
Fixes #538

Also since this doesn't make space-declaring directives into no-ops when they occur after an overflow, now errors with those directives don't get silenced.