### PR TITLE
Traverse the charmap trie to reconstruct mappings instead of saving them

### DIFF
--- a/src/asm/charmap.cpp
+++ b/src/asm/charmap.cpp
@@ -46,7 +46,7 @@ bool charmap_ForEach(
 		// Traverse the trie depth-first to derive the character mappings in definition order
 		std::map<size_t, std::string> mappings;
 		for (std::stack<std::pair<size_t, std::string>> prefixes({{0, ""}}); !prefixes.empty();) {
-			auto [nodeIdx, mapping] = prefixes.top();
+			auto [nodeIdx, mapping] = std::move(prefixes.top());
 			prefixes.pop();
 			CharmapNode const &node = charmap.nodes[nodeIdx];
 			if (node.isTerminal())

--- a/test/asm/state-file/a.dump.asm
+++ b/test/asm/state-file/a.dump.asm
@@ -17,9 +17,9 @@ newcharmap main
 charmap "c", $4
 charmap "c2", $a, $fffffff5, $3ade68b1
 newcharmap map2
-charmap "\0\n\t\r", $9, $d, $0, $a
 charmap "c", $4
 charmap "c2", $a, $fffffff5, $3ade68b1
+charmap "\0\n\t\r", $9, $d, $0, $a
 
 ; Macros
 macro mac2

--- a/test/asm/state-file/a.dump.asm
+++ b/test/asm/state-file/a.dump.asm
@@ -17,9 +17,9 @@ newcharmap main
 charmap "c", $4
 charmap "c2", $a, $fffffff5, $3ade68b1
 newcharmap map2
+charmap "\0\n\t\r", $9, $d, $0, $a
 charmap "c", $4
 charmap "c2", $a, $fffffff5, $3ade68b1
-charmap "\0\n\t\r", $9, $d, $0, $a
 
 ; Macros
 macro mac2


### PR DESCRIPTION
There's a fundamental issue with this approach that makes me not want to use it: it loses the order in which charmaps were defined, instead outputting them in the ASCII/UTF-8 byte order. (Even the mapped-value order would be more meaningful than that.)

Besides that, I still need to measure the performance benefit of not caching the mappings at definition time. I suspect that it was low; and the performance *hit* when actually making the dump file (admittedly a rare action) is visible.