### PR TITLE
Improve performance of emitting data

### DIFF
--- a/include/asm/format.hpp
+++ b/include/asm/format.hpp
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <string>
 
-enum FormatState {
+enum FormatState : unsigned char {
 	FORMAT_SIGN,    // expects '+' or ' ' (optional)
 	FORMAT_PREFIX,  // expects '#' (optional)
 	FORMAT_ALIGN,   // expects '-' (optional)
@@ -18,16 +18,17 @@ enum FormatState {
 };
 
 class FormatSpec {
-	FormatState state;
 	int sign;
 	bool prefix;
 	bool alignLeft;
 	bool padZero;
-	size_t width;
 	bool hasFrac;
 	size_t fracWidth;
+	size_t width;
 	int type;
 	bool valid;
+
+	FormatState state;
 
 public:
 	bool isEmpty() const { return !state; }

--- a/include/asm/lexer.hpp
+++ b/include/asm/lexer.hpp
@@ -21,7 +21,7 @@ static_assert(LEXER_BUF_SIZE > 1, "Lexer buffer size is too small");
 // This caps the size of buffer reads, and according to POSIX, passing more than SSIZE_MAX is UB
 static_assert(LEXER_BUF_SIZE <= SSIZE_MAX, "Lexer buffer size is too large");
 
-enum LexerMode {
+enum LexerMode : unsigned char {
 	LEXER_NORMAL,
 	LEXER_RAW,
 	LEXER_SKIP_TO_ELIF,
@@ -80,23 +80,23 @@ struct IfStackEntry {
 struct LexerState {
 	std::string path;
 
-	LexerMode mode;
+	std::deque<Expansion> expansions; // Front is the innermost current expansion
+	size_t macroArgScanDistance; // Max distance already scanned for macro args
+	bool disableMacroArgs;
+	bool disableInterpolation;
+	bool expandStrings;
+
 	bool atLineStart;
 	uint32_t lineNo;
 	uint32_t colNo;
 	int lastToken;
-
-	std::deque<IfStackEntry> ifStack;
+	LexerMode mode;
 
 	bool capturing;     // Whether the text being lexed should be captured
 	size_t captureSize; // Amount of text captured
 	std::shared_ptr<std::vector<char>> captureBuf; // Buffer to send the captured text to if set
 
-	bool disableMacroArgs;
-	bool disableInterpolation;
-	size_t macroArgScanDistance; // Max distance already scanned for macro args
-	bool expandStrings;
-	std::deque<Expansion> expansions; // Front is the innermost current expansion
+	std::deque<IfStackEntry> ifStack;
 
 	Either<ViewedContent, BufferedContent> content;
 

--- a/include/asm/output.hpp
+++ b/include/asm/output.hpp
@@ -14,7 +14,7 @@
 struct Expression;
 struct FileStackNode;
 
-enum StateFeature {
+enum StateFeature : unsigned char {
     STATE_EQU,
     STATE_VAR,
     STATE_EQUS,

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -18,9 +18,9 @@ struct Expression {
 	    std::string // Why the expression is not known, if it isn't
 	    >
 	    data = 0;
-	bool isSymbol = false; // Whether the expression represents a symbol suitable for const diffing
 	std::vector<uint8_t> rpn{}; // Bytes serializing the RPN expression
 	uint32_t rpnPatchSize = 0;  // Size the expression will take in the object file
+	bool isSymbol = false; // Whether the expression represents a symbol suitable for const diffing
 
 	Expression() = default;
 	Expression(Expression &&) = default;

--- a/include/asm/section.hpp
+++ b/include/asm/section.hpp
@@ -30,15 +30,15 @@ struct Patch {
 
 struct Section {
 	std::string name;
-	SectionType type;
-	SectionModifier modifier;
 	std::shared_ptr<FileStackNode> src; // Where the section was defined
 	uint32_t fileLine;                  // Line where the section was defined
-	uint32_t size;
 	uint32_t org;
 	uint32_t bank;
-	uint8_t align; // Exactly as specified in `ALIGN[]`
+	uint16_t size;
 	uint16_t alignOfs;
+	uint8_t align; // Exactly as specified in `ALIGN[]`
+	SectionType type;
+	SectionModifier modifier;
 	std::deque<Patch> patches;
 	std::vector<uint8_t> data;
 
@@ -73,8 +73,8 @@ void sect_SetLoadSection(
 void sect_EndLoadSection();
 
 Section *sect_GetSymbolSection();
-uint32_t sect_GetSymbolOffset();
-uint32_t sect_GetOutputOffset();
+uint16_t sect_GetSymbolOffset();
+uint16_t sect_GetOutputOffset();
 uint32_t sect_GetAlignBytes(uint8_t alignment, uint16_t offset);
 void sect_AlignPC(uint8_t alignment, uint16_t offset);
 

--- a/include/asm/symbol.hpp
+++ b/include/asm/symbol.hpp
@@ -15,7 +15,7 @@
 #include "asm/lexer.hpp"
 #include "asm/section.hpp"
 
-enum SymbolType {
+enum SymbolType : unsigned char {
 	SYM_LABEL,
 	SYM_EQU,
 	SYM_VAR,
@@ -29,12 +29,12 @@ bool sym_IsPC(Symbol const *sym); // For the inline `getSection` method
 
 struct Symbol {
 	std::string name;
+	std::shared_ptr<FileStackNode> src; // Where the symbol was defined
+	uint32_t fileLine;                  // Line where the symbol was defined
 	SymbolType type;
 	bool isExported; // Whether the symbol is to be exported
 	bool isBuiltin;  // Whether the symbol is a built-in
 	Section *section;
-	std::shared_ptr<FileStackNode> src; // Where the symbol was defined
-	uint32_t fileLine;                  // Line where the symbol was defined
 
 	std::variant<
 	    int32_t,                     // If isNumeric()

--- a/include/asm/warning.hpp
+++ b/include/asm/warning.hpp
@@ -5,7 +5,7 @@
 
 extern unsigned int nbErrors, maxErrors;
 
-enum WarningState { WARNING_DEFAULT, WARNING_DISABLED, WARNING_ENABLED, WARNING_ERROR };
+enum WarningState : unsigned char { WARNING_DEFAULT, WARNING_DISABLED, WARNING_ENABLED, WARNING_ERROR };
 
 enum WarningID {
 	WARNING_ASSERT,               // Assertions

--- a/include/gfx/main.hpp
+++ b/include/gfx/main.hpp
@@ -13,6 +13,8 @@
 #include "gfx/rgba.hpp"
 
 struct Options {
+	std::string input{}; // positional arg
+
 	bool useColorCurve = false;   // -C
 	bool allowDedup = false;      // -u
 	bool allowMirroringX = false; // -X, -m
@@ -20,15 +22,15 @@ struct Options {
 	bool columnMajor = false;     // -Z
 	uint8_t verbosity = 0;        // -v
 
-	std::string attrmap{};                    // -a, -A
-	std::array<uint8_t, 2> baseTileIDs{0, 0}; // -b
-	enum {
+	enum : unsigned char {
 		NO_SPEC,
 		EXPLICIT,
 		EMBEDDED,
-	} palSpecType = NO_SPEC; // -c
+	} palSpecType = NO_SPEC;                  // -c
+	uint8_t bitDepth = 2;                     // -d
+	std::string attrmap{};                    // -a, -A
+	std::array<uint8_t, 2> baseTileIDs{0, 0}; // -b
 	std::vector<std::array<std::optional<Rgba>, 4>> palSpec{};
-	uint8_t bitDepth = 2; // -d
 	struct {
 		uint16_t left;
 		uint16_t top;
@@ -36,16 +38,14 @@ struct Options {
 		uint16_t height;
 	} inputSlice{0, 0, 0, 0};                          // -L (margins in clockwise order, like CSS)
 	std::array<uint16_t, 2> maxNbTiles{UINT16_MAX, 0}; // -N
-	uint16_t nbPalettes = 8;                           // -n
 	std::string output{};                              // -o
 	std::string palettes{};                            // -p, -P
 	std::string palmap{};                              // -q, -Q
-	uint16_t reversedWidth = 0;                        // -r, in tiles
-	uint8_t nbColorsPerPal = 0;                        // -s; 0 means "auto" = 1 << bitDepth;
 	std::string tilemap{};                             // -t, -T
 	uint64_t trim = 0;                                 // -x
-
-	std::string input{}; // positional arg
+	uint16_t nbPalettes = 8;                           // -n
+	uint16_t reversedWidth = 0;                        // -r, in tiles
+	uint8_t nbColorsPerPal = 0;                        // -s; 0 means "auto" = 1 << bitDepth;
 
 	static constexpr uint8_t VERB_NONE = 0;     // Normal, no extra output
 	static constexpr uint8_t VERB_CFG = 1;      // Print configuration after parsing options

--- a/include/link/main.hpp
+++ b/include/link/main.hpp
@@ -37,16 +37,16 @@ extern bool disablePadding;
 	} while (0)
 
 struct FileStackNode {
-	FileStackNodeType type;
 	Either<
 	    std::vector<uint32_t>, // NODE_REPT
 	    std::string            // NODE_FILE, NODE_MACRO
 	    >
 	    data;
+	FileStackNodeType type;
 
-	FileStackNode *parent;
 	// Line at which the parent context was exited; meaningless for the root level
 	uint32_t lineNo;
+	FileStackNode *parent;
 
 	// REPT iteration counts since last named node, in reverse depth order
 	std::vector<uint32_t> &iters() { return data.get<std::vector<uint32_t>>(); }

--- a/include/link/symbol.hpp
+++ b/include/link/symbol.hpp
@@ -24,9 +24,9 @@ struct Label {
 struct Symbol {
 	// Info contained in the object files
 	std::string name;
-	ExportLevel type;
 	char const *objFileName;
 	FileStackNode const *src;
+	ExportLevel type;
 	int32_t lineNo;
 	Either<
 	    int32_t, // Constants just have a numeric value

--- a/include/linkdefs.hpp
+++ b/include/linkdefs.hpp
@@ -11,9 +11,9 @@
 #define RGBDS_OBJECT_VERSION_STRING "RGB9"
 #define RGBDS_OBJECT_REV            11U
 
-enum AssertionType { ASSERT_WARN, ASSERT_ERROR, ASSERT_FATAL };
+enum AssertionType : unsigned char { ASSERT_WARN, ASSERT_ERROR, ASSERT_FATAL };
 
-enum RPNCommand {
+enum RPNCommand : unsigned char {
 	RPN_ADD = 0x00,
 	RPN_SUB = 0x01,
 	RPN_MUL = 0x02,
@@ -62,7 +62,7 @@ enum RPNCommand {
 	RPN_SYM = 0x81
 };
 
-enum SectionType {
+enum SectionType : unsigned char {
 	SECTTYPE_WRAM0,
 	SECTTYPE_VRAM,
 	SECTTYPE_ROMX,
@@ -77,7 +77,7 @@ enum SectionType {
 	SECTTYPE_INVALID
 };
 
-enum FileStackNodeType {
+enum FileStackNodeType : unsigned char {
 	NODE_REPT,
 	NODE_FILE,
 	NODE_MACRO,
@@ -119,13 +119,13 @@ static inline uint32_t nbbanks(SectionType type) {
 	return sectionTypeInfo[type].lastBank - sectionTypeInfo[type].firstBank + 1;
 }
 
-enum SectionModifier { SECTION_NORMAL, SECTION_UNION, SECTION_FRAGMENT };
+enum SectionModifier : unsigned char { SECTION_NORMAL, SECTION_UNION, SECTION_FRAGMENT };
 
 extern char const * const sectionModNames[];
 
-enum ExportLevel { SYMTYPE_LOCAL, SYMTYPE_IMPORT, SYMTYPE_EXPORT };
+enum ExportLevel : unsigned char { SYMTYPE_LOCAL, SYMTYPE_IMPORT, SYMTYPE_EXPORT };
 
-enum PatchType {
+enum PatchType : unsigned char {
 	PATCHTYPE_BYTE,
 	PATCHTYPE_WORD,
 	PATCHTYPE_LONG,

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -43,11 +43,11 @@ std::stack<UnionStackEntry> currentUnionStack;
 std::deque<SectionStackEntry> sectionStack;
 std::deque<Section> sectionList;
 std::unordered_map<std::string, size_t> sectionMap; // Indexes into `sectionList`
-uint32_t curOffset; // Offset into the current section (see sect_GetSymbolOffset)
+uint16_t curOffset; // Offset into the current section (see sect_GetSymbolOffset)
 Section *currentSection = nullptr;
 static Section *currentLoadSection = nullptr;
 std::optional<std::string> currentLoadScope = std::nullopt;
-int32_t loadOffset; // Offset into the LOAD section's parent (see sect_GetOutputOffset)
+int16_t loadOffset; // Offset into the LOAD section's parent (see sect_GetOutputOffset)
 
 // A quick check to see if we have an initialized section
 [[nodiscard]] static bool requireSection() {
@@ -78,7 +78,7 @@ void sect_CheckSizes() {
 	for (Section const &sect : sectionList) {
 		if (uint32_t maxSize = sectionTypeInfo[sect.type].size; sect.size > maxSize)
 			error(
-			    "Section '%s' grew too big (max size = 0x%" PRIX32 " bytes, reached 0x%" PRIX32
+			    "Section '%s' grew too big (max size = 0x%" PRIX32 " bytes, reached 0x%" PRIX16
 			    ").\n",
 			    sect.name.c_str(),
 			    maxSize,
@@ -494,11 +494,11 @@ Section *sect_GetSymbolSection() {
 }
 
 // The offset into the section above
-uint32_t sect_GetSymbolOffset() {
+uint16_t sect_GetSymbolOffset() {
 	return curOffset;
 }
 
-uint32_t sect_GetOutputOffset() {
+uint16_t sect_GetOutputOffset() {
 	return curOffset + loadOffset;
 }
 
@@ -558,7 +558,7 @@ void sect_AlignPC(uint8_t alignment, uint16_t offset) {
 }
 
 static void growSection(uint32_t growth) {
-	if (curOffset > UINT32_MAX - growth)
+	if (growth > UINT16_MAX || curOffset > UINT16_MAX - growth)
 		fatalerror("Section size would overflow internal counter\n");
 	curOffset += growth;
 	if (uint32_t outOffset = sect_GetOutputOffset(); outOffset > currentSection->size)

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -502,10 +502,10 @@ void obj_ReadFile(char const *fileName, unsigned int fileID) {
 		// Since SDCC does not provide line info, everything will be reported as coming from the
 		// object file. It's better than nothing.
 		nodes[fileID].push_back({
-		    .type = NODE_FILE,
 		    .data = Either<std::vector<uint32_t>, std::string>(fileName),
-		    .parent = nullptr,
+		    .type = NODE_FILE,
 		    .lineNo = 0,
+		    .parent = nullptr,
 		});
 
 		std::vector<Symbol> &fileSymbols = symbolLists.emplace_front();

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <vector>
 
 #include "error.hpp"
 #include "extern/utf8decoder.hpp"

--- a/test/asm/incbin-empty-bad.err
+++ b/test/asm/incbin-empty-bad.err
@@ -1,3 +1,3 @@
 error: incbin-empty-bad.asm(3):
-    Specified range in INCBIN file 'empty.bin' is out of bounds (0 + 1 > 0)
+    Premature end of INCBIN file "empty.bin" (1 byte left to read)
 error: Assembly aborted (1 error)!

--- a/test/asm/incbin-end-bad.err
+++ b/test/asm/incbin-end-bad.err
@@ -1,3 +1,3 @@
 error: incbin-end-bad.asm(3):
-    Specified range in INCBIN file 'data.bin' is out of bounds (123 + 1 > 123)
+    Premature end of INCBIN file "data.bin" (1 byte left to read)
 error: Assembly aborted (1 error)!

--- a/test/asm/section-unsigned-overflow.asm
+++ b/test/asm/section-unsigned-overflow.asm
@@ -1,9 +1,9 @@
 section "overflow", rom0
 rept 10
-	ds $4000_0000
+	ds $4000
 endr
 
 section "moar overflow", romx
 rept 10
-	ds $4000_0000
+	ds $4000
 endr


### PR DESCRIPTION
Primarily, avoids reserving the max size for ROM sections' data. Also performs bulk reads.

Fixes #1483
