### PR TITLE
Allow dollar signs in identifiers

### DIFF
--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -1069,7 +1069,9 @@ A text string that can be expanded later, similarly to a macro.
 Symbol names can contain ASCII letters, numbers, underscores
 .Sq _ ,
 hashes
-.Sq #
+.Sq # ,
+dollar signs
+.Sq $ ,
 and at signs
 .Sq @ .
 However, they must begin with either a letter or an underscore.

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -1144,7 +1144,7 @@ static bool startsIdentifier(int c) {
 }
 
 static bool continuesIdentifier(int c) {
-	return startsIdentifier(c) || (c <= '9' && c >= '0') || c == '#' || c == '@';
+	return startsIdentifier(c) || (c <= '9' && c >= '0') || c == '#' || c == '$' || c == '@';
 }
 
 static Token readIdentifier(char firstChar, bool raw) {

--- a/test/asm/symbol-names.asm
+++ b/test/asm/symbol-names.asm
@@ -1,0 +1,11 @@
+def Alpha_Betical = 1
+def A1pha_Num3r1c = 2
+def C# = 3
+def l@tias = 4
+def ca$h = 5
+def c@#$@red = 6
+
+SECTION "test", WRAM0
+wABC:: db
+w123:: db
+w@#$:: db


### PR DESCRIPTION
These are already allowed by the [sym file spec](https://rgbds.gbdev.io/sym#name) and in many other assemblers. A benefit of allowing them here is that `prefix{var}` could expand out to `prefix$1A` and still be valid, instead of having to do `prefix{u:var}`.