### PR TITLE
Fix build in OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ else()
     # does not recognize this yet.
     add_compile_options(-Wno-gnu-zero-variadic-macro-arguments)
   endif()
-  add_definitions(-D_POSIX_C_SOURCE=200809L)
   if(SANITIZERS)
     set(SAN_FLAGS -fsanitize=shift -fsanitize=integer-divide-by-zero
                   -fsanitize=unreachable -fsanitize=vla-bound

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ WARNFLAGS	:= -Wall -pedantic -Wno-unknown-warning-option \
 # Overridable CXXFLAGS
 CXXFLAGS	?= -O3 -flto -DNDEBUG
 # Non-overridable CXXFLAGS
-REALCXXFLAGS	:= ${CXXFLAGS} ${WARNFLAGS} -std=c++2a -I include \
-		   -D_POSIX_C_SOURCE=200809L -fno-exceptions -fno-rtti
+REALCXXFLAGS	:= ${CXXFLAGS} ${WARNFLAGS} -std=c++2a -I include -fno-exceptions -fno-rtti
 # Overridable LDFLAGS
 LDFLAGS		?=
 # Non-overridable LDFLAGS


### PR DESCRIPTION
Fixes #1111, which was filed in December 2022, regarding building RGBDS v0.6.1 on OpenBSD 7.2. We're now up to RGBDS post-0.8.0 and OpenBSD 7.5. We've also switched from C entirely to C++. If this continues to build on the far-most-common CI targets of \*buntu Linux, Windows, and macOS, and this fixes it for OpenBSD, then I think we can safely get rid of defining `_POSIX_C_SOURCE=200809L`.

![image](https://github.com/user-attachments/assets/8c4ededb-0334-445b-b230-edf86d41d5b6)
