### PR TITLE
Use `setmode` instead of `fdopen`

### DIFF
--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -12,6 +12,7 @@
 
 #include "error.hpp"
 #include "helpers.hpp" // assume, Defer
+#include "platform.hpp"
 
 #include "asm/charmap.hpp"
 #include "asm/fstack.hpp"
@@ -311,7 +312,8 @@ void out_WriteObject() {
 		file = fopen(objectFileName.c_str(), "wb");
 	} else {
 		objectFileName = "<stdout>";
-		file = fdopen(STDOUT_FILENO, "wb");
+		(void)setmode(STDOUT_FILENO, O_BINARY);
+		file = stdout;
 	}
 	if (!file)
 		err("Failed to open object file '%s'", objectFileName.c_str());
@@ -503,7 +505,8 @@ void out_WriteState(std::string name, std::vector<StateFeature> const &features)
 		file = fopen(name.c_str(), "wb");
 	} else {
 		name = "<stdout>";
-		file = fdopen(STDOUT_FILENO, "wb");
+		(void)setmode(STDOUT_FILENO, O_BINARY);
+		file = stdout;
 	}
 	if (!file)
 		err("Failed to open state file '%s'", name.c_str());

--- a/src/fix/main.cpp
+++ b/src/fix/main.cpp
@@ -1160,9 +1160,9 @@ static bool processFilename(char const *name) {
 	nbErrors = 0;
 
 	if (!strcmp(name, "-")) {
+		name = "<stdin>";
 		(void)setmode(STDIN_FILENO, O_BINARY);
 		(void)setmode(STDOUT_FILENO, O_BINARY);
-		name = "<stdin>";
 		processFile(STDIN_FILENO, STDOUT_FILENO, name, 0);
 	} else {
 		// POSIX specifies that the results of O_RDWR on a FIFO are undefined.
@@ -1435,7 +1435,8 @@ int main(int argc, char *argv[]) {
 			logoFile = fopen(logoFilename, "rb");
 		} else {
 			logoFilename = "<stdin>";
-			logoFile = fdopen(STDIN_FILENO, "rb");
+			(void)setmode(STDIN_FILENO, O_BINARY);
+			logoFile = stdin;
 		}
 		if (!logoFile) {
 			fprintf(

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -490,7 +490,8 @@ void obj_ReadFile(char const *fileName, unsigned int fileID) {
 		file = fopen(fileName, "rb");
 	} else {
 		fileName = "<stdin>";
-		file = fdopen(STDIN_FILENO, "rb"); // `stdin` is in text mode by default
+		(void)setmode(STDIN_FILENO, O_BINARY);
+		file = stdin;
 	}
 	if (!file)
 		err("Failed to open file \"%s\"", fileName);

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -207,7 +207,8 @@ static void writeROM() {
 			outputFile = fopen(outputFileName, "wb");
 		} else {
 			outputFileName = "<stdout>";
-			outputFile = fdopen(STDOUT_FILENO, "wb");
+			(void)setmode(STDOUT_FILENO, O_BINARY);
+			outputFile = stdout;
 		}
 		if (!outputFile)
 			err("Failed to open output file \"%s\"", outputFileName);
@@ -222,7 +223,8 @@ static void writeROM() {
 			overlayFile = fopen(overlayFileName, "rb");
 		} else {
 			overlayFileName = "<stdin>";
-			overlayFile = fdopen(STDIN_FILENO, "rb");
+			(void)setmode(STDIN_FILENO, O_BINARY);
+			overlayFile = stdin;
 		}
 		if (!overlayFile)
 			err("Failed to open overlay file \"%s\"", overlayFileName);
@@ -545,7 +547,8 @@ static void writeSym() {
 		symFile = fopen(symFileName, "w");
 	} else {
 		symFileName = "<stdout>";
-		symFile = fdopen(STDOUT_FILENO, "w");
+		(void)setmode(STDOUT_FILENO, O_TEXT); // May have been set to O_BINARY previously
+		symFile = stdout;
 	}
 	if (!symFile)
 		err("Failed to open sym file \"%s\"", symFileName);
@@ -589,7 +592,8 @@ static void writeMap() {
 		mapFile = fopen(mapFileName, "w");
 	} else {
 		mapFileName = "<stdout>";
-		mapFile = fdopen(STDOUT_FILENO, "w");
+		(void)setmode(STDOUT_FILENO, O_TEXT); // May have been set to O_BINARY previously
+		mapFile = stdout;
 	}
 	if (!mapFile)
 		err("Failed to open map file \"%s\"", mapFileName);


### PR DESCRIPTION
Based on https://github.com/gbdev/rgbds/pull/1502#issuecomment-2358489367

I'll see if this fixes the build in OpenBSD.