### PR TITLE
Move definition of `_POSIX_C_SOURCE` to include/platform.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ else()
     # does not recognize this yet.
     add_compile_options(-Wno-gnu-zero-variadic-macro-arguments)
   endif()
-  add_definitions(-D_POSIX_C_SOURCE=200809L)
   if(SANITIZERS)
     set(SAN_FLAGS -fsanitize=shift -fsanitize=integer-divide-by-zero
                   -fsanitize=unreachable -fsanitize=vla-bound

--- a/Makefile
+++ b/Makefile
@@ -26,19 +26,16 @@ PNGLDLIBS	:= `${PKG_CONFIG} --libs-only-l libpng`
 # Note: if this comes up empty, `version.cpp` will automatically fall back to last release number
 VERSION_STRING	:= `git --git-dir=.git describe --tags --dirty --always 2>/dev/null`
 
-WARNFLAGS	:= -Wall -pedantic -Wno-unknown-warning-option \
-                   -Wno-gnu-zero-variadic-macro-arguments
+WARNFLAGS	:= -Wall -pedantic -Wno-unknown-warning-option -Wno-gnu-zero-variadic-macro-arguments
 
 # Overridable CXXFLAGS
 CXXFLAGS	?= -O3 -flto -DNDEBUG
 # Non-overridable CXXFLAGS
-REALCXXFLAGS	:= ${CXXFLAGS} ${WARNFLAGS} -std=c++2a -I include \
-		   -D_POSIX_C_SOURCE=200809L -fno-exceptions -fno-rtti
+REALCXXFLAGS	:= ${CXXFLAGS} ${WARNFLAGS} -std=c++2a -I include -fno-exceptions -fno-rtti
 # Overridable LDFLAGS
 LDFLAGS		?=
 # Non-overridable LDFLAGS
-REALLDFLAGS	:= ${LDFLAGS} ${WARNFLAGS} \
-		   -DBUILD_VERSION_STRING=\"${VERSION_STRING}\"
+REALLDFLAGS	:= ${LDFLAGS} ${WARNFLAGS} -DBUILD_VERSION_STRING=\"${VERSION_STRING}\"
 
 # Wrapper around bison that passes flags depending on what the version supports
 BISON		:= src/bison.sh

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -56,4 +56,9 @@
 	#define setmode(fd, mode) (0)
 #endif
 
+// MingGW and Cygwin need POSIX functions which are not standard C explicitly enabled
+#if defined(__MINGW32__) || defined(__MINGW32__) || defined(__CYGWIN__)
+	#define _POSIX_C_SOURCE 200809L
+#endif
+
 #endif // RGBDS_PLATFORM_HPP


### PR DESCRIPTION
Fixes #1111

This is how https://github.com/google/flatbuffers/pull/6205 and https://github.com/WebAssembly/wabt/pull/1360 dealt with the problem. (Defining `_POSIX_C_SOURCE` is required on some platforms, like Cygwin, and breaks others, like BSD. CMake makes platform detection easy, but POSIX Make does not, which leaves in-source definition.)

This works in OpenBSD 7.5, and in Cygwin on Windows! And as our CI proves, it works in MinGW! :)

![image](https://github.com/user-attachments/assets/329fa165-17be-4693-ac82-9cf78a395375)

![image](https://github.com/user-attachments/assets/34f03101-d7da-43fb-97b5-33d0e500598b)
