### PR TITLE
Refactoring and enhancements to RGBASM warnings

### DIFF
--- a/include/asm/warning.hpp
+++ b/include/asm/warning.hpp
@@ -5,8 +5,6 @@
 
 extern unsigned int nbErrors, maxErrors;
 
-enum WarningState { WARNING_DEFAULT, WARNING_DISABLED, WARNING_ENABLED, WARNING_ERROR };
-
 enum WarningID {
 	WARNING_ASSERT,               // Assertions
 	WARNING_BACKWARDS_FOR,        // `for` loop with backwards range
@@ -26,10 +24,9 @@ enum WarningID {
 
 	NB_PLAIN_WARNINGS,
 
-// Warnings past this point are "parametric" warnings, only mapping to a single flag
-#define PARAM_WARNINGS_START NB_PLAIN_WARNINGS
+	// Warnings past this point are "parametric" warnings, only mapping to a single flag
 	// Treating string as number may lose some bits
-	WARNING_NUMERIC_STRING_1 = PARAM_WARNINGS_START,
+	WARNING_NUMERIC_STRING_1 = NB_PLAIN_WARNINGS,
 	WARNING_NUMERIC_STRING_2,
 	// Purging an exported symbol or label
 	WARNING_PURGE_1,
@@ -41,20 +38,24 @@ enum WarningID {
 	WARNING_UNMAPPED_CHAR_1,
 	WARNING_UNMAPPED_CHAR_2,
 
-	NB_PLAIN_AND_PARAM_WARNINGS,
-#define NB_PARAM_WARNINGS (NB_PLAIN_AND_PARAM_WARNINGS - PARAM_WARNINGS_START)
-
-// Warnings past this point are "meta" warnings
-#define META_WARNINGS_START NB_PLAIN_AND_PARAM_WARNINGS
-	WARNING_ALL = META_WARNINGS_START,
-	WARNING_EXTRA,
-	WARNING_EVERYTHING,
-
 	NB_WARNINGS,
-#define NB_META_WARNINGS (NB_WARNINGS - META_WARNINGS_START)
 };
 
-extern WarningState warningStates[NB_PLAIN_AND_PARAM_WARNINGS];
+enum WarningAbled { WARNING_DEFAULT, WARNING_ENABLED, WARNING_DISABLED };
+
+struct WarningState {
+	WarningAbled state;
+	WarningAbled error;
+
+	void update(WarningState other);
+};
+
+struct Diagnostics {
+	WarningState flagStates[NB_WARNINGS];
+	WarningState metaStates[NB_WARNINGS];
+};
+
+extern Diagnostics warningStates;
 extern bool warningsAreErrors;
 
 void processWarningFlag(char const *flag);

--- a/man/rgbasm.1
+++ b/man/rgbasm.1
@@ -212,13 +212,19 @@ The following options alter the way warnings are processed.
 .Bl -tag -width Ds
 .It Fl Werror
 Make all warnings into errors.
+This can be negated as
+.Fl Wno-error
+to prevent turning all warnings into errors.
 .It Fl Werror=
-Make the specified warning into an error.
+Make the specified warning or meta warning into an error.
 A warning's name is appended
 .Pq example: Fl Werror=obsolete ,
 and this warning is implicitly enabled and turned into an error.
-This is an error if used with a meta warning, such as
-.Fl Werror=all .
+This can be negated as
+.Fl Wno-error=
+to prevent turning a specified warning into an error, even if
+.Fl Werror
+is in effect.
 .El
 .Pp
 The following warnings are
@@ -240,6 +246,10 @@ Note that each of these flag also has a negation (for example,
 .Fl Wcharmap-redef
 enables the warning that
 .Fl Wno-charmap-redef
+disables; and
+.Fl Wall
+enables every warning that
+.Fl Wno-all
 disables).
 Only the non-default flag is listed here.
 Ignoring the

--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -293,7 +293,7 @@ int main(int argc, char *argv[]) {
 			break;
 
 		case 'W':
-			processWarningFlag(musl_optarg);
+			opt_W(musl_optarg);
 			break;
 
 		case 'w':

--- a/src/asm/opt.cpp
+++ b/src/asm/opt.cpp
@@ -13,8 +13,6 @@
 #include "asm/section.hpp"
 #include "asm/warning.hpp"
 
-static constexpr size_t numWarningStates = sizeof(warningStates);
-
 struct OptStackEntry {
 	char binary[2];
 	char gbgfx[4];
@@ -22,7 +20,7 @@ struct OptStackEntry {
 	uint8_t fillByte;
 	bool warningsAreErrors;
 	size_t maxRecursionDepth;
-	WarningState warningStates[numWarningStates];
+	Diagnostics warningStates;
 };
 
 static std::stack<OptStackEntry> stack;
@@ -160,7 +158,7 @@ void opt_Push() {
 
 	// Both of these pulled from warning.hpp
 	entry.warningsAreErrors = warningsAreErrors;
-	memcpy(entry.warningStates, warningStates, numWarningStates);
+	entry.warningStates = warningStates;
 
 	entry.maxRecursionDepth = maxRecursionDepth; // Pulled from fstack.h
 
@@ -184,5 +182,5 @@ void opt_Pop() {
 
 	// opt_W does not apply a whole warning state; it processes one flag string
 	warningsAreErrors = entry.warningsAreErrors;
-	memcpy(warningStates, entry.warningStates, numWarningStates);
+	warningStates = entry.warningStates;
 }

--- a/src/asm/warning.cpp
+++ b/src/asm/warning.cpp
@@ -133,11 +133,11 @@ void processWarningFlag(char const *flag) {
 
 	// Check for `-Werror` or `-Wno-error` to return early
 	if (rootFlag == "error") {
-		// `-Werror` simply makes all warnings into errors
+		// `-Werror` promotes warnings to errors
 		warningsAreErrors = true;
 		return;
 	} else if (rootFlag == "no-error") {
-		// `-Wno-error` simply prevents all warnings from being errors
+		// `-Wno-error` disables promotion of warnings to errors
 		warningsAreErrors = false;
 		return;
 	}


### PR DESCRIPTION
Fixes #1527

* Allow a `no-` prefix to negate "meta" warnings (`-Wno-all`, `-Wno-extra`, `-Wno-everything`)
* Allow `-Wno-error` to prevent `-Werror` from making specific individual or meta warnings into errors

Needs more test cases, but ready to review as-is. (test/asm/warn-numeric-string.asm covers a lot already.)

(And yay, -55 LoC!)