### PR TITLE
Implement `0x/0o/0b` number prefixes

### DIFF
--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -272,12 +272,12 @@ further below.
 The instructions in the macro-language generally require constant expressions.
 .Ss Numeric formats
 There are a number of numeric formats.
-.Bl -column -offset indent "Precise fixed-point" "Prefix"
-.It Sy Format type Ta Sy Prefix Ta Sy Accepted characters
+.Bl -column -offset indent "Precise fixed-point" "Possible prefixes"
+.It Sy Format type Ta Sy Possible prefixes Ta Sy Accepted characters
 .It Decimal Ta none Ta 0123456789
-.It Hexadecimal Ta Li $ 0x 0X Ta 0123456789ABCDEF
-.It Octal Ta Li & 0o 0O Ta 01234567
-.It Binary Ta Li % 0b 0B Ta 01
+.It Hexadecimal Ta Li $ , 0x , 0X Ta 0123456789ABCDEF
+.It Octal Ta Li & , 0o , 0O Ta 01234567
+.It Binary Ta Li % , 0b , 0B Ta 01
 .It Fixed-point Ta none Ta 01234.56789
 .It Precise fixed-point Ta none Ta 12.34q8
 .It Character constant Ta none Ta \(dqABYZ\(dq

--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -274,14 +274,14 @@ The instructions in the macro-language generally require constant expressions.
 There are a number of numeric formats.
 .Bl -column -offset indent "Precise fixed-point" "Prefix"
 .It Sy Format type Ta Sy Prefix Ta Sy Accepted characters
-.It Hexadecimal Ta $ Ta 0123456789ABCDEF
 .It Decimal Ta none Ta 0123456789
-.It Octal Ta & Ta 01234567
-.It Binary Ta % Ta 01
+.It Hexadecimal Ta Li $ 0x 0X Ta 0123456789ABCDEF
+.It Octal Ta Li & 0o 0O Ta 01234567
+.It Binary Ta Li % 0b 0B Ta 01
 .It Fixed-point Ta none Ta 01234.56789
 .It Precise fixed-point Ta none Ta 12.34q8
 .It Character constant Ta none Ta \(dqABYZ\(dq
-.It Game Boy graphics Ta \` Ta 0123
+.It Game Boy graphics Ta Li \` Ta 0123
 .El
 .Pp
 Underscores are also accepted in numbers, except at the beginning of one.

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -1733,7 +1733,25 @@ static Token yylex_NORMAL() {
 
 			// Handle numbers
 
-		case '0': // Decimal or fixed-point number
+		case '0': // Decimal, fixed-point, or base-prefix number
+			switch (peek()) {
+			case 'x':
+			case 'X':
+				shiftChar();
+				return Token(T_(NUMBER), readHexNumber());
+			case 'o':
+			case 'O':
+				shiftChar();
+				return Token(T_(NUMBER), readNumber(8, 0));
+			case 'b':
+			case 'B':
+				shiftChar();
+				return Token(T_(NUMBER), readBinaryNumber());
+			}
+			[[fallthrough]];
+
+			// Decimal or fixed-point number
+
 		case '1':
 		case '2':
 		case '3':

--- a/test/asm/number-prefixes.asm
+++ b/test/asm/number-prefixes.asm
@@ -1,0 +1,16 @@
+MACRO test
+	assert (\1) == (\2)
+ENDM
+
+test 0xDEADbeef, $DEADbeef
+test 0o755, &755
+test 0b101010, %101010
+
+test 0XcafeBABE, $cafeBABE
+test 0O644, &644
+test 0B11100100, %11100100
+
+pusho b.X
+test 0b.X.X, %.X.X
+test 0BX.X., %X.X.
+popo


### PR DESCRIPTION
This may help with code-generation compatibility. Also there have been occasions when I pasted a hex number from C or Python into RGBASM and then had to correct the base prefix from `0x` to `$`; this would avoid that.