### PR TITLE
`LOAD FRAGMENT` is not allowed

### DIFF
--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -953,9 +953,9 @@ blocks, nor can you change or stop the current section within them.
 .Ic LOAD
 blocks can use the
 .Ic UNION
-or
+modifier as described below, but not the
 .Ic FRAGMENT
-modifiers, as described below.
+modifier.
 .Ss Unionized sections
 When you're tight on RAM, you may want to define overlapping static memory allocations, as explained in the
 .Sx Unions


### PR DESCRIPTION
Fixes #1535

This just corrects the docs to match the existing behavior. #1537 may eventually lead to bring support back, but for now the docs ought to be accurate.