### PR TITLE
Make tests work with CTest

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,9 +33,7 @@ jobs:
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DSANITIZERS=ON -DMORE_WARNINGS=ON
           cmake --build build -j --verbose
-          cp build/src/rgb{asm,link,fix,gfx} .
           sudo cmake --install build --verbose
-          cmake --install build --verbose --component "Test support programs"
       - name: Package binaries
         run: |
           mkdir bins
@@ -175,7 +173,6 @@ jobs:
           cmake -S . -B build -A ${{ matrix.platform }} -DCMAKE_INSTALL_PREFIX=install_dir -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release -j --verbose
           cmake --install build --verbose --prefix install_dir
-          cmake --install build --verbose --component "Test support programs"
       - name: Package binaries
         shell: bash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@
 CMakeCache.txt
 CMakeFiles/
 cmake_install.cmake
+build/
 callgrind.out.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: MIT
 
 # 3.9 required for LTO checks
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+# 3.17 optional for CMAKE_CTEST_ARGUMENTS
+cmake_minimum_required(VERSION 3.9..3.17 FATAL_ERROR)
 
 project(rgbds
         LANGUAGES CXX)
+
+include(CTest)
 
 # get real path of source and binary directories
 get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
@@ -87,6 +90,8 @@ endif(GIT)
 find_package(PkgConfig)
 if(MSVC OR NOT PKG_CONFIG_FOUND)
   # fallback to find_package
+  # cmake's FindPNG is very fragile; it breaks when multiple versions are installed
+  # this is most evident on macOS but can occur on Linux too
   find_package(PNG REQUIRED)
 else()
   pkg_check_modules(LIBPNG REQUIRED libpng)
@@ -98,6 +103,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_subdirectory(src)
+set(CMAKE_CTEST_ARGUMENTS "--verbose")
 add_subdirectory(test)
 
 # By default, build in Release mode; Debug mode must be explicitly requested

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,10 +91,11 @@ foreach(PROG "asm" "fix" "gfx" "link")
                  ${rgb${PROG}_src}
                  ${common_src}
                  )
-  if(SUFFIX)
-    set_target_properties(rgb${PROG} PROPERTIES SUFFIX ${SUFFIX})
-  endif()
   install(TARGETS rgb${PROG} RUNTIME DESTINATION bin)
+  # Required to run tests
+  set_target_properties(rgb${PROG} PROPERTIES
+  # hack for MSVC: no-op generator expression to stop generation of "per-configuration subdirectory"
+                        RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}>)
 endforeach()
 
 if(LIBPNG_FOUND) # pkg-config

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,18 @@
 # SPDX-License-Identifier: MIT
 
+OPTION(USE_NONFREE_TESTS "run tests that build nonfree codebases" ON)
+
+if(NOT USE_NONFREE_TESTS)
+  set(ONLY_FREE "--only-free")
+endif()
+
 add_executable(randtilegen gfx/randtilegen.cpp)
 add_executable(rgbgfx_test gfx/rgbgfx_test.cpp)
+set_target_properties(randtilegen rgbgfx_test PROPERTIES
+# hack for MSVC: no-op generator expression to stop generation of "per-configuration subdirectory"
+                      RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_SOURCE_DIR}/gfx>)
 
-install(TARGETS randtilegen rgbgfx_test
-        DESTINATION ${rgbds_SOURCE_DIR}/test/gfx
-        COMPONENT "Test support programs"
-        EXCLUDE_FROM_ALL
-        )
+configure_file(CTestCustom.cmake.in ${CMAKE_BINARY_DIR}/CTestCustom.cmake)
 
 foreach(TARGET randtilegen rgbgfx_test)
   if(LIBPNG_FOUND) # pkg-config
@@ -20,3 +25,8 @@ foreach(TARGET randtilegen rgbgfx_test)
     target_link_libraries(${TARGET} PRIVATE ${PNG_LIBRARIES})
   endif()
 endforeach()
+
+add_test(NAME all
+         COMMAND ./run-tests.sh ${ONLY_FREE}
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/test/CTestCustom.cmake.in
+++ b/test/CTestCustom.cmake.in
@@ -1,0 +1,1 @@
+set(CTEST_CUSTOM_PRE_TEST "bash -c 'cd @CMAKE_CURRENT_SOURCE_DIR@\; ./fetch-test-deps.sh @ONLY_FREE@'")


### PR DESCRIPTION
tests expect rgb{asm,link,fix,gfx} to be in ./

add CTestCustom.cmake to pull in dependencies

add option to disable non-free tests

Switch find_package conditions to explicitly state that it's broken on MacOS, and use pkg-config there only.