### PR TITLE
Don't use pkg-config for libpng with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,13 +84,7 @@ else(GIT)
   message(STATUS "Cannot determine RGBDS version (Git not installed), falling back")
 endif(GIT)
 
-find_package(PkgConfig)
-if(MSVC OR NOT PKG_CONFIG_FOUND)
-  # fallback to find_package
-  find_package(PNG REQUIRED)
-else()
-  pkg_check_modules(LIBPNG REQUIRED libpng)
-endif()
+find_package(PNG REQUIRED)
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,15 +97,9 @@ foreach(PROG "asm" "fix" "gfx" "link")
   install(TARGETS rgb${PROG} RUNTIME DESTINATION bin)
 endforeach()
 
-if(LIBPNG_FOUND) # pkg-config
-  target_include_directories(rgbgfx PRIVATE ${LIBPNG_INCLUDE_DIRS})
-  target_link_directories(rgbgfx PRIVATE ${LIBPNG_LIBRARY_DIRS})
-  target_link_libraries(rgbgfx PRIVATE ${LIBPNG_LIBRARIES})
-else()
-  target_compile_definitions(rgbgfx PRIVATE ${PNG_DEFINITIONS})
-  target_include_directories(rgbgfx PRIVATE ${PNG_INCLUDE_DIRS})
-  target_link_libraries(rgbgfx PRIVATE ${PNG_LIBRARIES})
-endif()
+target_compile_definitions(rgbgfx PRIVATE ${PNG_DEFINITIONS})
+target_include_directories(rgbgfx PRIVATE ${PNG_INCLUDE_DIRS})
+target_link_libraries(rgbgfx PRIVATE ${PNG_LIBRARIES})
 
 include(CheckLibraryExists)
 check_library_exists("m" "sin" "" HAS_LIBM)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,13 +10,7 @@ install(TARGETS randtilegen rgbgfx_test
         )
 
 foreach(TARGET randtilegen rgbgfx_test)
-  if(LIBPNG_FOUND) # pkg-config
-    target_include_directories(${TARGET} PRIVATE ${LIBPNG_INCLUDE_DIRS})
-    target_link_directories(${TARGET} PRIVATE ${LIBPNG_LIBRARY_DIRS})
-    target_link_libraries(${TARGET} PRIVATE ${LIBPNG_LIBRARIES})
-  else()
-    target_compile_definitions(${TARGET} PRIVATE ${PNG_DEFINITIONS})
-    target_include_directories(${TARGET} PRIVATE ${PNG_INCLUDE_DIRS})
-    target_link_libraries(${TARGET} PRIVATE ${PNG_LIBRARIES})
-  endif()
+  target_compile_definitions(${TARGET} PRIVATE ${PNG_DEFINITIONS})
+  target_include_directories(${TARGET} PRIVATE ${PNG_INCLUDE_DIRS})
+  target_link_libraries(${TARGET} PRIVATE ${PNG_LIBRARIES})
 endforeach()


### PR DESCRIPTION
This may have only been added in the first place for 1-to-1 compatibility with the Makefile.

Split off from #1539 (@JL2210 please confirm this is OK?)