### PR TITLE
Fix detection of tiles with too many colors

### DIFF
--- a/include/gfx/proto_palette.hpp
+++ b/include/gfx/proto_palette.hpp
@@ -18,12 +18,8 @@ private:
 	std::array<uint16_t, capacity> _colorIndices{UINT16_MAX, UINT16_MAX, UINT16_MAX, UINT16_MAX};
 
 public:
-	/*
-	 * Adds the specified color to the set, or **silently drops it** if the set is full.
-	 *
-	 * Returns whether the color was unique.
-	 */
-	bool add(uint16_t color);
+	// Adds the specified color to the set, or **silently drops it** if the set is full.
+	void add(uint16_t color);
 
 	enum ComparisonResult {
 		NEITHER,

--- a/src/gfx/proto_palette.cpp
+++ b/src/gfx/proto_palette.cpp
@@ -6,7 +6,7 @@
 
 #include "helpers.hpp"
 
-bool ProtoPalette::add(uint16_t color) {
+void ProtoPalette::add(uint16_t color) {
 	size_t i = 0;
 
 	// Seek the first slot greater than the new color
@@ -16,12 +16,12 @@ bool ProtoPalette::add(uint16_t color) {
 		++i;
 		if (i == _colorIndices.size()) {
 			// We reached the end of the array without finding the color, so it's a new one.
-			return true;
+			return;
 		}
 	}
 	// If we found it, great! Nothing else to do.
 	if (_colorIndices[i] == color) {
-		return false;
+		return;
 	}
 
 	// Swap entries until the end
@@ -30,12 +30,11 @@ bool ProtoPalette::add(uint16_t color) {
 		++i;
 		if (i == _colorIndices.size()) {
 			// The set is full, but doesn't include the new color.
-			return true;
+			return;
 		}
 	}
 	// Write that last one into the new slot
 	_colorIndices[i] = color;
-	return true;
 }
 
 ProtoPalette::ComparisonResult ProtoPalette::compare(ProtoPalette const &other) const {


### PR DESCRIPTION
This fixes the initial observation in #1531 ("RGBGFX somehow thinks a 5-color tile has 13 colors") but does not fix the actual bug (which trips up the `index < palette.size()` assertion).