### PR TITLE
Errors may occur at the first token of a line

### DIFF
--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -404,6 +404,14 @@ asm_file: lines;
 lines:
 	  %empty
 	| lines diff_mark line
+	// Continue parsing the next line on a syntax error
+	| error {
+		lexer_SetMode(LEXER_NORMAL);
+		lexer_ToggleStringExpansion(true);
+	} endofline {
+		fstk_StopRept();
+		yyerrok;
+	}
 ;
 
 diff_mark:
@@ -425,14 +433,6 @@ diff_mark:
 line:
 	  plain_directive endofline
 	| line_directive // Directives that manage newlines themselves
-	// Continue parsing the next line on a syntax error
-	| error {
-		lexer_SetMode(LEXER_NORMAL);
-		lexer_ToggleStringExpansion(true);
-	} endofline {
-		fstk_StopRept();
-		yyerrok;
-	}
 ;
 
 endofline: NEWLINE | EOB;

--- a/test/asm/macro-syntax.err
+++ b/test/asm/macro-syntax.err
@@ -6,4 +6,6 @@ error: macro-syntax.asm(8):
     '\1' cannot be used outside of a macro
 error: macro-syntax.asm(9):
     syntax error, unexpected ENDM
-error: Assembly aborted (4 errors)!
+error: macro-syntax.asm(11):
+    "old" is not a macro
+error: Assembly aborted (5 errors)!

--- a/test/asm/skip-expansions.asm
+++ b/test/asm/skip-expansions.asm
@@ -28,4 +28,4 @@ ENDM
 	mac2 elif, 6 * 7  ; this prints "it's $2A" because it skips the `\1` line and takes the `else`
 	mac2 elif, 6 * 9
 	mac2 elif
-	mac2
+	mac2 ; this prints "args:" *and* "forty-two!" since it doesn't create an `elif`

--- a/test/asm/skip-expansions.err
+++ b/test/asm/skip-expansions.err
@@ -2,4 +2,6 @@ error: skip-expansions.asm(31) -> skip-expansions.asm::mac2(21):
     Macro argument '\1' not defined
 error: skip-expansions.asm(31) -> skip-expansions.asm::mac2(21):
     syntax error, unexpected (
-error: Assembly aborted (2 errors)!
+error: skip-expansions.asm(31) -> skip-expansions.asm::mac2(21):
+    Macro argument '\2' not defined
+error: Assembly aborted (3 errors)!

--- a/test/asm/skip-expansions.out
+++ b/test/asm/skip-expansions.out
@@ -6,3 +6,4 @@ it's $2A
 it's $36
 args: elif
 args: 
+forty-two!


### PR DESCRIPTION
This isn't the first time we've had pre-existing test cases which should have made us aware of a bug if we'd really thought about their output. :P