### PR TITLE
Escape characters in section names in map files

### DIFF
--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -452,17 +452,10 @@ static void writeMapBank(SortedSections const &sectList, SectionType type, uint3
 
 		prevEndAddr = sect->org + sect->size;
 
+		fprintf(mapFile, "\tSECTION: $%04" PRIx16, sect->org);
 		if (sect->size != 0)
-			fprintf(
-			    mapFile,
-			    "\tSECTION: $%04" PRIx16 "-$%04x ($%04" PRIx16 " byte%s) [\"",
-			    sect->org,
-			    prevEndAddr - 1,
-			    sect->size,
-			    sect->size == 1 ? "" : "s"
-			);
-		else
-			fprintf(mapFile, "\tSECTION: $%04" PRIx16 " (0 bytes) [\"", sect->org);
+			fprintf(mapFile, "-$%04x", prevEndAddr - 1);
+		fprintf(mapFile, " ($%04" PRIx16 " byte%s) [\"", sect->size, sect->size == 1 ? "" : "s");
 		printSectionName(sect->name, mapFile);
 		fputs("\"]\n", mapFile);
 

--- a/test/link/map-file/a.asm
+++ b/test/link/map-file/a.asm
@@ -25,3 +25,5 @@ wLabel1:: ds 6
 SECTION "hram", HRAM
 hLabel:: ds 7
 .local::
+
+SECTION "\n\r\t\"\\", ROM0[1]

--- a/test/link/map-file/ref.out.map
+++ b/test/link/map-file/ref.out.map
@@ -10,6 +10,7 @@ ROM0 bank #0:
 	SECTION: $0000-$0000 ($0001 byte) ["rom0"]
 	         $0000 = Label0
 	         $0001 = Label0.local
+	SECTION: $0001 ($0000 bytes) ["\n\r\t\"\\"]
 	EMPTY: $0001-$3fff ($3fff bytes)
 	TOTAL EMPTY: $3fff bytes
 


### PR DESCRIPTION
With the second commit here, this slightly changes .map file output: a zero-byte section is printed as "`($0000 bytes)`", instead of "`(0 bytes)`". This is more consistent with other "`($xxxx bytes)`" sections, and with the sizes of `EMPTY` space.