### PR TITLE
Deprecate `LD` with `[C]`

### DIFF
--- a/man/rgbasm-old.5
+++ b/man/rgbasm-old.5
@@ -260,6 +260,13 @@ Deprecated in 0.9.0.
 .Pp
 Instead, use
 .Ql LDH .
+.Ss LD [C], A and LD A, [C]
+Deprecated in 0.9.0.
+.Pp
+Instead, use
+.Ql LDH [C], A
+and
+.Ql LDH A, [C] .
 .Ss rgbasm -i
 Deprecated in 0.6.0, removed in 0.8.0.
 .Pp

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -2022,6 +2022,7 @@ z80_ld_mem:
 
 z80_ld_c_ind:
 	Z80_LD c_ind COMMA MODE_A {
+		warning(WARNING_OBSOLETE, "LD [C], A is deprecated; use LDH [C], A\n");
 		sect_ConstByte(0xE2);
 	}
 ;
@@ -2054,6 +2055,7 @@ z80_ld_a:
 		sect_ConstByte(0x40 | ($2 << 3) | $4);
 	}
 	| Z80_LD reg_a COMMA c_ind {
+		warning(WARNING_OBSOLETE, "LD A, [C] is deprecated; use LDH A, [C]\n");
 		sect_ConstByte(0xF2);
 	}
 	| Z80_LD reg_a COMMA reg_rr {

--- a/test/asm/deprecated-ldio.err
+++ b/test/asm/deprecated-ldio.err
@@ -1,3 +1,7 @@
+warning: deprecated-ldio.asm(8): [-Wobsolete]
+    LD [C], A is deprecated; use LDH [C], A
+warning: deprecated-ldio.asm(9): [-Wobsolete]
+    LD A, [C] is deprecated; use LDH A, [C]
 warning: deprecated-ldio.asm(13): [-Wobsolete]
     LDIO is deprecated; use LDH
 warning: deprecated-ldio.asm(14): [-Wobsolete]
@@ -6,6 +10,10 @@ warning: deprecated-ldio.asm(15): [-Wobsolete]
     LDIO is deprecated; use LDH
 warning: deprecated-ldio.asm(16): [-Wobsolete]
     LDIO is deprecated; use LDH
+warning: deprecated-ldio.asm(23): [-Wobsolete]
+    LD [C], A is deprecated; use LDH [C], A
+warning: deprecated-ldio.asm(24): [-Wobsolete]
+    LD A, [C] is deprecated; use LDH A, [C]
 warning: deprecated-ldio.asm(28): [-Wobsolete]
     LDIO is deprecated; use LDH
 warning: deprecated-ldio.asm(29): [-Wobsolete]

--- a/test/asm/ff00+c-bad.asm
+++ b/test/asm/ff00+c-bad.asm
@@ -1,9 +1,9 @@
 
 SECTION "ff00+c or not to ff00+c", ROMX
 
-	ld a, [$ff00 + c]
-	ld [65280 + c], a
+	ldh a, [$ff00 + c]
+	ldh [65280 + c], a
 
 	; Not ok
-	ld a, [$ff01 + c]
-	ld [xyz + c], a
+	ldh a, [$ff01 + c]
+	ldh [xyz + c], a

--- a/test/asm/ff00+c.asm
+++ b/test/asm/ff00+c.asm
@@ -1,5 +1,5 @@
 SECTION "test", ROM0[0]
-	ld [ $ff00 + c ], a
+	ldh [ $ff00 + c ], a
 	; 257 spaces exceeds both LEXER_BUF_SIZE (42) and uint8_t limit (255)
-	ld [ $ff00 +                                                                                                                                                                                                                                                                 c ], a
-	ld [ $ff00                                                                                                                                                                                                                                                                 + c ], a
+	ldh [ $ff00 +                                                                                                                                                                                                                                                                 c ], a
+	ldh [ $ff00                                                                                                                                                                                                                                                                 + c ], a

--- a/test/asm/invalid-instructions.asm
+++ b/test/asm/invalid-instructions.asm
@@ -1,6 +1,6 @@
 SECTION "invalid", ROM0[$10000]
 	ld [hl], [hl]
-	ld a, [$00ff+c]
+	ldh a, [$00ff+c]
 	ld b, [c]
 	ld b, [bc]
 	ld b, [$4000]

--- a/test/link/all-instructions.asm
+++ b/test/link/all-instructions.asm
@@ -154,8 +154,8 @@ ENDM
     ld  [hl],a
     ld  [$ABCD],a
     ldh [$ff00+$DB],a
-    ld  [$ff00+c],a
-    ld  [$ff00 + c],a
+    ldh [$ff00+c],a
+    ldh [$ff00 + c],a
     ldh [c],a
 
     ld  a,[bc]
@@ -163,8 +163,8 @@ ENDM
     ld  a,[hl]
     ld  a,[$ABCD]
     ldh a,[$ff00+$DB]
-    ld  a,[$ff00+c]
-    ld  a,[$ff00 + c]
+    ldh a,[$ff00+c]
+    ldh a,[$ff00 + c]
     ldh a,[c]
 
     ld  [hl+],a


### PR DESCRIPTION
Fixes #1573

Be sure to update the [gbdev.io opcode table](https://gbdev.io/gb-opcodes/optables/classic) after this.