### PR TITLE
Deduplicating tiles without an input or output tileset should be OK

### DIFF
--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -999,10 +999,11 @@ static UniqueTiles dedupTiles(
 		}
 	}
 
+	bool inputWithoutOutput = !options.inputTileset.empty() && options.output.empty();
 	for (auto [tile, attr] : zip(png.visitAsTiles(), attrmap)) {
 		auto [tileID, matchType] = tiles.addTile({tile, palettes[mappings[attr.protoPaletteID]]});
 
-		if (matchType == TileData::NOPE && options.output.empty()) {
+		if (inputWithoutOutput && matchType == TileData::NOPE) {
 			error(
 			    "Tile at (%" PRIu32 ", %" PRIu32
 			    ") is not within the input tileset, and `-o` was not given!",


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/303217943234215948/790920525253836912/1322390021608701952).

`rgbgfx -u -t foo.tilemap foo.png` has no output tileset and no input tileset, but nevertheless complains that each tile "is not within the input tileset, and `-o` was not given!"

I *think* the desired fix is to only make that check if an input tileset was given.