### PR TITLE
Fix RGBFIX writing bytes when one syscall is not sufficient

### DIFF
--- a/src/fix/main.cpp
+++ b/src/fix/main.cpp
@@ -805,13 +805,11 @@ static ssize_t writeBytes(int fd, uint8_t *buf, size_t len) {
 
 		if (ret == -1 && errno != EINTR) // Return errors, unless we only were interrupted
 			return -1;
-		// EOF reached
-		if (ret == 0)
-			return total;
-		// If anything was read, accumulate it, and continue
+		// If anything was written, accumulate it, and continue
 		if (ret != -1) {
 			total += ret;
 			len -= ret;
+			buf += ret;
 		}
 	}
 


### PR DESCRIPTION
This does not yet fix #1580. However, I think it's a correct change anyway -- `writeBytes` *should* be advancing `buf` when it partially writes, correct? (And unlike `read`, a 0 return value has nothing to do with EOF.)