### PR TITLE
Run gcc static analysis in CI

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,0 +1,18 @@
+name: Static analysis
+on:
+  - push
+  - pull_request
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Install deps
+        shell: bash
+        run: |
+          ./.github/scripts/install_deps.sh ubuntu-latest
+      - name: Static analysis
+        run: | # Silence warnings with too many false positives (https://stackoverflow.com/a/73913076)
+          make -kj CXX=g++-14 CXXFLAGS="-fanalyzer -fanalyzer-verbosity=0 -Wno-analyzer-use-of-uninitialized-value -DNDEBUG" Q=


### PR DESCRIPTION
Fixes #970

When I built with `-fanalyzer` locally, with g++ 11, I got a `analyzer-malloc-leak` warning about `static std::vector<std::string> includePaths = {""};` in src/asm/fstack.cpp. That warning does not occur in CI here with g++ 14.

On the other hand, CI's g++ 14 gave a lot of [false positive](https://stackoverflow.com/a/73913076) `analyzer-use-of-uninitialized-value` warnings, which I think are because it's not strictly meant for use with C++ yet. (Even [the gcc 14.2 docs](https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Static-Analyzer-Options.html) say "The analyzer is only suitable for use on C code in this release.")

Silencing that type of warning results in no static analyzer warnings in CI. And even if there are warnings, it doesn't cause the build to fail -- it's just a resource we can check, like `checkdiff`. So I *think* this is okay to merge.

(If it's *not* okay to merge, maybe we should close the issue anyway, on the grounds that it no longer applies since we migrated to C++.)