### PR TITLE
Enable more sanitizers in `make develop`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -54,7 +54,7 @@ IncludeCategories:
 IndentAccessModifiers: false
 IndentCaseBlocks: false
 IndentCaseLabels: false
-IndentExternBlock: NoIndent
+IndentExternBlock: Indent
 IndentGotoLabels: false
 IndentPPDirectives: BeforeHash
 IndentRequires: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,8 @@ else()
     add_compile_options(-Wno-gnu-zero-variadic-macro-arguments)
   endif()
   if(SANITIZERS)
-    set(SAN_FLAGS -fsanitize=shift -fsanitize=integer-divide-by-zero
-                  -fsanitize=unreachable -fsanitize=vla-bound
-                  -fsanitize=signed-integer-overflow -fsanitize=bounds
-                  -fsanitize=object-size -fsanitize=bool -fsanitize=enum
-                  -fsanitize=alignment -fsanitize=null -fsanitize=address)
+    set(SAN_FLAGS -fsanitize=address -fsanitize=undefined
+                  -fsanitize=float-divide-by-zero)
     add_compile_options(${SAN_FLAGS})
     add_link_options(${SAN_FLAGS})
     add_definitions(-D_GLIBCXX_ASSERTIONS)

--- a/Makefile
+++ b/Makefile
@@ -206,12 +206,8 @@ develop:
 		-Wformat=2 -Wformat-overflow=2 -Wformat-truncation=1 \
 		-Wno-format-nonliteral -Wno-strict-overflow -Wno-unused-but-set-variable \
 		-Wno-type-limits -Wno-tautological-constant-out-of-range-compare -Wvla \
-		-D_GLIBCXX_ASSERTIONS \
-		-fsanitize=shift -fsanitize=integer-divide-by-zero \
-		-fsanitize=unreachable -fsanitize=vla-bound \
-		-fsanitize=signed-integer-overflow -fsanitize=bounds \
-		-fsanitize=object-size -fsanitize=bool -fsanitize=enum \
-		-fsanitize=alignment -fsanitize=null -fsanitize=address" \
+		-D_GLIBCXX_ASSERTIONS -fsanitize=address -fsanitize=undefined \
+		-fsanitize=float-divide-by-zero" \
 		CXXFLAGS="-ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls"
 
 # This target is used during development in order to more easily debug with gdb.

--- a/src/asm/fixpoint.cpp
+++ b/src/asm/fixpoint.cpp
@@ -73,7 +73,11 @@ int32_t fix_Mul(int32_t i, int32_t j, int32_t q) {
 }
 
 int32_t fix_Div(int32_t i, int32_t j, int32_t q) {
-	return double2fix(fix2double(i, q) / fix2double(j, q), q);
+	double dividend = fix2double(i, q);
+	double divisor = fix2double(j, q);
+	if (fpclassify(divisor) == FP_ZERO)
+		return dividend < 0 ? INT32_MIN : dividend > 0 ? INT32_MAX : 0;
+	return double2fix(dividend / divisor, q);
 }
 
 int32_t fix_Mod(int32_t i, int32_t j, int32_t q) {
@@ -85,7 +89,10 @@ int32_t fix_Pow(int32_t i, int32_t j, int32_t q) {
 }
 
 int32_t fix_Log(int32_t i, int32_t j, int32_t q) {
-	return double2fix(log(fix2double(i, q)) / log(fix2double(j, q)), q);
+	double divisor = log(fix2double(j, q));
+	if (fpclassify(divisor) == FP_ZERO)
+		return INT32_MAX;
+	return double2fix(log(fix2double(i, q)) / divisor, q);
 }
 
 int32_t fix_Round(int32_t i, int32_t q) {

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -6,6 +6,21 @@
 
 #include "helpers.hpp"
 
+// We do not build `make develop` with `-fsanitize=leak` because macOS clang++ does not support it.
+// Instead, we enable ASan (`-fsanitize=address`) to check for memory leaks in all four programs.
+#ifdef __clang__
+	#if __has_feature(address_sanitizer) && !defined(__SANITIZE_ADDRESS__)
+		#define __SANITIZE_ADDRESS__
+	#endif
+#endif
+#if defined(__SANITIZE_ADDRESS__) && !defined(__APPLE__)
+extern "C" {
+	char const *__asan_default_options(void) {
+		return "detect_leaks=1";
+	}
+}
+#endif
+
 // This variable is passed via `-D` from the Makefile, but not from CMake
 // (in which `configure_file()` is used on this file to replace some syntax)
 #ifndef BUILD_VERSION_STRING

--- a/test/asm/math.asm
+++ b/test/asm/math.asm
@@ -37,6 +37,9 @@ ENDM
 
 	assert LOG(100.0, 10.0) == 2.0
 	assert LOG(256.0, 2.0) == 8.0
+	assert LOG(10.0, 1.0) == $7fff_ffff ; +inf
+	assert LOG(0.0, 2.71828) == $8000_0000 ; -inf
+	assert LOG(-1.0, 2.71828) == 0 ; nan
 
 	assert ROUND(1.5) == 2.0
 	assert ROUND(-1.5) == -2.0


### PR DESCRIPTION
- `-fsanitize=undefined` encompasses multiple checks we were specifying
- `"detect_leaks=1"` for `__asan_default_options` checks for memory leaks (except for with macOS clang++, which does not support LSan)
- `-fsanitize=float-divide-by-zero` is an extra UBSan check (and reveals a UB bug to fix with fixed-point `DIV` and `LOG`)