### PR TITLE
Include <signal.h> in rgbgfx_test.cpp

### DIFF
--- a/test/gfx/rgbgfx_test.cpp
+++ b/test/gfx/rgbgfx_test.cpp
@@ -5,6 +5,7 @@
 	#include <sys/stat.h>
 	#include <sys/wait.h>
 
+	#include <signal.h>
 	#include <spawn.h>
 	#include <unistd.h>
 #else


### PR DESCRIPTION
This is apparently necessary for [BSD](https://cgit.freebsd.org/ports/tree/devel/rgbds/files/patch-test_gfx_rgbgfx__test.cpp), and harmless for Linux. (It already gets `pid_t` from some other header, but POSIX has it in signal.h.)

@nunotexbsd This should mean that in 0.9.1 you can remove that patch file. :)