### PR TITLE
Implement warning for unused macro args

### DIFF
--- a/include/asm/macro.hpp
+++ b/include/asm/macro.hpp
@@ -6,18 +6,21 @@
 #include <memory>
 #include <stdint.h>
 #include <string>
+#include <utility>
 #include <vector>
 
 struct MacroArgs {
 	unsigned int shift;
-	std::vector<std::shared_ptr<std::string>> args;
+	std::vector<std::pair<std::shared_ptr<std::string>, bool>> args;
 
 	uint32_t nbArgs() const { return args.size() - shift; }
-	std::shared_ptr<std::string> getArg(uint32_t i) const;
-	std::shared_ptr<std::string> getAllArgs() const;
+	std::shared_ptr<std::string> getArg(uint32_t i);
+	std::shared_ptr<std::string> getAllArgs();
 
 	void appendArg(std::shared_ptr<std::string> arg);
 	void shiftArgs(int32_t count);
+
+	void checkUsedArgs() const;
 };
 
 #endif // RGBDS_ASM_MACRO_HPP

--- a/include/asm/warning.hpp
+++ b/include/asm/warning.hpp
@@ -22,6 +22,7 @@ enum WarningID {
 	WARNING_SHIFT_AMOUNT,         // Strange `SHIFT` amount
 	WARNING_UNMATCHED_DIRECTIVE,  // `PUSH[C|O|S]` without `POP[C|O|S]`
 	WARNING_UNTERMINATED_LOAD,    // `LOAD` without `ENDL`
+	WARNING_UNUSED_MACRO_ARG,     // Unused macro argument
 	WARNING_USER,                 // User-defined `WARN`ings
 
 	NB_PLAIN_WARNINGS,

--- a/man/rgbasm.1
+++ b/man/rgbasm.1
@@ -381,6 +381,10 @@ or
 .Ic POPS .
 This warning is enabled by
 .Fl Wextra .
+.It Fl Wunused-macro-arg
+Warn when an argument passed to a macro invocation is not used.
+This warning is enabled by
+.Fl Wall .
 .It Fl Wunterminated-load
 Warn when a
 .Ic LOAD

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -188,8 +188,13 @@ bool yywrap() {
 			context.uniqueIDStr->clear(); // Invalidate the current unique ID (if any).
 			return false;
 		}
-	} else if (contextStack.size() == 1) {
-		return true;
+	} else {
+		// If the context is a MACRO body, warn about unused arguments
+		if (context.fileInfo->type == NODE_MACRO && context.macroArgs)
+			context.macroArgs->checkUsedArgs();
+		// Do not pop the very top of the context stack
+		if (contextStack.size() == 1)
+			return true;
 	}
 
 	contextStack.pop();

--- a/src/asm/macro.cpp
+++ b/src/asm/macro.cpp
@@ -12,13 +12,18 @@
 
 #define MAXMACROARGS 99999
 
-std::shared_ptr<std::string> MacroArgs::getArg(uint32_t i) const {
+std::shared_ptr<std::string> MacroArgs::getArg(uint32_t i) {
 	uint32_t realIndex = i + shift - 1;
 
-	return realIndex >= args.size() ? nullptr : args[realIndex];
+	if (realIndex >= args.size())
+		return nullptr;
+
+	auto &arg = args[realIndex];
+	arg.second = true;
+	return arg.first;
 }
 
-std::shared_ptr<std::string> MacroArgs::getAllArgs() const {
+std::shared_ptr<std::string> MacroArgs::getAllArgs() {
 	size_t nbArgs = args.size();
 
 	if (shift >= nbArgs)
@@ -27,18 +32,19 @@ std::shared_ptr<std::string> MacroArgs::getAllArgs() const {
 	size_t len = 0;
 
 	for (uint32_t i = shift; i < nbArgs; i++)
-		len += args[i]->length() + 1; // 1 for comma
+		len += args[i].first->length() + 1; // 1 for comma
 
 	auto str = std::make_shared<std::string>();
 	str->reserve(len + 1); // 1 for comma
 
 	for (uint32_t i = shift; i < nbArgs; i++) {
-		auto const &arg = args[i];
+		auto &arg = args[i];
 
-		str->append(*arg);
+		arg.second = true;
+		str->append(*arg.first);
 
 		// Commas go between args and after a last empty arg
-		if (i < nbArgs - 1 || arg->empty())
+		if (i < nbArgs - 1 || arg.first->empty())
 			str->push_back(','); // no space after comma
 	}
 
@@ -50,7 +56,7 @@ void MacroArgs::appendArg(std::shared_ptr<std::string> arg) {
 		warning(WARNING_EMPTY_MACRO_ARG, "Empty macro argument\n");
 	if (args.size() == MAXMACROARGS)
 		error("A maximum of " EXPAND_AND_STR(MAXMACROARGS) " arguments is allowed\n");
-	args.push_back(arg);
+	args.emplace_back(arg, false);
 }
 
 void MacroArgs::shiftArgs(int32_t count) {
@@ -63,5 +69,18 @@ void MacroArgs::shiftArgs(int32_t count) {
 		shift = 0;
 	} else {
 		shift += count;
+	}
+}
+
+void MacroArgs::checkUsedArgs() const {
+	for (size_t i = 0; i < args.size(); i++) {
+		auto const &arg = args[i];
+		if (!arg.second) {
+			warning(
+			    WARNING_UNUSED_MACRO_ARG,
+			    i < 9 ? "Unused macro arg \\%zu\n" : "Unused macro arg \\<%zu>\n",
+			    i + 1
+			);
+		}
 	}
 }

--- a/src/asm/warning.cpp
+++ b/src/asm/warning.cpp
@@ -58,6 +58,7 @@ static const WarningFlag warningFlags[NB_WARNINGS] = {
     {"shift-amount",         LEVEL_EVERYTHING},
     {"unmatched-directive",  LEVEL_EXTRA     },
     {"unterminated-load",    LEVEL_EXTRA     },
+    {"unused-macro-arg",     LEVEL_ALL       },
     {"user",                 LEVEL_DEFAULT   },
     // Parametric warnings
     {"numeric-string",       LEVEL_EVERYTHING},

--- a/test/asm/arg-shift.asm
+++ b/test/asm/arg-shift.asm
@@ -1,3 +1,5 @@
+OPT Wno-unused-macro-arg ; various macro arguments go unused
+
 MACRO print_all
 	REPT _NARG
 		PRINT " \1"

--- a/test/asm/bracketed-macro-args.asm
+++ b/test/asm/bracketed-macro-args.asm
@@ -1,3 +1,5 @@
+OPT Wno-unused-macro-arg ; various macro arguments go unused
+
 MACRO printargs
 	PRINTLN "first = \<1>"
 	FOR I, 2, _NARG

--- a/test/asm/bracketed-macro-args.err
+++ b/test/asm/bracketed-macro-args.err
@@ -1,13 +1,13 @@
-error: bracketed-macro-args.asm(33) -> bracketed-macro-args.asm::bad(26):
+error: bracketed-macro-args.asm(35) -> bracketed-macro-args.asm::bad(28):
     Bracketed symbol "nonnumeric" is not numeric
-error: bracketed-macro-args.asm(33) -> bracketed-macro-args.asm::bad(27):
+error: bracketed-macro-args.asm(35) -> bracketed-macro-args.asm::bad(29):
     Invalid bracketed macro argument '\<0>'
-error: bracketed-macro-args.asm(33) -> bracketed-macro-args.asm::bad(28):
+error: bracketed-macro-args.asm(35) -> bracketed-macro-args.asm::bad(30):
     Bracketed symbol "undefined" does not exist
-error: bracketed-macro-args.asm(33) -> bracketed-macro-args.asm::bad(29):
+error: bracketed-macro-args.asm(35) -> bracketed-macro-args.asm::bad(31):
     Macro argument '\<2>' not defined
-error: bracketed-macro-args.asm(33) -> bracketed-macro-args.asm::bad(30):
+error: bracketed-macro-args.asm(35) -> bracketed-macro-args.asm::bad(32):
     Macro argument '\<2>' not defined
-error: bracketed-macro-args.asm(39) -> bracketed-macro-args.asm::toolong(36):
+error: bracketed-macro-args.asm(41) -> bracketed-macro-args.asm::toolong(38):
     Bracketed symbol "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" does not exist
 error: Assembly aborted (6 errors)!

--- a/test/asm/builtin-overwrite.asm
+++ b/test/asm/builtin-overwrite.asm
@@ -33,5 +33,5 @@ endm
 
     ; Representative numeric and string builtins
     ; (SOURCE_DATE_EPOCH in test.sh makes this reproducible)
-    tickle __UTC_YEAR__, 1
-    tickle __ISO_8601_UTC__, 0
+    tickle __UTC_YEAR__
+    tickle __ISO_8601_UTC__

--- a/test/asm/line-continuation-whitespace.err
+++ b/test/asm/line-continuation-whitespace.err
@@ -1,3 +1,5 @@
 error: line-continuation-whitespace.asm(7):
     Label "foo" created outside of a SECTION
+warning: line-continuation-whitespace.asm(8) -> line-continuation-whitespace.asm::bar(5): [-Wunused-macro-arg]
+    Unused macro arg \1
 error: Assembly aborted (1 error)!

--- a/test/asm/line-continuation.err
+++ b/test/asm/line-continuation.err
@@ -4,4 +4,6 @@ warning: line-continuation.asm(6) -> line-continuation.asm::spam(4): [-Wuser]
     spam
 error: line-continuation.asm(14):
     Label "foo" created outside of a SECTION
+warning: line-continuation.asm(15) -> line-continuation.asm::bar(12): [-Wunused-macro-arg]
+    Unused macro arg \1
 error: Assembly aborted (2 errors)!

--- a/test/asm/macro-arg-0.err
+++ b/test/asm/macro-arg-0.err
@@ -2,4 +2,8 @@ error: macro-arg-0.asm(5) -> macro-arg-0.asm::m(2):
     Begun line continuation, but encountered character '0'
 error: macro-arg-0.asm(5) -> macro-arg-0.asm::m(3):
     Invalid bracketed macro argument '\<0>'
+warning: macro-arg-0.asm(5) -> macro-arg-0.asm::m(4): [-Wunused-macro-arg]
+    Unused macro arg \1
+warning: macro-arg-0.asm(5) -> macro-arg-0.asm::m(4): [-Wunused-macro-arg]
+    Unused macro arg \2
 error: Assembly aborted (2 errors)!

--- a/test/asm/narg-decreases-after-shift.asm
+++ b/test/asm/narg-decreases-after-shift.asm
@@ -1,3 +1,5 @@
+OPT Wno-unused-macro-arg ; various macro arguments go unused
+
 MACRO testing
 	db _NARG
 	shift

--- a/test/asm/narg-decreases-after-shift.err
+++ b/test/asm/narg-decreases-after-shift.err
@@ -1,2 +1,2 @@
-warning: narg-decreases-after-shift.asm(14) -> narg-decreases-after-shift.asm::testing(9): [-Wmacro-shift]
+warning: narg-decreases-after-shift.asm(16) -> narg-decreases-after-shift.asm::testing(11): [-Wmacro-shift]
     Cannot shift macro arguments past their end

--- a/test/asm/rept-shift.err
+++ b/test/asm/rept-shift.err
@@ -4,4 +4,10 @@ warning: rept-shift.asm(15) -> rept-shift.asm::m(11): [-Wmacro-shift]
     Cannot shift macro arguments past their end
 error: rept-shift.asm(15) -> rept-shift.asm::m(12):
     Macro argument '\1' not defined
+warning: rept-shift.asm(15) -> rept-shift.asm::m(13): [-Wunused-macro-arg]
+    Unused macro arg \2
+warning: rept-shift.asm(15) -> rept-shift.asm::m(13): [-Wunused-macro-arg]
+    Unused macro arg \3
+warning: rept-shift.asm(15) -> rept-shift.asm::m(13): [-Wunused-macro-arg]
+    Unused macro arg \4
 error: Assembly aborted (1 error)!

--- a/test/asm/shift-negative.asm
+++ b/test/asm/shift-negative.asm
@@ -17,4 +17,6 @@ MACRO m
 	shift -1
 	shift -1
 ENDM
+	pusho Wno-unused-macro-arg
 	m one
+	popo

--- a/test/asm/shift-negative.err
+++ b/test/asm/shift-negative.err
@@ -1,8 +1,8 @@
-warning: shift-negative.asm(20) -> shift-negative.asm::m(13): [-Wmacro-shift]
+warning: shift-negative.asm(21) -> shift-negative.asm::m(13): [-Wmacro-shift]
     Cannot shift macro arguments past their end
-warning: shift-negative.asm(20) -> shift-negative.asm::m(14): [-Wmacro-shift]
+warning: shift-negative.asm(21) -> shift-negative.asm::m(14): [-Wmacro-shift]
     Cannot shift macro arguments past their beginning
-warning: shift-negative.asm(20) -> shift-negative.asm::m(16): [-Wmacro-shift]
+warning: shift-negative.asm(21) -> shift-negative.asm::m(16): [-Wmacro-shift]
     Cannot shift macro arguments past their end
-warning: shift-negative.asm(20) -> shift-negative.asm::m(18): [-Wmacro-shift]
+warning: shift-negative.asm(21) -> shift-negative.asm::m(18): [-Wmacro-shift]
     Cannot shift macro arguments past their beginning

--- a/test/asm/skip-expansions.asm
+++ b/test/asm/skip-expansions.asm
@@ -1,3 +1,5 @@
+OPT Wno-unused-macro-arg ; various macro arguments go unused
+
 ; skipping ahead to `elif`/`else`/`endc`/`endr`/`endm` disables expansions!
 
 MACRO mac1

--- a/test/asm/skip-expansions.err
+++ b/test/asm/skip-expansions.err
@@ -1,7 +1,7 @@
-error: skip-expansions.asm(31) -> skip-expansions.asm::mac2(21):
+error: skip-expansions.asm(33) -> skip-expansions.asm::mac2(23):
     Macro argument '\1' not defined
-error: skip-expansions.asm(31) -> skip-expansions.asm::mac2(21):
+error: skip-expansions.asm(33) -> skip-expansions.asm::mac2(23):
     syntax error, unexpected (
-error: skip-expansions.asm(31) -> skip-expansions.asm::mac2(21):
+error: skip-expansions.asm(33) -> skip-expansions.asm::mac2(23):
     Macro argument '\2' not defined
 error: Assembly aborted (3 errors)!

--- a/test/asm/undefined-builtins.asm
+++ b/test/asm/undefined-builtins.asm
@@ -37,5 +37,7 @@ MACRO m
 	assert DEF(_NARG)
 	println _NARG
 	println "{_NARG}!"
+	; Avoid `-Wunused-macro-arg` by evaluating all args
+	redef _use_all_args equs "\#"
 ENDM
 	m 1, 2, 3

--- a/test/asm/use-purged-symbol.err
+++ b/test/asm/use-purged-symbol.err
@@ -2,6 +2,8 @@ error: use-purged-symbol.asm(6):
     Macro "m" not defined; it was purged
 error: use-purged-symbol.asm(13) -> use-purged-symbol.asm::m2(10):
     Bracketed symbol "argi" does not exist; it was purged
+warning: use-purged-symbol.asm(13) -> use-purged-symbol.asm::m2(11): [-Wunused-macro-arg]
+    Unused macro arg \1
 error: use-purged-symbol.asm(15):
     Expected constant expression: 'argi' is not constant at assembly time; it was purged
 error: use-purged-symbol.asm(17):


### PR DESCRIPTION
Fixes #1579

I'm a bit wary of how much new warning output this will create for various projects. But, even those that do `-Weverything` can always add `-Wno-unused-macro-arg` if they find the workarounds (e.g. `assert isconst("use all args: \#")`) to be awkward/annoying.