### PR TITLE
Fix the node type for "file" nodes in object files

### DIFF
--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -44,9 +44,6 @@ struct FileStackNode {
 	    : type(type_), data(data_){};
 
 	std::string const &dump(uint32_t curLineNo) const;
-
-	// If true, entering this context generates a new unique ID.
-	bool generatesUniqueID() const { return type == NODE_REPT || type == NODE_MACRO; }
 };
 
 #define DEFAULT_MAX_DEPTH 64

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -210,7 +210,7 @@ static bool newFileContext(std::string const &filePath, bool updateStateNow) {
 	std::shared_ptr<MacroArgs> macroArgs = nullptr;
 
 	auto fileInfo =
-	    std::make_shared<FileStackNode>(NODE_MACRO, filePath == "-" ? "<stdin>" : filePath);
+	    std::make_shared<FileStackNode>(NODE_FILE, filePath == "-" ? "<stdin>" : filePath);
 	if (!contextStack.empty()) {
 		Context &oldContext = contextStack.top();
 		fileInfo->parent = oldContext.fileInfo;


### PR DESCRIPTION
I'm pretty sure the distinction between `NODE_FILE` and `NODE_MACRO` no longer matters at all. It only mattered before for determining whether `\@` got a new value, but now that's done directly by setting `.uniqueIDStr` in the new context (`newFileContext` just copies the current context's pointer, `newMacroContext` creates a new one). It doesn't look like rgbds-obj cares either: the node type only matters for the `Display` trait, which has identical handling for file and macro nodes. However, I'd rather not try removing node type 2 in a patch release (upcoming 0.9.1) just to be safe.