### PR TITLE
Remove the 99999 macro arg limit

### DIFF
--- a/src/asm/macro.cpp
+++ b/src/asm/macro.cpp
@@ -6,11 +6,7 @@
 #include <string.h>
 #include <string>
 
-#include "helpers.hpp"
-
 #include "asm/warning.hpp"
-
-#define MAXMACROARGS 99999
 
 std::shared_ptr<std::string> MacroArgs::getArg(uint32_t i) const {
 	uint32_t realIndex = i + shift - 1;
@@ -48,8 +44,6 @@ std::shared_ptr<std::string> MacroArgs::getAllArgs() const {
 void MacroArgs::appendArg(std::shared_ptr<std::string> arg) {
 	if (arg->empty())
 		warning(WARNING_EMPTY_MACRO_ARG, "Empty macro argument\n");
-	if (args.size() == MAXMACROARGS)
-		error("A maximum of " EXPAND_AND_STR(MAXMACROARGS) " arguments is allowed\n");
 	args.push_back(arg);
 }
 


### PR DESCRIPTION
This limit was never documented, and was basically a convenience in C because allocating memory for all those args was handled manually. Now they're just in a `std::vector`, and this check feels more like cruft than an actual safety mechanism.

(It's possible for a vector to OOM, of course, but we have plenty of other places that risk that. The parser has many values which unboundedly build up a vector, like `charmap` multi-values, `purge`d symbols, or `ds N, ...` expressions. Nobody is actually ever going to get near the machine limits.)