### PR TITLE
Update Dockerfile to use Debian 12 slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11-slim
+FROM debian:12-slim
 LABEL org.opencontainers.image.source=https://github.com/gbdev/rgbds
 ARG version=0.9.0
 WORKDIR /rgbds
@@ -8,7 +8,7 @@ COPY . .
 RUN apt-get update && \
     apt-get install sudo make cmake gcc build-essential -y
 
-RUN ./.github/scripts/install_deps.sh ubuntu-20.04
+RUN ./.github/scripts/install_deps.sh ubuntu-22.04
 RUN make -j CXXFLAGS="-O3 -flto -DNDEBUG -static" PKG_CONFIG="pkg-config --static" Q=
 
 RUN tar caf rgbds-${version}-linux-x86_64.tar.xz --transform='s#.*/##' rgbasm rgblink rgbfix rgbgfx man/* .github/scripts/install.sh


### PR DESCRIPTION
`debian:12-slim` [corresponds](https://askubuntu.com/questions/445487/what-debian-version-are-the-different-ubuntu-versions-based-on) to `ubuntu-22.04` LTS.