### PR TITLE
Ensure that object file section IDs are correct

### DIFF
--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -66,8 +66,14 @@ static uint32_t getSectIDIfAny(Section *sect) {
 	if (!sect)
 		return UINT32_MAX;
 
-	if (auto search = sectionMap.find(sect->name); search != sectionMap.end())
-		return static_cast<uint32_t>(sectionMap.size() - search->second - 1);
+	// Search in `sectionList` instead of `sectionMap`, since section fragments share the
+	// same name but have different IDs
+	if (auto search =
+	    std::find_if(RANGE(sectionList), [&sect](Section const &s) { return &s == sect; });
+	    search != sectionList.end())
+		return static_cast<uint32_t>(
+		    sectionList.size() - std::distance(sectionList.begin(), search) - 1
+		);
 
 	fatalerror("Unknown section '%s'\n", sect->name.c_str());
 }


### PR DESCRIPTION
I can't make a test case to demonstrate this because it doesn't currently occur, since RGBASM merges section fragments (and unions) at assembly time when they're in the same object:

```c++
	// Check if another section exists with the same name; merge if yes, otherwise create one

	Section *sect = sect_FindSectionByName(name);

	if (sect) {
		mergeSections(*sect, type, org, bank, alignment, alignOffset, mod);
	} else {
		sect = createSection(name, type, org, bank, alignment, alignOffset, mod);
	}
```

However, this is a theoretically correct fix which would avoid bugs if that ever changes.