### PR TITLE
Correct the `DAA` documentation

### DIFF
--- a/man/gbz80.7
+++ b/man/gbz80.7
@@ -615,9 +615,6 @@ to the adjustment.
 .It
 Subtract the adjustment from
 .Sy A .
-.It
-Set the carry flag if borrow (i.e. if adjustment >
-.Sy A ) .
 .El
 .It If the subtract flag Sy N No is not set:
 .Bl -enum -compact
@@ -639,15 +636,13 @@ to the adjustment.
 If the carry flag is set or
 .Sy A
 >
-.Ad $9F ,
+.Ad $99 ,
 then add
 .Ad $60
-to the adjustment.
+to the adjustment and set the carry flag.
 .It
 Add the adjustment to
 .Sy A .
-.It
-Set the carry flag if overflow from bit 7.
 .El
 .El
 .Pp


### PR DESCRIPTION
Fixes #1602

@calc84maniac Thanks for pointing this out! Can you please confirm this is now accurate?

<img width="882" alt="Screen Shot 2025-01-17 at 21 53 15" src="https://github.com/user-attachments/assets/00f6a831-2317-49b8-b834-14269d555da8" />
