### PR TITLE
Undeprecate `ld [$ff00+c]`

### DIFF
--- a/man/rgbasm-old.5
+++ b/man/rgbasm-old.5
@@ -266,6 +266,14 @@ Instead, use
 .Ql LDH [C], A
 and
 .Ql LDH A, [C] .
+.Pp
+Note that
+.Ql LD [$FF00+C], A
+and
+.Ql LD A, [$FF00+C]
+were also deprecated in 0.9.0, but were
+.Em undeprecated
+in 0.9.1.
 .Ss LDH [n8], A and LDH A, [n8]
 Deprecated in 0.9.0.
 .Pp

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -1973,14 +1973,21 @@ z80_ldh:
 	| Z80_LDH MODE_A COMMA c_ind {
 		sect_ConstByte(0xF2);
 	}
+	| Z80_LDH MODE_A COMMA ff00_c_ind {
+		sect_ConstByte(0xF2);
+	}
 	| Z80_LDH c_ind COMMA MODE_A {
+		sect_ConstByte(0xE2);
+	}
+	| Z80_LDH ff00_c_ind COMMA MODE_A {
 		sect_ConstByte(0xE2);
 	}
 ;
 
-c_ind:
-	  LBRACK MODE_C RBRACK
-	| LBRACK relocexpr OP_ADD MODE_C RBRACK {
+c_ind: LBRACK MODE_C RBRACK;
+
+ff00_c_ind:
+	LBRACK relocexpr OP_ADD MODE_C RBRACK {
 		// This has to use `relocexpr`, not `iconst`, to avoid a shift/reduce conflict
 		if ($2.getConstVal() != 0xFF00)
 			::error("Base value must be equal to $FF00 for $FF00+C\n");
@@ -2031,7 +2038,10 @@ z80_ld_mem:
 ;
 
 z80_ld_c_ind:
-	Z80_LD c_ind COMMA MODE_A {
+	Z80_LD ff00_c_ind COMMA MODE_A {
+		sect_ConstByte(0xE2);
+	}
+	| Z80_LD c_ind COMMA MODE_A {
 		warning(WARNING_OBSOLETE, "LD [C], A is deprecated; use LDH [C], A\n");
 		sect_ConstByte(0xE2);
 	}
@@ -2063,6 +2073,9 @@ z80_ld_a:
 	}
 	| Z80_LD reg_a COMMA reg_r {
 		sect_ConstByte(0x40 | ($2 << 3) | $4);
+	}
+	| Z80_LD reg_a COMMA ff00_c_ind {
+		sect_ConstByte(0xF2);
 	}
 	| Z80_LD reg_a COMMA c_ind {
 		warning(WARNING_OBSOLETE, "LD A, [C] is deprecated; use LDH A, [C]\n");

--- a/test/asm/deprecated-ldio.err
+++ b/test/asm/deprecated-ldio.err
@@ -2,10 +2,6 @@ warning: deprecated-ldio.asm(5): [-Wobsolete]
     LDH is deprecated with values from $00 to $FF; use $FF00 to $FFFF
 warning: deprecated-ldio.asm(6): [-Wobsolete]
     LDH is deprecated with values from $00 to $FF; use $FF00 to $FFFF
-warning: deprecated-ldio.asm(8): [-Wobsolete]
-    LD [C], A is deprecated; use LDH [C], A
-warning: deprecated-ldio.asm(9): [-Wobsolete]
-    LD A, [C] is deprecated; use LDH A, [C]
 warning: deprecated-ldio.asm(13): [-Wobsolete]
     LDIO is deprecated; use LDH
 warning: deprecated-ldio.asm(14): [-Wobsolete]
@@ -18,10 +14,6 @@ warning: deprecated-ldio.asm(20): [-Wobsolete]
     LDH is deprecated with values from $00 to $FF; use $FF00 to $FFFF
 warning: deprecated-ldio.asm(21): [-Wobsolete]
     LDH is deprecated with values from $00 to $FF; use $FF00 to $FFFF
-warning: deprecated-ldio.asm(23): [-Wobsolete]
-    LD [C], A is deprecated; use LDH [C], A
-warning: deprecated-ldio.asm(24): [-Wobsolete]
-    LD A, [C] is deprecated; use LDH A, [C]
 warning: deprecated-ldio.asm(28): [-Wobsolete]
     LDIO is deprecated; use LDH
 warning: deprecated-ldio.asm(29): [-Wobsolete]

--- a/test/asm/ff00+c-bad.asm
+++ b/test/asm/ff00+c-bad.asm
@@ -1,9 +1,9 @@
 
 SECTION "ff00+c or not to ff00+c", ROMX
 
-	ldh a, [$ff00 + c]
-	ldh [65280 + c], a
+	ld a, [$ff00 + c]
+	ld [65280 + c], a
 
 	; Not ok
-	ldh a, [$ff01 + c]
-	ldh [xyz + c], a
+	ld a, [$ff01 + c]
+	ld [xyz + c], a

--- a/test/asm/ff00+c.asm
+++ b/test/asm/ff00+c.asm
@@ -1,5 +1,5 @@
 SECTION "test", ROM0[0]
-	ldh [ $ff00 + c ], a
+	ld [ $ff00 + c ], a
 	; 257 spaces exceeds both LEXER_BUF_SIZE (64) and uint8_t limit (255)
-	ldh [ $ff00 +                                                                                                                                                                                                                                                                 c ], a
-	ldh [ $ff00                                                                                                                                                                                                                                                                 + c ], a
+	ld [ $ff00 +                                                                                                                                                                                                                                                                 c ], a
+	ld [ $ff00                                                                                                                                                                                                                                                                 + c ], a

--- a/test/asm/invalid-instructions.asm
+++ b/test/asm/invalid-instructions.asm
@@ -1,6 +1,6 @@
 SECTION "invalid", ROM0[$10000]
 	ld [hl], [hl]
-	ldh a, [$00ff+c]
+	ld a, [$00ff+c]
 	ld b, [c]
 	ld b, [bc]
 	ld b, [$4000]

--- a/test/link/all-instructions.asm
+++ b/test/link/all-instructions.asm
@@ -154,7 +154,7 @@ ENDM
     ld  [hl],a
     ld  [$ABCD],a
     ldh [$ff00+$DB],a
-    ldh [$ff00+c],a
+    ld  [$ff00+c],a
     ldh [$ff00 + c],a
     ldh [c],a
 
@@ -164,7 +164,7 @@ ENDM
     ld  a,[$ABCD]
     ldh a,[$ff00+$DB]
     ldh a,[$ff00+c]
-    ldh a,[$ff00 + c]
+    ld  a,[$ff00 + c]
     ldh a,[c]
 
     ld  [hl+],a


### PR DESCRIPTION
Fixes #1600

#1574 deprecated `ld [c]`, as it documented in rgbasm-old.5. But it also deprecated `ld [$ff00+c]`, which is popular enough that we want to keep it.

<img width="738" alt="Screen Shot 2025-01-17 at 23 51 30" src="https://github.com/user-attachments/assets/f5f3bed5-079c-476c-91a5-c60a4409f1f9" />

Also note that although `ldh [c]` is the recommended form of this instruction, `ldh [$ff00+c]` is a valid but redundant alternative.

(Maybe in the future we'll deprecate `ldh [$ff00+c]`, or deprecate `[$ff00+c]` altogether, but not for now.)