### PR TITLE
Avoid the need for `diff --strip-trailing-cr` in Windows tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,10 @@
 # Flags also need Unix line endings (see https://github.com/gbdev/rgbds/issues/955)
 *.flags text eol=lf
 
+# Test outputs need Windows line endings (see https://github.com/gbdev/rgbds/pull/1635)
+*.out text eol=crlf
+*.err text eol=crlf
+
 # Binary files need exact bytes
 *.bin binary
 *.gb binary

--- a/test/asm/test.sh
+++ b/test/asm/test.sh
@@ -30,7 +30,7 @@ RGBASM=../../rgbasm
 RGBLINK=../../rgblink
 
 tryDiff () {
-	if ! diff -au --strip-trailing-cr "$1" "$2"; then
+	if ! diff -au "$1" "$2"; then
 		echo "${bold}${red}${i%.asm}${variant}.$3 mismatch!${rescolors}${resbold}"
 		false
 	fi

--- a/test/fix/test.sh
+++ b/test/fix/test.sh
@@ -25,7 +25,7 @@ rescolors="$(tput op)"
 RGBFIX=./rgbfix
 
 tryDiff () {
-	if ! diff -au --strip-trailing-cr "$1" "$2"; then
+	if ! diff -au "$1" "$2"; then
 		echo "${bold}${red}${3:-$1} mismatch!${rescolors}${resbold}"
 		false
 	fi

--- a/test/gfx/test.sh
+++ b/test/gfx/test.sh
@@ -83,7 +83,7 @@ for f in *.png; do
 	newTest "$RGBGFX" $flags "$f"
 	if [[ -e "${f%.png}.err" ]]; then
 		runTest 2>"$errtmp"
-		diff -au --strip-trailing-cr "${f%.png}.err" "$errtmp" || failTest
+		diff -au "${f%.png}.err" "$errtmp" || failTest
 	else
 		runTest && checkOutput "${f%.png}" || failTest $?
 	fi
@@ -91,7 +91,7 @@ for f in *.png; do
 	newTest "$RGBGFX" $flags - "<$f"
 	if [[ -e "${f%.png}.err" ]]; then
 		runTest 2>"$errtmp"
-		diff -au --strip-trailing-cr <(sed "s/$f/<stdin>/g" "${f%.png}.err") "$errtmp" || failTest
+		diff -au <(sed "s/$f/<stdin>/g" "${f%.png}.err") "$errtmp" || failTest
 	else
 		runTest && checkOutput "${f%.png}" || failTest $?
 	fi

--- a/test/link/test.sh
+++ b/test/link/test.sh
@@ -38,7 +38,7 @@ continueTest () {
 }
 
 tryDiff () {
-	if ! diff -au --strip-trailing-cr "$1" "$2"; then
+	if ! diff -au "$1" "$2"; then
 		echo "${bold}${red}$1 mismatch!${rescolors}${resbold}"
 		false
 	fi


### PR DESCRIPTION
Follow-up to #1635.