### PR TITLE
Define `operator!=` in terms of `operator==`

### DIFF
--- a/include/gfx/rgba.hpp
+++ b/include/gfx/rgba.hpp
@@ -36,7 +36,9 @@ struct Rgba {
 		auto shl = [](uint8_t val, unsigned shift) { return static_cast<uint32_t>(val) << shift; };
 		return shl(red, 24) | shl(green, 16) | shl(blue, 8) | shl(alpha, 0);
 	}
+
 	bool operator==(Rgba const &rhs) const { return toCSS() == rhs.toCSS(); }
+	bool operator!=(Rgba const &rhs) const { return !operator==(rhs); }
 
 	// CGB colors are RGB555, so we use bit 15 to signify that the color is transparent instead
 	// Since the rest of the bits don't matter then, we return 0x8000 exactly.

--- a/include/itertools.hpp
+++ b/include/itertools.hpp
@@ -25,6 +25,7 @@ class EnumSeq {
 		auto operator*() const { return _value; }
 
 		bool operator==(Iterator const &rhs) const { return _value == rhs._value; }
+		bool operator!=(Iterator const &rhs) const { return !operator==(rhs); }
 	};
 
 public:
@@ -58,6 +59,7 @@ public:
 	bool operator==(ZipIterator const &rhs) const {
 		return std::get<0>(_iters) == std::get<0>(rhs._iters);
 	}
+	bool operator!=(ZipIterator const &rhs) const { return !operator==(rhs); }
 };
 
 template<typename... Ts>

--- a/src/gfx/pal_packing.cpp
+++ b/src/gfx/pal_packing.cpp
@@ -86,7 +86,8 @@ private:
 	public:
 		Iter() = default;
 
-		bool operator==(Iter const &other) const { return _iter == other._iter; }
+		bool operator==(Iter const &rhs) const { return _iter == rhs._iter; }
+		bool operator!=(Iter const &rhs) const { return !operator==(rhs); }
 
 		Iter &operator++() {
 			++_iter;

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -466,6 +466,7 @@ public:
 			}
 
 			bool operator==(Iterator const &rhs) const { return coords() == rhs.coords(); }
+			bool operator!=(Iterator const &rhs) const { return !operator==(rhs); }
 		};
 
 	public:


### PR DESCRIPTION
`contrib/coverage.bash` reports these as inconsistently used.