### PR TITLE
Derive `operator!=` from `operator==` (stops supporting gcc 9.x)

### DIFF
--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -100,7 +100,7 @@ jobs:
           path: rgbds-${{ env.version }}-macos.zip
 
   linux:
-    runs-on: ubuntu-20.04 # Oldest supported, for best glibc compatibility.
+    runs-on: ubuntu-22.04 # Oldest supported, for best glibc compatibility.
     steps:
       - name: Get version from tag
         shell: bash
@@ -112,7 +112,7 @@ jobs:
       - name: Install deps
         shell: bash
         run: |
-          ./.github/scripts/install_deps.sh ubuntu-20.04
+          ./.github/scripts/install_deps.sh ubuntu-22.04
       - name: Build binaries
         run: |
           make -kj WARNFLAGS="-Wall -Wextra -pedantic -static" PKG_CONFIG="pkg-config --static" Q=

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,7 +7,7 @@ jobs:
   unix:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-14]
+        os: [ubuntu-22.04, macos-14]
         cxx: [g++, clang++]
         buildsys: [make, cmake]
         exclude:

--- a/include/gfx/rgba.hpp
+++ b/include/gfx/rgba.hpp
@@ -38,7 +38,6 @@ struct Rgba {
 	}
 
 	bool operator==(Rgba const &rhs) const { return toCSS() == rhs.toCSS(); }
-	bool operator!=(Rgba const &rhs) const { return !operator==(rhs); }
 
 	// CGB colors are RGB555, so we use bit 15 to signify that the color is transparent instead
 	// Since the rest of the bits don't matter then, we return 0x8000 exactly.

--- a/include/itertools.hpp
+++ b/include/itertools.hpp
@@ -25,7 +25,6 @@ class EnumSeq {
 		auto operator*() const { return _value; }
 
 		bool operator==(Iterator const &rhs) const { return _value == rhs._value; }
-		bool operator!=(Iterator const &rhs) const { return !operator==(rhs); }
 	};
 
 public:
@@ -59,7 +58,6 @@ public:
 	bool operator==(ZipIterator const &rhs) const {
 		return std::get<0>(_iters) == std::get<0>(rhs._iters);
 	}
-	bool operator!=(ZipIterator const &rhs) const { return !operator==(rhs); }
 };
 
 template<typename... Ts>

--- a/src/gfx/pal_packing.cpp
+++ b/src/gfx/pal_packing.cpp
@@ -87,7 +87,6 @@ private:
 		Iter() = default;
 
 		bool operator==(Iter const &rhs) const { return _iter == rhs._iter; }
-		bool operator!=(Iter const &rhs) const { return !operator==(rhs); }
 
 		Iter &operator++() {
 			++_iter;

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -466,7 +466,6 @@ public:
 			}
 
 			bool operator==(Iterator const &rhs) const { return coords() == rhs.coords(); }
-			bool operator!=(Iterator const &rhs) const { return !operator==(rhs); }
 		};
 
 	public:


### PR DESCRIPTION
Follow-up to #1659.

gcc started supporting `operator!=` derived from `operator==` in version 10.1 (released May 2020). Version 9 (up to 9.5, released May 2022) did not.

Ubuntu 20.04 LTS came with gcc 9.3 (released March 2020) by default. Since then, there have been two more LTS releases, 22.04 and 24.04. We were testing and building on 20.04 in CI "for best glibc compatibility", but with two newer LTS releases to choose from, that can be dropped. (See [this Discord conversation](https://discord.com/channels/303217943234215948/790920525253836912/1340269429296201840).)