### PR TITLE
Exclude more lines from test coverage

### DIFF
--- a/src/gfx/main.cpp
+++ b/src/gfx/main.cpp
@@ -103,6 +103,7 @@ void fatal(char const *fmt, ...) {
 }
 
 void Options::verbosePrint(uint8_t level, char const *fmt, ...) const {
+	// LCOV_EXCL_START
 	if (verbosity >= level) {
 		va_list ap;
 
@@ -110,6 +111,7 @@ void Options::verbosePrint(uint8_t level, char const *fmt, ...) const {
 		vfprintf(stderr, fmt, ap);
 		va_end(ap);
 	}
+	// LCOV_EXCL_STOP
 }
 
 // Short options
@@ -586,13 +588,17 @@ static char *parseArgv(int argc, char *argv[]) {
 			options.tilemap = musl_optarg;
 			break;
 		case 'V':
+			// LCOV_EXCL_START
 			printf("rgbgfx %s\n", get_package_version_string());
 			exit(0);
+			// LCOV_EXCL_STOP
 		case 'v':
+			// LCOV_EXCL_START
 			if (options.verbosity < Options::VERB_VVVVVV) {
 				++options.verbosity;
 			}
 			break;
+			// LCOV_EXCL_STOP
 		case 'x':
 			options.trim = parseNumber(arg, "Number of tiles to trim", 0);
 			if (*arg != '\0') {
@@ -750,6 +756,7 @@ int main(int argc, char *argv[]) {
 		parseExternalPalSpec(localOptions.externalPalSpec);
 	}
 
+	// LCOV_EXCL_START
 	if (options.verbosity >= Options::VERB_CFG) {
 		fprintf(stderr, "rgbgfx %s\n", get_package_version_string());
 
@@ -862,6 +869,7 @@ int main(int argc, char *argv[]) {
 		printPath("Output palettes", options.palettes);
 		fputs("Ready.\n", stderr);
 	}
+	// LCOV_EXCL_STOP
 
 	// Do not do anything if option parsing went wrong.
 	requireZeroErrors();

--- a/src/gfx/pal_packing.cpp
+++ b/src/gfx/pal_packing.cpp
@@ -559,6 +559,7 @@ std::tuple<DefaultInitVec<size_t>, size_t>
 		}
 	}
 
+	// LCOV_EXCL_START
 	if (options.verbosity >= Options::VERB_INTERM) {
 		for (auto &&assignment : assignments) {
 			fprintf(stderr, "{ ");
@@ -571,11 +572,13 @@ std::tuple<DefaultInitVec<size_t>, size_t>
 			fprintf(stderr, "} (volume = %zu)\n", assignment.volume());
 		}
 	}
+	// LCOV_EXCL_STOP
 
 	// "Decant" the result
 	decant(assignments, protoPalettes);
 	// Note that the result does not contain any empty palettes
 
+	// LCOV_EXCL_START
 	if (options.verbosity >= Options::VERB_INTERM) {
 		for (auto &&assignment : assignments) {
 			fprintf(stderr, "{ ");
@@ -588,6 +591,7 @@ std::tuple<DefaultInitVec<size_t>, size_t>
 			fprintf(stderr, "} (volume = %zu)\n", assignment.volume());
 		}
 	}
+	// LCOV_EXCL_STOP
 
 	DefaultInitVec<size_t> mappings(protoPalettes.size());
 	for (size_t i = 0; i < assignments.size(); ++i) {

--- a/src/gfx/pal_sorting.cpp
+++ b/src/gfx/pal_sorting.cpp
@@ -40,7 +40,7 @@ void sortIndexed(
 					return true;
 				}
 			}
-			unreachable_(); // This should not be possible
+			unreachable_(); // LCOV_EXCL_LINE
 		});
 	}
 }

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -193,13 +193,15 @@ public:
 		    PNG_LIBPNG_VER_STRING, static_cast<png_voidp>(this), handleError, handleWarning
 		);
 		if (!png) {
-			fatal("Failed to allocate PNG structure: %s", strerror(errno));
+			fatal("Failed to create PNG read structure: %s", strerror(errno)); // LCOV_EXCL_LINE
 		}
 
 		info = png_create_info_struct(png);
 		if (!info) {
+			// LCOV_EXCL_START
 			png_destroy_read_struct(&png, nullptr, nullptr);
-			fatal("Failed to allocate PNG info structure: %s", strerror(errno));
+			fatal("Failed to create PNG info structure: %s", strerror(errno));
+			// LCOV_EXCL_STOP
 		}
 
 		png_set_read_fn(png, this, readData);
@@ -555,6 +557,7 @@ static std::tuple<DefaultInitVec<size_t>, std::vector<Palette>>
 	auto [mappings, nbPalettes] = overloadAndRemove(protoPalettes);
 	assume(mappings.size() == protoPalettes.size());
 
+	// LCOV_EXCL_START
 	if (options.verbosity >= Options::VERB_INTERM) {
 		fprintf(
 		    stderr,
@@ -566,6 +569,7 @@ static std::tuple<DefaultInitVec<size_t>, std::vector<Palette>>
 			fprintf(stderr, "%zu -> %zu\n", i, mappings[i]);
 		}
 	}
+	// LCOV_EXCL_STOP
 
 	std::vector<Palette> palettes(nbPalettes);
 	// If the image contains at least one transparent pixel, force transparency in the first slot of
@@ -653,6 +657,7 @@ static std::tuple<DefaultInitVec<size_t>, std::vector<Palette>>
 }
 
 static void outputPalettes(std::vector<Palette> const &palettes) {
+	// LCOV_EXCL_START
 	if (options.verbosity >= Options::VERB_INTERM) {
 		for (auto &&palette : palettes) {
 			fputs("{ ", stderr);
@@ -662,6 +667,7 @@ static void outputPalettes(std::vector<Palette> const &palettes) {
 			fputs("}\n", stderr);
 		}
 	}
+	// LCOV_EXCL_STOP
 
 	if (palettes.size() > options.nbPalettes) {
 		// If the palette generation is wrong, other (dependee) operations are likely to be
@@ -676,7 +682,9 @@ static void outputPalettes(std::vector<Palette> const &palettes) {
 	if (!options.palettes.empty()) {
 		File output;
 		if (!output.open(options.palettes, std::ios_base::out | std::ios_base::binary)) {
+			// LCOV_EXCL_START
 			fatal("Failed to create \"%s\": %s", output.c_str(options.palettes), strerror(errno));
+			// LCOV_EXCL_STOP
 		}
 
 		for (Palette const &palette : palettes) {
@@ -829,7 +837,9 @@ static void outputUnoptimizedTileData(
 ) {
 	File output;
 	if (!output.open(options.output, std::ios_base::out | std::ios_base::binary)) {
+		// LCOV_EXCL_START
 		fatal("Failed to create \"%s\": %s", output.c_str(options.output), strerror(errno));
+		// LCOV_EXCL_STOP
 	}
 
 	uint16_t widthTiles = options.inputSlice.width ? options.inputSlice.width : png.getWidth() / 8;
@@ -868,7 +878,9 @@ static void outputUnoptimizedMaps(
 		if (!path.empty()) {
 			file.emplace();
 			if (!file->open(path, std::ios_base::out | std::ios_base::binary)) {
+				// LCOV_EXCL_START
 				fatal("Failed to create \"%s\": %s", file->c_str(options.tilemap), strerror(errno));
+				// LCOV_EXCL_STOP
 			}
 		}
 	};
@@ -1013,7 +1025,9 @@ static UniqueTiles dedupTiles(
 static void outputTileData(UniqueTiles const &tiles) {
 	File output;
 	if (!output.open(options.output, std::ios_base::out | std::ios_base::binary)) {
+		// LCOV_EXCL_START
 		fatal("Failed to create \"%s\": %s", output.c_str(options.output), strerror(errno));
+		// LCOV_EXCL_STOP
 	}
 
 	uint16_t tileID = 0;
@@ -1035,7 +1049,9 @@ static void outputTileData(UniqueTiles const &tiles) {
 static void outputTilemap(DefaultInitVec<AttrmapEntry> const &attrmap) {
 	File output;
 	if (!output.open(options.tilemap, std::ios_base::out | std::ios_base::binary)) {
+		// LCOV_EXCL_START
 		fatal("Failed to create \"%s\": %s", output.c_str(options.tilemap), strerror(errno));
+		// LCOV_EXCL_STOP
 	}
 
 	for (AttrmapEntry const &entry : attrmap) {
@@ -1048,7 +1064,9 @@ static void outputAttrmap(
 ) {
 	File output;
 	if (!output.open(options.attrmap, std::ios_base::out | std::ios_base::binary)) {
+		// LCOV_EXCL_START
 		fatal("Failed to create \"%s\": %s", output.c_str(options.attrmap), strerror(errno));
+		// LCOV_EXCL_STOP
 	}
 
 	for (AttrmapEntry const &entry : attrmap) {
@@ -1064,7 +1082,9 @@ static void outputPalmap(
 ) {
 	File output;
 	if (!output.open(options.palmap, std::ios_base::out | std::ios_base::binary)) {
+		// LCOV_EXCL_START
 		fatal("Failed to create \"%s\": %s", output.c_str(options.palmap), strerror(errno));
+		// LCOV_EXCL_STOP
 	}
 
 	for (AttrmapEntry const &entry : attrmap) {
@@ -1092,6 +1112,7 @@ void process() {
 	// Now, we have all the image's colors in `colors`
 	// The next step is to order the palette
 
+	// LCOV_EXCL_START
 	if (options.verbosity >= Options::VERB_INTERM) {
 		fputs("Image colors: [ ", stderr);
 		for (auto const &slot : colors) {
@@ -1102,6 +1123,7 @@ void process() {
 		}
 		fputs("]\n", stderr);
 	}
+	// LCOV_EXCL_STOP
 
 	// Now, iterate through the tiles, generating proto-palettes as we go
 	// We do this unconditionally because this performs the image validation (which we want to
@@ -1191,6 +1213,7 @@ continue_visiting_tiles:;
 	    protoPalettes.size(),
 	    protoPalettes.size() != 1 ? "s" : ""
 	);
+	// LCOV_EXCL_START
 	if (options.verbosity >= Options::VERB_INTERM) {
 		for (auto const &protoPal : protoPalettes) {
 			fputs("[ ", stderr);
@@ -1200,6 +1223,7 @@ continue_visiting_tiles:;
 			fputs("]\n", stderr);
 		}
 	}
+	// LCOV_EXCL_STOP
 
 	if (options.palSpecType == Options::EMBEDDED) {
 		generatePalSpec(png);

--- a/src/gfx/reverse.cpp
+++ b/src/gfx/reverse.cpp
@@ -401,7 +401,9 @@ void reverse() {
 	options.verbosePrint(Options::VERB_LOG_ACT, "Writing image...\n");
 	File pngFile;
 	if (!pngFile.open(options.input, std::ios::out | std::ios::binary)) {
+		// LCOV_EXCL_START
 		fatal("Failed to create \"%s\": %s", pngFile.c_str(options.input), strerror(errno));
+		// LCOV_EXCL_STOP
 	}
 	png_structp png = png_create_write_struct(
 	    PNG_LIBPNG_VER_STRING,
@@ -410,11 +412,15 @@ void reverse() {
 	    pngWarning
 	);
 	if (!png) {
+		// LCOV_EXCL_START
 		fatal("Failed to create PNG write struct: %s", strerror(errno));
+		// LCOV_EXCL_STOP
 	}
 	png_infop pngInfo = png_create_info_struct(png);
 	if (!pngInfo) {
-		fatal("Failed to create PNG info struct: %s", strerror(errno));
+		// LCOV_EXCL_START
+		fatal("Failed to create PNG info structure: %s", strerror(errno));
+		// LCOV_EXCL_STOP
 	}
 	png_set_write_fn(png, &pngFile, writePng, flushPng);
 

--- a/src/link/assign.cpp
+++ b/src/link/assign.cpp
@@ -424,5 +424,5 @@ max_out:
 		}
 	}
 
-	unreachable_();
+	unreachable_(); // LCOV_EXCL_LINE
 }

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -397,11 +397,15 @@ int main(int argc, char *argv[]) {
 			is32kMode = true;
 			break;
 		case 'V':
+			// LCOV_EXCL_START
 			printf("rgblink %s\n", get_package_version_string());
 			exit(0);
+			// LCOV_EXCL_STOP
 		case 'v':
+			// LCOV_EXCL_START
 			beVerbose = true;
 			break;
+			// LCOV_EXCL_STOP
 		case 'w':
 			isWRAM0Mode = true;
 			break;

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -228,7 +228,7 @@ static uint8_t parseHexDigit(int c) {
 	} else if (c >= 'a' && c <= 'f') {
 		return c - 'a' + 10;
 	} else {
-		unreachable_();
+		unreachable_(); // LCOV_EXCL_LINE
 	}
 }
 

--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -208,8 +208,10 @@ static void mergeSections(Section &target, std::unique_ptr<Section> &&other) {
 		break;
 
 	case SECTION_NORMAL:
+		// LCOV_EXCL_START
 		unreachable_();
 	}
+	// LCOV_EXCL_STOP
 
 	// Note that the order in which fragments are stored in the `nextu` list does not
 	// really matter, only that offsets were properly computed above


### PR DESCRIPTION
These fall into a few categories:
- `_unreachable()`
- Verbose print messages
- Errors that should never practically occur (alloc/read/write failure, more than UINT32_MAX anonymous labels, etc)

Fixes #1636 (there may be more lines to exclude, but the obvious ones are mostly taken care of)