### PR TITLE
Clear some more TODO comments

### DIFF
--- a/src/gfx/pal_packing.cpp
+++ b/src/gfx/pal_packing.cpp
@@ -168,16 +168,6 @@ private:
 	std::unordered_set<uint16_t> &uniqueColors() const {
 		// We check for *distinct* colors by stuffing them into a `set`; this should be
 		// faster than "back-checking" on every element (O(n²))
-		//
-		// TODO: calc84maniac suggested another approach; try implementing it, see if it
-		// performs better:
-		// > So basically you make a priority queue that takes iterators into each of your sets
-		// > (paired with end iterators so you'll know where to stop), and the comparator tests the
-		// > values pointed to by each iterator
-		// > Then each iteration you pop from the queue,
-		// > optionally add one to your count, increment the iterator and push it back into the
-		// > queue if it didn't reach the end
-		// > And you do this until the priority queue is empty
 		static std::unordered_set<uint16_t> colors;
 
 		colors.clear();
@@ -477,7 +467,6 @@ std::tuple<DefaultInitVec<size_t>, size_t>
 				);
 
 				// All efficiencies are identical iff min equals max
-				// TODO: maybe not ideal to re-compute these two?
 				ProtoPalette const &minProtoPal = protoPalettes[minEfficiencyIter->protoPalIndex];
 				ProtoPalette const &maxProtoPal = protoPalettes[maxEfficiencyIter->protoPalIndex];
 				size_t minSize = minProtoPal.size();

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -58,17 +58,16 @@ void parseInlinePalSpec(char const * const rawArg) {
 	options.palSpec.clear();
 	options.palSpec.emplace_back(); // Value-initialized, not default-init'd, so we get zeros
 
-	size_t n = 0; // Index into the argument
-	// TODO: store max `nbColors` ever reached, and compare against palette size later
+	size_t n = 0;        // Index into the argument
 	size_t nbColors = 0; // Number of colors in the current palette
 	for (;;) {
 		++n; // Ignore the '#' (checked either by caller or previous loop iteration)
 
 		std::optional<Rgba> &color = options.palSpec.back()[nbColors];
-		// Check for #none first.
-		if (arg.compare(n, 4, "none"sv) == 0 || arg.compare(n, 4, "NONE"sv) == 0) {
+		// Check for "#none" first.
+		if (strncasecmp(&rawArg[n], "none", literal_strlen("none")) == 0) {
 			color = {};
-			n += 4;
+			n += literal_strlen("none");
 		} else {
 			auto pos = std::min(arg.find_first_not_of("0123456789ABCDEFabcdef"sv, n), arg.length());
 			switch (pos - n) {
@@ -172,7 +171,6 @@ static T readLE(U const *bytes) {
 [[gnu::warn_unused_result]]
 static bool readLine(std::filebuf &file, std::string &buffer) {
 	assume(buffer.empty());
-	// TODO: maybe this can be optimized to bulk reads?
 	for (;;) {
 		auto c = file.sbumpc();
 		if (c == std::filebuf::traits_type::eof()) {

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <tuple>
 
-#include "helpers.hpp" // assume
+#include "helpers.hpp" // assume, literal_strlen
 #include "linkdefs.hpp"
 #include "platform.hpp"
 
@@ -449,7 +449,7 @@ void sdobj_ReadFile(FileStackNode const &where, FILE *file, std::vector<Symbol> 
 				// It's fine to keep modifying the symbol after `AddSymbol`, only
 				// the name must not be modified
 			}
-			if (strncasecmp(&token[1], "ef", 2) != 0) {
+			if (strncasecmp(&token[1], "ef", literal_strlen("ef")) != 0) {
 				fatal(&where, lineNo, "'S' line is neither \"Def\" nor \"Ref\"");
 			}
 

--- a/test/gfx/none_round_trip.flags
+++ b/test/gfx/none_round_trip.flags
@@ -1,1 +1,1 @@
--c#none,#fff,#000
+-c#nOnE,#fFf,#000


### PR DESCRIPTION
All of these were regarding changes that would hypothetically perform better, but not at actual bottlenecks in RGBGFX. (For example, on my laptop from 2013, RGBGFX can convert a *130 megapixel* PNG in 2.6 seconds. Actual inputs are unlikely to ever be larger than one ROM bank, which can store 65 kilopixels of 2bpp data.)

I also changed some hardcoded numbers to use `literal_strlen`, and changed some case-insensitive string comparisons to use `strncasecmp` (thus allowing, not just "`none`" and "`NONE`", but also "`None`", "`nOnE`", etc).