### PR TITLE
Show specific messages for some more invalid instructions, not just "syntax error"

### DIFF
--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -582,7 +582,7 @@ void Expression::makeCheckBitIndex(uint8_t mask) {
 // Checks that an RPN expression's value fits within N bits (signed or unsigned)
 void Expression::checkNBit(uint8_t n) const {
 	if (isKnown()) {
-		::checkNBit(value(), n, "Expression");
+		::checkNBit(value(), n, nullptr);
 	}
 }
 
@@ -591,11 +591,23 @@ bool checkNBit(int32_t v, uint8_t n, char const *name) {
 	assume(n < CHAR_BIT * sizeof(int)); // Otherwise `1 << n` is UB
 
 	if (v < -(1 << n) || v >= 1 << n) {
-		warning(WARNING_TRUNCATION_1, "%s must be %u-bit\n", name, n);
+		warning(
+		    WARNING_TRUNCATION_1,
+		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit\n"
+		                    : "%s must be %u-bit\n",
+		    name ? name : "Expression",
+		    n
+		);
 		return false;
 	}
 	if (v < -(1 << (n - 1))) {
-		warning(WARNING_TRUNCATION_2, "%s must be %u-bit\n", name, n);
+		warning(
+		    WARNING_TRUNCATION_2,
+		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit\n"
+		                    : "%s must be %u-bit\n",
+		    name ? name : "Expression",
+		    n
+		);
 		return false;
 	}
 

--- a/src/bison.sh
+++ b/src/bison.sh
@@ -15,13 +15,16 @@ fi
 BISON_FLAGS="-Wall -Dparse.lac=full -Dlr.type=ielr"
 
 # Set some optimization flags on versions that support them
-if [ "$BISON_MAJOR" -eq 4 ] || [ "$BISON_MAJOR" -eq 3 ] && [ "$BISON_MINOR" -ge 5 ]; then
+if [ "$BISON_MAJOR" -ge 4 ] || [ "$BISON_MAJOR" -eq 3 ] && [ "$BISON_MINOR" -ge 5 ]; then
 	BISON_FLAGS="$BISON_FLAGS -Dapi.token.raw=true"
 fi
-if [ "$BISON_MAJOR" -eq 4 ] || [ "$BISON_MAJOR" -eq 3 ] && [ "$BISON_MINOR" -ge 6 ]; then
+if [ "$BISON_MAJOR" -ge 4 ] || [ "$BISON_MAJOR" -eq 3 ] && [ "$BISON_MINOR" -ge 6 ]; then
 	BISON_FLAGS="$BISON_FLAGS -Dparse.error=detailed"
 else
 	BISON_FLAGS="$BISON_FLAGS -Dparse.error=verbose"
+fi
+if [ "$BISON_MAJOR" -ge 4 ] || [ "$BISON_MAJOR" -eq 3 ] && [ "$BISON_MINOR" -ge 7 ]; then
+	BISON_FLAGS="$BISON_FLAGS -Wcounterexamples"
 fi
 
 # Replace the arguments to this script ($@) with the ones in $BISON_FLAGS

--- a/test/asm/ds-bad.err
+++ b/test/asm/ds-bad.err
@@ -1,5 +1,5 @@
 error: ds-bad.asm(3):
     Expected constant expression: 'unknown' is not constant at assembly time
 warning: ds-bad.asm(4): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 error: Assembly aborted (1 error)!

--- a/test/asm/invalid-instructions.asm
+++ b/test/asm/invalid-instructions.asm
@@ -6,3 +6,16 @@ SECTION "invalid", ROM0[$10000]
 	ld b, [$4000]
 	bit 8, a
 	rst $40
+
+	ld bc, bc
+	ld de, hl
+	ld hl, de
+
+	ld hl, sp ; no offset!
+	; ld sp, hl is valid
+
+	ld sp, bc
+	ld bc, sp
+
+	ld af, bc
+	ld bc, af

--- a/test/asm/invalid-instructions.err
+++ b/test/asm/invalid-instructions.err
@@ -16,4 +16,20 @@ error: invalid-instructions.asm(7):
     Invalid bit index 8 for BIT
 error: invalid-instructions.asm(8):
     Invalid address $40 for RST
-error: Assembly aborted (8 errors)!
+error: invalid-instructions.asm(10):
+    LD BC, BC is not a valid instruction; use LD B, B and LD C, C
+error: invalid-instructions.asm(11):
+    LD DE, HL is not a valid instruction; use LD D, H and LD E, L
+error: invalid-instructions.asm(12):
+    LD HL, DE is not a valid instruction; use LD H, D and LD L, E
+error: invalid-instructions.asm(14):
+    LD HL, SP is not a valid instruction; use LD HL, SP + 0
+error: invalid-instructions.asm(17):
+    LD SP, BC is not a valid instruction
+error: invalid-instructions.asm(18):
+    syntax error, unexpected sp
+error: invalid-instructions.asm(20):
+    syntax error, unexpected af
+error: invalid-instructions.asm(21):
+    syntax error, unexpected af
+error: Assembly aborted (16 errors)!

--- a/test/asm/warn-truncation.err
+++ b/test/asm/warn-truncation.err
@@ -1,64 +1,64 @@
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(23): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(24): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(25): [-Wtruncation]
     Expression must be 16-bit
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(26): [-Wtruncation]
     Expression must be 16-bit
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(28): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(29): [-Wtruncation]
     Expression must be 16-bit
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(30): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 warning: warn-truncation.asm(35) -> warn-truncation.asm::try(31): [-Wtruncation]
     Expression must be 16-bit
 warning: warn-truncation.asm(37) -> warn-truncation.asm::try(23): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 warning: warn-truncation.asm(37) -> warn-truncation.asm::try(24): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 warning: warn-truncation.asm(37) -> warn-truncation.asm::try(25): [-Wtruncation]
     Expression must be 16-bit
 warning: warn-truncation.asm(37) -> warn-truncation.asm::try(26): [-Wtruncation]
     Expression must be 16-bit
 warning: warn-truncation.asm(38) -> warn-truncation.asm::try(23): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 warning: warn-truncation.asm(38) -> warn-truncation.asm::try(24): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 warning: warn-truncation.asm(38) -> warn-truncation.asm::try(25): [-Wtruncation]
     Expression must be 16-bit
 warning: warn-truncation.asm(38) -> warn-truncation.asm::try(26): [-Wtruncation]
     Expression must be 16-bit
 warning: warn-truncation.asm(38) -> warn-truncation.asm::try(28): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 warning: warn-truncation.asm(38) -> warn-truncation.asm::try(29): [-Wtruncation]
     Expression must be 16-bit
 warning: warn-truncation.asm(38) -> warn-truncation.asm::try(30): [-Wtruncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 warning: warn-truncation.asm(38) -> warn-truncation.asm::try(31): [-Wtruncation]
     Expression must be 16-bit
 error: warn-truncation.asm(39) -> warn-truncation.asm::try(23): [-Werror=truncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 error: warn-truncation.asm(39) -> warn-truncation.asm::try(24): [-Werror=truncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 error: warn-truncation.asm(39) -> warn-truncation.asm::try(25): [-Werror=truncation]
     Expression must be 16-bit
 error: warn-truncation.asm(39) -> warn-truncation.asm::try(26): [-Werror=truncation]
     Expression must be 16-bit
 error: warn-truncation.asm(40) -> warn-truncation.asm::try(23): [-Werror=truncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 error: warn-truncation.asm(40) -> warn-truncation.asm::try(24): [-Werror=truncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 error: warn-truncation.asm(40) -> warn-truncation.asm::try(25): [-Werror=truncation]
     Expression must be 16-bit
 error: warn-truncation.asm(40) -> warn-truncation.asm::try(26): [-Werror=truncation]
     Expression must be 16-bit
 error: warn-truncation.asm(40) -> warn-truncation.asm::try(28): [-Werror=truncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 error: warn-truncation.asm(40) -> warn-truncation.asm::try(29): [-Werror=truncation]
     Expression must be 16-bit
 error: warn-truncation.asm(40) -> warn-truncation.asm::try(30): [-Werror=truncation]
-    Expression must be 8-bit
+    Expression must be 8-bit; use LOW() to force 8-bit
 error: warn-truncation.asm(40) -> warn-truncation.asm::try(31): [-Werror=truncation]
     Expression must be 16-bit


### PR DESCRIPTION
Fixes #1583

This PR adds specific messages for these invalid instructions:

- `ld bc|de|hl, bc|de|hl`
- `ld hl, sp` (should be `ld hl, sp + 0`)
- `ld sp, bc|de` (`ld sp, hl` is valid)
- Out-of-range 8-bit expressions (suggests `LOW()`)

There are *many* more "plausible but invalid" instructions we could parse and specifically warn about, including:

- Using `bc|de` where only `hl` is valid (e.g. `jp bc` or `add de, sp` or `ldi a, de`)
- Using `[bc|de|hli|hld]` where only `[hl]` is valid (e.g. in arithmetic and bitwise instructions)
- Using `af` or `sp` where only other 16-bit registers are valid (e.g. `add af, 12` or `push sp`)
- Using 8-bit registers besides `a` where only the accumulator is valid (e.g. `sub b, c` or `ld b, [de]` or `ldi h, bc`)
- Using `[c]` where is is not valid (e.g. `ld [c], b` or `inc [c]`)
- Using registers where only condition codes are valid (e.g. `jr b, .label` or `call a, Routine`; `c` being a register *and* condition confused me as a beginner)

Parsing all of these would quickly get out of hand, until/unless we refactored the parser to be a lot more general in how it parses instructions, and do the discerning of correct register arguments manually (as opposed to letting Bison-generated rules handle them). That might not end up being much more complicated, since the parser currently has a whole hierarchy of "subset" patterns to match which particular registers can go with which instructions.

For now, I think these few new messages are a reasonable addition and example of how errors could be more helpful.