### PR TITLE
Hint to {interpolate} names when EQUS expanding does not occur

### DIFF
--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -141,6 +141,13 @@ static void alreadyDefinedError(Symbol const &sym, char const *asType) {
 		}
 		fputs(" at ", stderr);
 		dumpFilename(sym);
+		if (sym.type == SYM_EQUS) {
+			fprintf(
+			    stderr,
+			    "    (should it be {interpolated} to define its contents \"%s\"?)\n",
+			    sym.getEqus()->c_str()
+			);
+		}
 	}
 }
 

--- a/test/asm/builtin-overwrite.err
+++ b/test/asm/builtin-overwrite.err
@@ -32,24 +32,34 @@ error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(6):
     Built-in symbol '__ISO_8601_UTC__' cannot be purged
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(9):
     '__ISO_8601_UTC__' already defined at <builtin>
+    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(10):
     '__ISO_8601_UTC__' already defined at <builtin>
+    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(13):
     '__ISO_8601_UTC__' already defined as constant at <builtin>
+    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(14):
     '__ISO_8601_UTC__' already defined as constant at <builtin>
+    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(17):
     '__ISO_8601_UTC__' already defined at <builtin>
+    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(18):
     '__ISO_8601_UTC__' already defined at <builtin>
+    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(21):
     '__ISO_8601_UTC__' already defined as constant at <builtin>
+    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(22):
     '__ISO_8601_UTC__' already defined as constant at <builtin>
+    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(25):
     '__ISO_8601_UTC__' already defined as non-EQU at <builtin>
+    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(26):
     '__ISO_8601_UTC__' already defined as non-EQU at <builtin>
+    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(29):
     Built-in symbol '__ISO_8601_UTC__' cannot be redefined
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(30):

--- a/test/asm/command-line-symbols.err
+++ b/test/asm/command-line-symbols.err
@@ -1,3 +1,4 @@
 error: command-line-symbols.asm(3):
     'FOO' already defined at <command-line>
+    (should it be {interpolated} to define its contents "hello"?)
 error: Assembly aborted (1 error)!

--- a/test/asm/def.asm
+++ b/test/asm/def.asm
@@ -28,3 +28,15 @@ redef string equs "there"
 
 redef constant equ 6*9
 	println constant
+
+macro mac
+endm
+
+redef mac equ 42
+
+def name equs "constant2"
+def name equ 1337
+
+redef name equs "mac2"
+macro name
+endm

--- a/test/asm/def.err
+++ b/test/asm/def.err
@@ -1,3 +1,11 @@
 error: def.asm(23):
     'constant' already defined at def.asm(10)
-error: Assembly aborted (1 error)!
+error: def.asm(35):
+    'mac' already defined as non-EQU at def.asm(32)
+error: def.asm(38):
+    'name' already defined at def.asm(37)
+    (should it be {interpolated} to define its contents "constant2"?)
+error: def.asm(42):
+    'name' already defined at def.asm(40)
+    (should it be {interpolated} to define its contents "mac2"?)
+error: Assembly aborted (4 errors)!

--- a/test/asm/for.err
+++ b/test/asm/for.err
@@ -6,6 +6,7 @@ warning: for.asm(20): [-Wbackwards-for]
     FOR goes backwards from 1 to 2 by -1
 error: for.asm(46):
     's' already defined as constant at for.asm(39)
+    (should it be {interpolated} to define its contents "x"?)
 error: for.asm(48) -> for.asm::REPT~4(54):
     'v' already defined as constant at for.asm(48) -> for.asm::REPT~4(52)
 FATAL: for.asm(48) -> for.asm::REPT~4(54):

--- a/test/asm/redef-equ.err
+++ b/test/asm/redef-equ.err
@@ -1,3 +1,4 @@
 error: redef-equ.asm(25):
     'N' already defined as non-EQU at redef-equ.asm(24)
+    (should it be {interpolated} to define its contents "X"?)
 error: Assembly aborted (1 error)!


### PR DESCRIPTION
This might help migrating older codebases, since the new `DEF`inition syntax prevents `EQUS` expansion.