### PR TITLE
Reuse `startsIdentifier` and `continuesIdentifier` functions

### DIFF
--- a/include/util.hpp
+++ b/include/util.hpp
@@ -3,6 +3,9 @@
 #ifndef RGBDS_UTIL_HPP
 #define RGBDS_UTIL_HPP
 
+bool startsIdentifier(int c);
+bool continuesIdentifier(int c);
+
 char const *printChar(int c);
 
 #endif // RGBDS_UTIL_HPP

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -136,9 +136,8 @@ struct CaseInsensitive {
 	}
 };
 
-// This map lists all RGBASM keywords which `yylex_NORMAL` lexes as identifiers
-// (see `startsIdentifier` and `continuesIdentifier` below). All non-identifier
-// tokens are lexed separately.
+// This map lists all RGBASM keywords which `yylex_NORMAL` lexes as identifiers.
+// All non-identifier tokens are lexed separately.
 static std::unordered_map<std::string, int, CaseInsensitive, CaseInsensitive> keywordDict = {
     {"ADC",           T_(SM83_ADC)         },
     {"ADD",           T_(SM83_ADD)         },
@@ -612,8 +611,6 @@ static bool isMacroChar(char c) {
 static int peek();
 static void shiftChar();
 static uint32_t readNumber(int radix, uint32_t baseValue);
-static bool startsIdentifier(int c);
-static bool continuesIdentifier(int c);
 
 static uint32_t readBracketedMacroArgNum() {
 	bool disableMacroArgs = lexerState->disableMacroArgs;
@@ -1214,15 +1211,6 @@ static uint32_t readGfxConstant() {
 }
 
 // Functions to read identifiers and keywords
-
-static bool startsIdentifier(int c) {
-	// Anonymous labels internally start with '!'
-	return (c <= 'Z' && c >= 'A') || (c <= 'z' && c >= 'a') || c == '.' || c == '_';
-}
-
-static bool continuesIdentifier(int c) {
-	return startsIdentifier(c) || (c <= '9' && c >= '0') || c == '#' || c == '$' || c == '@';
-}
 
 static Token readIdentifier(char firstChar, bool raw) {
 	std::string identifier(1, firstChar);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6,6 +6,15 @@
 #include <stdint.h>
 #include <stdio.h>
 
+bool startsIdentifier(int c) {
+	// This returns false for anonymous labels, which internally start with a '!'
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '.' || c == '_';
+}
+
+bool continuesIdentifier(int c) {
+	return startsIdentifier(c) || (c >= '0' && c <= '9') || c == '#' || c == '$' || c == '@';
+}
+
 char const *printChar(int c) {
 	// "'A'" + '\0': 4 bytes
 	// "'\\n'" + '\0': 5 bytes

--- a/test/asm/builtin-overwrite.err
+++ b/test/asm/builtin-overwrite.err
@@ -32,34 +32,24 @@ error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(6):
     Built-in symbol '__ISO_8601_UTC__' cannot be purged
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(9):
     '__ISO_8601_UTC__' already defined at <builtin>
-    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(10):
     '__ISO_8601_UTC__' already defined at <builtin>
-    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(13):
     '__ISO_8601_UTC__' already defined as constant at <builtin>
-    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(14):
     '__ISO_8601_UTC__' already defined as constant at <builtin>
-    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(17):
     '__ISO_8601_UTC__' already defined at <builtin>
-    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(18):
     '__ISO_8601_UTC__' already defined at <builtin>
-    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(21):
     '__ISO_8601_UTC__' already defined as constant at <builtin>
-    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(22):
     '__ISO_8601_UTC__' already defined as constant at <builtin>
-    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(25):
     '__ISO_8601_UTC__' already defined as non-EQU at <builtin>
-    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(26):
     '__ISO_8601_UTC__' already defined as non-EQU at <builtin>
-    (should it be {interpolated} to define its contents ""1989-04-21T12:34:56Z""?)
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(29):
     Built-in symbol '__ISO_8601_UTC__' cannot be redefined
 error: builtin-overwrite.asm(37) -> builtin-overwrite.asm::tickle(30):


### PR DESCRIPTION
This also allows checking that string contents are a valid identifier before suggesting to interpolate them.