### PR TITLE
Some errors should be `-Wbuiltin-args` warnings

### DIFF
--- a/man/rgbasm.1
+++ b/man/rgbasm.1
@@ -300,7 +300,7 @@ This warning is enabled by
 .Fl Wall .
 .It Fl Wbuiltin-args
 Warn about incorrect arguments to built-in functions, such as
-.Fn STRSUB
+.Fn STRSLICE
 with indexes outside of the string's bounds.
 This warning is enabled by
 .Fl Wall .

--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -595,8 +595,8 @@ The following functions operate on string expressions, but return integers.
 .It Fn STRCMP str1 str2 Ta Compares Ar str1 No and Ar str2 No according to ASCII ordering of their characters. Returns -1 if Ar str1 No is lower than Ar str2 Ns , 1 if Ar str1 No is greater than Ar str2 Ns , or 0 if they match.
 .It Fn STRFIND str sub Ta Returns the first index of Ar sub No in Ar str Ns , or -1 if it's not present.
 .It Fn STRRFIND str sub Ta Returns the last index of Ar sub No in Ar str Ns , or -1 if it's not present.
-.It Fn INCHARMAP str Ta Returns 1 if Ar str No has an entry in the current charmap, or 0 otherwise .
-.It Fn CHARLEN str Ta Returns the number of charmap entries in Ar str No with the current charmap .
+.It Fn INCHARMAP str Ta Returns 1 if Ar str No has an entry in the current charmap, or 0 otherwise.
+.It Fn CHARLEN str Ta Returns the number of charmap entries in Ar str No with the current charmap.
 .It Fn CHARCMP str1 str2 Ta Compares Ar str1 No and Ar str2 No according to their charmap entry values with the current charmap. Returns -1 if Ar str1 No is lower than Ar str2 Ns , 1 if Ar str1 No is greater than Ar str2 Ns , or 0 if they match.
 .It Fn CHARSIZE char Ta Returns how many values are in the charmap entry for Ar char No with the current charmap.
 .El

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -433,12 +433,12 @@ diff_mark:
 	  %empty // OK
 	| OP_ADD {
 		::error(
-			"syntax error, unexpected + at the beginning of the line (is it a leftover diff mark?)\n"
+		    "syntax error, unexpected + at the beginning of the line (is it a leftover diff mark?)\n"
 		);
 	}
 	| OP_SUB {
 		::error(
-			"syntax error, unexpected - at the beginning of the line (is it a leftover diff mark?)\n"
+		    "syntax error, unexpected - at the beginning of the line (is it a leftover diff mark?)\n"
 		);
 	}
 ;
@@ -703,9 +703,9 @@ align_spec:
 			$$.alignment = $$.alignOfs = 0;
 		} else if ($3 <= -(1 << $1) || $3 >= 1 << $1) {
 			::error(
-				"The absolute alignment offset (%" PRIu32 ") must be less than alignment size (%d)\n",
-				static_cast<uint32_t>($3 < 0 ? -$3 : $3),
-				1 << $1
+			    "The absolute alignment offset (%" PRIu32 ") must be less than alignment size (%d)\n",
+			    static_cast<uint32_t>($3 < 0 ? -$3 : $3),
+			    1 << $1
 			);
 			$$.alignment = $$.alignOfs = 0;
 		} else {
@@ -1572,7 +1572,7 @@ relocexpr_no_str:
 	| OP_CHARSIZE LPAREN string RPAREN {
 		size_t charSize = charmap_CharSize($3);
 		if (charSize == 0) {
-			::error("CHARSIZE: No character mapping for \"%s\"\n", $3.c_str());
+			warning(WARNING_BUILTIN_ARG, "CHARSIZE: No character mapping for \"%s\"\n", $3.c_str());
 		}
 		$$.makeNumber(charSize);
 	}
@@ -1648,9 +1648,9 @@ string_literal:
 		bool unique;
 		$$ = charmap_Reverse($3, unique);
 		if (!unique) {
-			::error("REVCHAR: Multiple character mappings to values\n");
+			warning(WARNING_BUILTIN_ARG, "REVCHAR: Multiple character mappings to values\n");
 		} else if ($$.empty()) {
-			::error("REVCHAR: No character mapping to values\n");
+			warning(WARNING_BUILTIN_ARG, "REVCHAR: No character mapping to values\n");
 		}
 	}
 	| OP_STRCAT LPAREN RPAREN {

--- a/test/asm/charsize.err
+++ b/test/asm/charsize.err
@@ -1,9 +1,8 @@
-error: charsize.asm(17):
+warning: charsize.asm(17): [-Wbuiltin-args]
     CHARSIZE: No character mapping for ""
-error: charsize.asm(18):
+warning: charsize.asm(18): [-Wbuiltin-args]
     CHARSIZE: No character mapping for "hello world"
-error: charsize.asm(19):
+warning: charsize.asm(19): [-Wbuiltin-args]
     CHARSIZE: No character mapping for "abcdef"
-error: charsize.asm(20):
+warning: charsize.asm(20): [-Wbuiltin-args]
     CHARSIZE: No character mapping for "é"
-error: Assembly aborted (4 errors)!

--- a/test/asm/revchar.err
+++ b/test/asm/revchar.err
@@ -1,5 +1,4 @@
-error: revchar.asm(22) -> revchar.asm::test(13):
+warning: revchar.asm(22) -> revchar.asm::test(13): [-Wbuiltin-args]
     REVCHAR: Multiple character mappings to values
-error: revchar.asm(23) -> revchar.asm::test(13):
+warning: revchar.asm(23) -> revchar.asm::test(13): [-Wbuiltin-args]
     REVCHAR: No character mapping to values
-error: Assembly aborted (2 errors)!


### PR DESCRIPTION
Fixes #1699

I also fixed some formatting inconsistencies (unnecessary spaces in man page macros, and tabs instead of spaces in parser.y where clang-format can't auto-fix them).