### PR TITLE
Only define `parse.lac` for Bison 3.5 or greater

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,10 +9,10 @@ set(common_src
     )
 
 find_package(BISON 3.0.0 REQUIRED)
-set(BISON_FLAGS "-Wall -Dparse.lac=full -Dlr.type=ielr")
+set(BISON_FLAGS "-Wall -Dlr.type=ielr")
 # Set some optimization flags on versions that support them
 if(BISON_VERSION VERSION_GREATER_EQUAL "3.5")
-  set(BISON_FLAGS "${BISON_FLAGS} -Dapi.token.raw=true")
+  set(BISON_FLAGS "${BISON_FLAGS} -Dparse.lac=full -Dapi.token.raw=true")
 endif()
 if(BISON_VERSION VERSION_GREATER_EQUAL "3.6")
   set(BISON_FLAGS "${BISON_FLAGS} -Dparse.error=detailed")

--- a/src/bison.sh
+++ b/src/bison.sh
@@ -12,11 +12,11 @@ if [ "$BISON_MAJOR" -lt 3 ]; then
 	exit 1
 fi
 
-BISON_FLAGS="-Wall -Dparse.lac=full -Dlr.type=ielr"
+BISON_FLAGS="-Wall -Dlr.type=ielr"
 
 # Set some optimization flags on versions that support them
 if [ "$BISON_MAJOR" -ge 4 ] || [ "$BISON_MAJOR" -eq 3 ] && [ "$BISON_MINOR" -ge 5 ]; then
-	BISON_FLAGS="$BISON_FLAGS -Dapi.token.raw=true"
+	BISON_FLAGS="$BISON_FLAGS -Dparse.lac=full -Dapi.token.raw=true"
 fi
 if [ "$BISON_MAJOR" -ge 4 ] || [ "$BISON_MAJOR" -eq 3 ] && [ "$BISON_MINOR" -ge 6 ]; then
 	BISON_FLAGS="$BISON_FLAGS -Dparse.error=detailed"


### PR DESCRIPTION
The `%define` variable `parse.lac` was implemented for C++ parsers in Bison 3.5 (https://savannah.gnu.org/news/?id=9603). If it is defined but not used, it can give a `<command line>:2: error: %define variable 'parse.lac' is not used` error.