### PR TITLE
Refactor warnings and errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,8 @@ src/link/main.o: src/link/script.hpp
 
 rgbfix_obj := \
 	src/fix/main.o \
-	src/extern/getopt.o
+	src/extern/getopt.o \
+	src/error.o
 
 rgbgfx_obj := \
 	src/gfx/main.o \

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,7 @@ src/link/main.o: src/link/script.hpp
 
 rgbfix_obj := \
 	src/fix/main.o \
-	src/extern/getopt.o \
-	src/error.o
+	src/extern/getopt.o
 
 rgbgfx_obj := \
 	src/gfx/main.o \

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ rgbgfx_obj := \
 	src/gfx/proto_palette.o \
 	src/gfx/reverse.o \
 	src/gfx/rgba.o \
+	src/gfx/warning.o \
 	src/extern/getopt.o \
 	src/error.o
 

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ rgblink_obj := \
 	src/link/sdas_obj.o \
 	src/link/section.o \
 	src/link/symbol.o \
+	src/link/warning.o \
 	src/extern/getopt.o \
 	src/extern/utf8decoder.o \
 	src/error.o \

--- a/include/asm/warning.hpp
+++ b/include/asm/warning.hpp
@@ -74,4 +74,11 @@ void fatalerror(char const *fmt, ...);
 [[gnu::format(printf, 1, 2)]]
 void error(char const *fmt, ...);
 
+// Used for errors that make it impossible to assemble correctly, but don't
+// affect the following code. The code will fail to assemble but the user will
+// get a list of all errors at the end, making it easier to fix all of them at
+// once.
+[[gnu::format(printf, 1, 2)]]
+void errorNoNewline(char const *fmt, ...);
+
 #endif // RGBDS_ASM_WARNING_HPP

--- a/include/error.hpp
+++ b/include/error.hpp
@@ -3,16 +3,10 @@
 #ifndef RGBDS_ERROR_HPP
 #define RGBDS_ERROR_HPP
 
-extern "C" {
-	[[gnu::format(printf, 1, 2)]]
-	void warn(char const *fmt...);
-	[[gnu::format(printf, 1, 2)]]
-	void warnx(char const *fmt, ...);
+[[gnu::format(printf, 1, 2)]]
+void warnx(char const *fmt, ...);
 
-	[[gnu::format(printf, 1, 2), noreturn]]
-	void err(char const *fmt, ...);
-	[[gnu::format(printf, 1, 2), noreturn]]
-	void errx(char const *fmt, ...);
-}
+[[gnu::format(printf, 1, 2), noreturn]]
+void errx(char const *fmt, ...);
 
 #endif // RGBDS_ERROR_HPP

--- a/include/gfx/main.hpp
+++ b/include/gfx/main.hpp
@@ -85,16 +85,9 @@ extern Options options;
 void giveUp();
 // If any error has been emitted thus far, calls `giveUp()`.
 void requireZeroErrors();
-// Prints a warning, and does not change the error count
-[[gnu::format(printf, 1, 2)]]
-void warning(char const *fmt, ...);
 // Prints an error, and increments the error count
 [[gnu::format(printf, 1, 2)]]
 void error(char const *fmt, ...);
-// Prints an error, and increments the error count
-// Does not take format arguments so `format_` and `-Wformat-security` won't complain about
-// calling `errorMessage(msg)`.
-void errorMessage(char const *msg);
 // Prints a fatal error, increments the error count, and gives up
 [[gnu::format(printf, 1, 2), noreturn]]
 void fatal(char const *fmt, ...);

--- a/include/gfx/warning.hpp
+++ b/include/gfx/warning.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef RGBDS_GFX_WARNING_HPP
+#define RGBDS_GFX_WARNING_HPP
+
+// Prints the error count, and exits with failure
+[[noreturn]]
+void giveUp();
+
+// If any error has been emitted thus far, calls `giveUp()`
+void requireZeroErrors();
+
+// Prints an error, and increments the error count
+[[gnu::format(printf, 1, 2)]]
+void error(char const *fmt, ...);
+
+// Prints a fatal error, increments the error count, and gives up
+[[gnu::format(printf, 1, 2), noreturn]]
+void fatal(char const *fmt, ...);
+
+#endif // RGBDS_GFX_WARNING_HPP

--- a/include/link/main.hpp
+++ b/include/link/main.hpp
@@ -59,11 +59,4 @@ struct FileStackNode {
 	std::string const &dump(uint32_t curLineNo) const;
 };
 
-[[gnu::format(printf, 3, 4)]]
-void warning(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
-[[gnu::format(printf, 3, 4)]]
-void error(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
-[[gnu::format(printf, 3, 4), noreturn]]
-void fatal(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
-
 #endif // RGBDS_LINK_MAIN_HPP

--- a/include/link/warning.hpp
+++ b/include/link/warning.hpp
@@ -11,8 +11,8 @@ struct FileStackNode;
 void warning(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
 [[gnu::format(printf, 3, 4)]]
 void error(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
-[[gnu::format(printf, 3, 4)]]
-void errorNoNewline(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
+[[gnu::format(printf, 1, 2)]]
+void errorNoDump(char const *fmt, ...);
 [[gnu::format(printf, 2, 3)]]
 void argErr(char flag, char const *fmt, ...);
 [[gnu::format(printf, 3, 4), noreturn]]

--- a/include/link/warning.hpp
+++ b/include/link/warning.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef RGBDS_LINK_WARNING_HPP
+#define RGBDS_LINK_WARNING_HPP
+
+#include <stdint.h>
+
+struct FileStackNode;
+
+[[gnu::format(printf, 3, 4)]]
+void warning(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
+[[gnu::format(printf, 3, 4)]]
+void error(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
+[[gnu::format(printf, 2, 3)]]
+void argErr(char flag, char const *fmt, ...);
+[[gnu::format(printf, 3, 4), noreturn]]
+void fatal(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
+
+void requireZeroErrors();
+
+#endif // RGBDS_LINK_WARNING_HPP

--- a/include/link/warning.hpp
+++ b/include/link/warning.hpp
@@ -11,6 +11,8 @@ struct FileStackNode;
 void warning(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
 [[gnu::format(printf, 3, 4)]]
 void error(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
+[[gnu::format(printf, 3, 4)]]
+void errorNoNewline(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...);
 [[gnu::format(printf, 2, 3)]]
 void argErr(char flag, char const *fmt, ...);
 [[gnu::format(printf, 3, 4), noreturn]]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ set(rgblink_src
     "link/sdas_obj.cpp"
     "link/section.cpp"
     "link/symbol.cpp"
+    "link/warning.cpp"
     "extern/getopt.cpp"
     "extern/utf8decoder.cpp"
     "error.cpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ set(rgblink_src
 set(rgbfix_src
     "fix/main.cpp"
     "extern/getopt.cpp"
+    "error.cpp"
     )
 
 set(rgbgfx_src

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ set(rgbgfx_src
     "gfx/proto_palette.cpp"
     "gfx/reverse.cpp"
     "gfx/rgba.cpp"
+    "gfx/warning.cpp"
     "extern/getopt.cpp"
     "error.cpp"
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,8 +47,28 @@ set(rgbasm_src
     "asm/section.cpp"
     "asm/symbol.cpp"
     "asm/warning.cpp"
+    "extern/getopt.cpp"
     "extern/utf8decoder.cpp"
     "diagnostics.cpp"
+    "error.cpp"
+    "linkdefs.cpp"
+    "opmath.cpp"
+    "util.cpp"
+    )
+
+set(rgblink_src
+    "${BISON_LINKER_SCRIPT_PARSER_OUTPUT_SOURCE}"
+    "link/assign.cpp"
+    "link/main.cpp"
+    "link/object.cpp"
+    "link/output.cpp"
+    "link/patch.cpp"
+    "link/sdas_obj.cpp"
+    "link/section.cpp"
+    "link/symbol.cpp"
+    "extern/getopt.cpp"
+    "extern/utf8decoder.cpp"
+    "error.cpp"
     "linkdefs.cpp"
     "opmath.cpp"
     "util.cpp"
@@ -56,6 +76,7 @@ set(rgbasm_src
 
 set(rgbfix_src
     "fix/main.cpp"
+    "extern/getopt.cpp"
     )
 
 set(rgbgfx_src
@@ -69,22 +90,6 @@ set(rgbgfx_src
     "gfx/rgba.cpp"
     "extern/getopt.cpp"
     "error.cpp"
-    )
-
-set(rgblink_src
-    "${BISON_LINKER_SCRIPT_PARSER_OUTPUT_SOURCE}"
-    "link/assign.cpp"
-    "link/main.cpp"
-    "link/object.cpp"
-    "link/output.cpp"
-    "link/patch.cpp"
-    "link/sdas_obj.cpp"
-    "link/section.cpp"
-    "link/symbol.cpp"
-    "extern/utf8decoder.cpp"
-    "linkdefs.cpp"
-    "opmath.cpp"
-    "util.cpp"
     )
 
 foreach(PROG "asm" "fix" "gfx" "link")

--- a/src/asm/charmap.cpp
+++ b/src/asm/charmap.cpp
@@ -86,14 +86,14 @@ void charmap_New(std::string const &name, std::string const *baseName) {
 
 	if (baseName != nullptr) {
 		if (auto search = charmapMap.find(*baseName); search == charmapMap.end()) {
-			error("Base charmap '%s' doesn't exist\n", baseName->c_str());
+			error("Base charmap '%s' doesn't exist", baseName->c_str());
 		} else {
 			baseIdx = search->second;
 		}
 	}
 
 	if (charmapMap.find(name) != charmapMap.end()) {
-		error("Charmap '%s' already exists\n", name.c_str());
+		error("Charmap '%s' already exists", name.c_str());
 		return;
 	}
 
@@ -114,7 +114,7 @@ void charmap_New(std::string const &name, std::string const *baseName) {
 
 void charmap_Set(std::string const &name) {
 	if (auto search = charmapMap.find(name); search == charmapMap.end()) {
-		error("Charmap '%s' doesn't exist\n", name.c_str());
+		error("Charmap '%s' doesn't exist", name.c_str());
 	} else {
 		currentCharmap = &charmapList[search->second];
 	}
@@ -126,7 +126,7 @@ void charmap_Push() {
 
 void charmap_Pop() {
 	if (charmapStack.empty()) {
-		error("No entries in the charmap stack\n");
+		error("No entries in the charmap stack");
 		return;
 	}
 
@@ -136,13 +136,13 @@ void charmap_Pop() {
 
 void charmap_CheckStack() {
 	if (!charmapStack.empty()) {
-		warning(WARNING_UNMATCHED_DIRECTIVE, "`PUSHC` without corresponding `POPC`\n");
+		warning(WARNING_UNMATCHED_DIRECTIVE, "`PUSHC` without corresponding `POPC`");
 	}
 }
 
 void charmap_Add(std::string const &mapping, std::vector<int32_t> &&value) {
 	if (mapping.empty()) {
-		error("Cannot map an empty string\n");
+		error("Cannot map an empty string");
 		return;
 	}
 
@@ -168,7 +168,7 @@ void charmap_Add(std::string const &mapping, std::vector<int32_t> &&value) {
 	CharmapNode &node = charmap.nodes[nodeIdx];
 
 	if (node.isTerminal()) {
-		warning(WARNING_CHARMAP_REDEF, "Overriding charmap mapping\n");
+		warning(WARNING_CHARMAP_REDEF, "Overriding charmap mapping");
 	}
 
 	std::swap(node.value, value);
@@ -268,7 +268,7 @@ size_t charmap_ConvertNext(std::string_view &input, std::vector<int32_t> *output
 		// This will write the codepoint's value to `output`, little-endian
 		for (uint32_t state = 0, codepoint = 0; inputIdx + codepointLen < input.length();) {
 			if (decode(&state, &codepoint, input[inputIdx + codepointLen]) == 1) {
-				error("Input string is not valid UTF-8\n");
+				error("Input string is not valid UTF-8");
 				codepointLen = 1;
 				break;
 			}
@@ -286,11 +286,11 @@ size_t charmap_ConvertNext(std::string_view &input, std::vector<int32_t> *output
 
 		// Warn if this character is not mapped but any others are
 		if (int firstChar = input[inputIdx]; charmap.nodes.size() > 1) {
-			warning(WARNING_UNMAPPED_CHAR_1, "Unmapped character %s\n", printChar(firstChar));
+			warning(WARNING_UNMAPPED_CHAR_1, "Unmapped character %s", printChar(firstChar));
 		} else if (charmap.name != DEFAULT_CHARMAP_NAME) {
 			warning(
 			    WARNING_UNMAPPED_CHAR_2,
-			    "Unmapped character %s not in " DEFAULT_CHARMAP_NAME " charmap\n",
+			    "Unmapped character %s not in " DEFAULT_CHARMAP_NAME " charmap",
 			    printChar(firstChar)
 			);
 		}

--- a/src/asm/format.cpp
+++ b/src/asm/format.cpp
@@ -162,19 +162,19 @@ void FormatSpec::appendString(std::string &str, std::string const &value) const 
 	}
 
 	if (sign) {
-		error("Formatting string with sign flag '%c'\n", sign);
+		error("Formatting string with sign flag '%c'", sign);
 	}
 	if (padZero) {
-		error("Formatting string with padding flag '0'\n");
+		error("Formatting string with padding flag '0'");
 	}
 	if (hasFrac) {
-		error("Formatting string with fractional width\n");
+		error("Formatting string with fractional width");
 	}
 	if (hasPrec) {
-		error("Formatting string with fractional precision\n");
+		error("Formatting string with fractional precision");
 	}
 	if (useType != 's') {
-		error("Formatting string as type '%c'\n", useType);
+		error("Formatting string as type '%c'", useType);
 	}
 
 	std::string useValue = exact ? escapeString(value) : value;
@@ -203,16 +203,16 @@ void FormatSpec::appendNumber(std::string &str, uint32_t value) const {
 
 	if (useType != 'X' && useType != 'x' && useType != 'b' && useType != 'o' && useType != 'f'
 	    && useExact) {
-		error("Formatting type '%c' with exact flag '#'\n", useType);
+		error("Formatting type '%c' with exact flag '#'", useType);
 	}
 	if (useType != 'f' && hasFrac) {
-		error("Formatting type '%c' with fractional width\n", useType);
+		error("Formatting type '%c' with fractional width", useType);
 	}
 	if (useType != 'f' && hasPrec) {
-		error("Formatting type '%c' with fractional precision\n", useType);
+		error("Formatting type '%c' with fractional precision", useType);
 	}
 	if (useType == 's') {
-		error("Formatting number as type 's'\n");
+		error("Formatting number as type 's'");
 	}
 
 	char signChar = sign; // 0 or ' ' or '+'
@@ -254,7 +254,7 @@ void FormatSpec::appendNumber(std::string &str, uint32_t value) const {
 		// Default fractional width (C++'s is 6 for "%f"; here 5 is enough for Q16.16)
 		size_t useFracWidth = hasFrac ? fracWidth : 5;
 		if (useFracWidth > 255) {
-			error("Fractional width %zu too long, limiting to 255\n", useFracWidth);
+			error("Fractional width %zu too long, limiting to 255", useFracWidth);
 			useFracWidth = 255;
 		}
 
@@ -262,7 +262,7 @@ void FormatSpec::appendNumber(std::string &str, uint32_t value) const {
 		size_t usePrec = hasPrec ? precision : defaultPrec;
 		if (usePrec < 1 || usePrec > 31) {
 			error(
-			    "Fixed-point constant precision %zu invalid, defaulting to %zu\n",
+			    "Fixed-point constant precision %zu invalid, defaulting to %zu",
 			    usePrec,
 			    defaultPrec
 			);

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -160,7 +160,7 @@ bool yywrap() {
 
 	if (ifDepth != 0) {
 		fatalerror(
-		    "Ended block with %" PRIu32 " unterminated IF construct%s\n",
+		    "Ended block with %" PRIu32 " unterminated IF construct%s",
 		    ifDepth,
 		    ifDepth == 1 ? "" : "s"
 		);
@@ -188,7 +188,7 @@ bool yywrap() {
 
 			// This error message will refer to the current iteration
 			if (sym->type != SYM_VAR) {
-				fatalerror("Failed to update FOR symbol value\n");
+				fatalerror("Failed to update FOR symbol value");
 			}
 		}
 		// Advance to the next iteration
@@ -211,7 +211,7 @@ bool yywrap() {
 
 static void checkRecursionDepth() {
 	if (contextStack.size() > maxRecursionDepth) {
-		fatalerror("Recursion limit (%zu) exceeded\n", maxRecursionDepth);
+		fatalerror("Recursion limit (%zu) exceeded", maxRecursionDepth);
 	}
 }
 
@@ -317,13 +317,13 @@ void fstk_RunInclude(std::string const &path, bool preInclude) {
 			// LCOV_EXCL_STOP
 			failedOnMissingInclude = true;
 		} else {
-			error("Unable to open included file '%s': %s\n", path.c_str(), strerror(errno));
+			error("Unable to open included file '%s': %s", path.c_str(), strerror(errno));
 		}
 		return;
 	}
 
 	if (!newFileContext(*fullPath, false)) {
-		fatalerror("Failed to set up lexer for file include\n"); // LCOV_EXCL_LINE
+		fatalerror("Failed to set up lexer for file include"); // LCOV_EXCL_LINE
 	}
 }
 
@@ -332,14 +332,14 @@ void fstk_RunMacro(std::string const &macroName, std::shared_ptr<MacroArgs> macr
 
 	if (!macro) {
 		if (sym_IsPurgedExact(macroName)) {
-			error("Macro \"%s\" not defined; it was purged\n", macroName.c_str());
+			error("Macro \"%s\" not defined; it was purged", macroName.c_str());
 		} else {
-			error("Macro \"%s\" not defined\n", macroName.c_str());
+			error("Macro \"%s\" not defined", macroName.c_str());
 		}
 		return;
 	}
 	if (macro->type != SYM_MACRO) {
-		error("\"%s\" is not a macro\n", macroName.c_str());
+		error("\"%s\" is not a macro", macroName.c_str());
 		return;
 	}
 
@@ -372,12 +372,12 @@ void fstk_RunFor(
 	} else if (step < 0 && stop < start) {
 		count = (static_cast<int64_t>(start) - stop - 1) / -static_cast<int64_t>(step) + 1;
 	} else if (step == 0) {
-		error("FOR cannot have a step value of 0\n");
+		error("FOR cannot have a step value of 0");
 	}
 
 	if ((step > 0 && start > stop) || (step < 0 && start < stop)) {
 		warning(
-		    WARNING_BACKWARDS_FOR, "FOR goes backwards from %d to %d by %d\n", start, stop, step
+		    WARNING_BACKWARDS_FOR, "FOR goes backwards from %d to %d by %d", start, stop, step
 		);
 	}
 
@@ -394,7 +394,7 @@ void fstk_RunFor(
 
 bool fstk_Break() {
 	if (contextStack.top().fileInfo->type != NODE_REPT) {
-		error("BREAK can only be used inside a REPT/FOR block\n");
+		error("BREAK can only be used inside a REPT/FOR block");
 		return false;
 	}
 
@@ -404,14 +404,14 @@ bool fstk_Break() {
 
 void fstk_NewRecursionDepth(size_t newDepth) {
 	if (contextStack.size() > newDepth + 1) {
-		fatalerror("Recursion limit (%zu) exceeded\n", newDepth);
+		fatalerror("Recursion limit (%zu) exceeded", newDepth);
 	}
 	maxRecursionDepth = newDepth;
 }
 
 void fstk_Init(std::string const &mainPath, size_t maxDepth) {
 	if (!newFileContext(mainPath, true)) {
-		fatalerror("Failed to open main file\n");
+		fatalerror("Failed to open main file");
 	}
 
 	maxRecursionDepth = maxDepth;

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -376,9 +376,7 @@ void fstk_RunFor(
 	}
 
 	if ((step > 0 && start > stop) || (step < 0 && start < stop)) {
-		warning(
-		    WARNING_BACKWARDS_FOR, "FOR goes backwards from %d to %d by %d", start, stop, step
-		);
+		warning(WARNING_BACKWARDS_FOR, "FOR goes backwards from %d to %d by %d", start, stop, step);
 	}
 
 	if (count == 0) {

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -1289,8 +1289,7 @@ static uint32_t readGfxConstant() {
 		error("Invalid graphics constant, no digits after '`'");
 	} else if (width == 9) {
 		warning(
-		    WARNING_LARGE_CONSTANT,
-		    "Graphics constant is too long, only first 8 pixels considered"
+		    WARNING_LARGE_CONSTANT, "Graphics constant is too long, only first 8 pixels considered"
 		);
 	}
 

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -384,7 +384,7 @@ void lexer_IncIFDepth() {
 
 void lexer_DecIFDepth() {
 	if (lexerState->ifStack.empty()) {
-		fatalerror("Found ENDC outside of an IF construct\n");
+		fatalerror("Found ENDC outside of an IF construct");
 	}
 
 	lexerState->ifStack.pop_front();
@@ -423,7 +423,7 @@ bool LexerState::setFileAsNextState(std::string const &filePath, bool updateStat
 		struct stat statBuf;
 		if (stat(filePath.c_str(), &statBuf) != 0) {
 			// LCOV_EXCL_START
-			error("Failed to stat file \"%s\": %s\n", filePath.c_str(), strerror(errno));
+			error("Failed to stat file \"%s\": %s", filePath.c_str(), strerror(errno));
 			return false;
 			// LCOV_EXCL_STOP
 		}
@@ -432,7 +432,7 @@ bool LexerState::setFileAsNextState(std::string const &filePath, bool updateStat
 		int fd = open(path.c_str(), O_RDONLY);
 		if (fd < 0) {
 			// LCOV_EXCL_START
-			error("Failed to open file \"%s\": %s\n", path.c_str(), strerror(errno));
+			error("Failed to open file \"%s\": %s", path.c_str(), strerror(errno));
 			return false;
 			// LCOV_EXCL_STOP
 		}
@@ -565,7 +565,7 @@ size_t BufferedContent::readMore(size_t startIndex, size_t nbChars) {
 
 	if (nbReadChars == -1) {
 		// LCOV_EXCL_START
-		fatalerror("Error while reading \"%s\": %s\n", lexerState->path.c_str(), strerror(errno));
+		fatalerror("Error while reading \"%s\": %s", lexerState->path.c_str(), strerror(errno));
 		// LCOV_EXCL_STOP
 	}
 
@@ -600,7 +600,7 @@ static void beginExpansion(std::shared_ptr<std::string> str, std::optional<std::
 
 void lexer_CheckRecursionDepth() {
 	if (lexerState->expansions.size() > maxRecursionDepth + 1) {
-		fatalerror("Recursion limit (%zu) exceeded\n", maxRecursionDepth);
+		fatalerror("Recursion limit (%zu) exceeded", maxRecursionDepth);
 	}
 }
 
@@ -637,7 +637,7 @@ static uint32_t readBracketedMacroArgNum() {
 	if (c >= '0' && c <= '9') {
 		uint32_t n = readDecimalNumber(0);
 		if (n > INT32_MAX) {
-			error("Number in bracketed macro argument is too large\n");
+			error("Number in bracketed macro argument is too large");
 			return 0;
 		}
 		num = negative ? -n : static_cast<int32_t>(n);
@@ -646,7 +646,7 @@ static uint32_t readBracketedMacroArgNum() {
 			shiftChar();
 			c = peek();
 			if (!startsIdentifier(c)) {
-				error("Empty raw symbol in bracketed macro argument\n");
+				error("Empty raw symbol in bracketed macro argument");
 				return 0;
 			}
 		}
@@ -662,14 +662,14 @@ static uint32_t readBracketedMacroArgNum() {
 
 		if (!sym) {
 			if (sym_IsPurgedScoped(symName)) {
-				error("Bracketed symbol \"%s\" does not exist; it was purged\n", symName.c_str());
+				error("Bracketed symbol \"%s\" does not exist; it was purged", symName.c_str());
 			} else {
-				error("Bracketed symbol \"%s\" does not exist\n", symName.c_str());
+				error("Bracketed symbol \"%s\" does not exist", symName.c_str());
 			}
 			num = 0;
 			symbolError = true;
 		} else if (!sym->isNumeric()) {
-			error("Bracketed symbol \"%s\" is not numeric\n", symName.c_str());
+			error("Bracketed symbol \"%s\" is not numeric", symName.c_str());
 			num = 0;
 			symbolError = true;
 		} else {
@@ -682,13 +682,13 @@ static uint32_t readBracketedMacroArgNum() {
 	c = peek();
 	shiftChar();
 	if (c != '>') {
-		error("Invalid character in bracketed macro argument %s\n", printChar(c));
+		error("Invalid character in bracketed macro argument %s", printChar(c));
 		return 0;
 	} else if (empty) {
-		error("Empty bracketed macro argument\n");
+		error("Empty bracketed macro argument");
 		return 0;
 	} else if (num == 0 && !symbolError) {
-		error("Invalid bracketed macro argument '\\<0>'\n");
+		error("Invalid bracketed macro argument '\\<0>'");
 		return 0;
 	} else {
 		return num;
@@ -699,13 +699,13 @@ static std::shared_ptr<std::string> readMacroArg(char name) {
 	if (name == '@') {
 		auto str = fstk_GetUniqueIDStr();
 		if (!str) {
-			error("'\\@' cannot be used outside of a macro or REPT/FOR block\n");
+			error("'\\@' cannot be used outside of a macro or REPT/FOR block");
 		}
 		return str;
 	} else if (name == '#') {
 		MacroArgs *macroArgs = fstk_GetCurrentMacroArgs();
 		if (!macroArgs) {
-			error("'\\#' cannot be used outside of a macro\n");
+			error("'\\#' cannot be used outside of a macro");
 			return nullptr;
 		}
 
@@ -721,13 +721,13 @@ static std::shared_ptr<std::string> readMacroArg(char name) {
 
 		MacroArgs *macroArgs = fstk_GetCurrentMacroArgs();
 		if (!macroArgs) {
-			error("'\\<%" PRIu32 ">' cannot be used outside of a macro\n", num);
+			error("'\\<%" PRIu32 ">' cannot be used outside of a macro", num);
 			return nullptr;
 		}
 
 		auto str = macroArgs->getArg(num);
 		if (!str) {
-			error("Macro argument '\\<%" PRId32 ">' not defined\n", num);
+			error("Macro argument '\\<%" PRId32 ">' not defined", num);
 		}
 		return str;
 	} else {
@@ -735,13 +735,13 @@ static std::shared_ptr<std::string> readMacroArg(char name) {
 
 		MacroArgs *macroArgs = fstk_GetCurrentMacroArgs();
 		if (!macroArgs) {
-			error("'\\%c' cannot be used outside of a macro\n", name);
+			error("'\\%c' cannot be used outside of a macro", name);
 			return nullptr;
 		}
 
 		auto str = macroArgs->getArg(name - '0');
 		if (!str) {
-			error("Macro argument '\\%c' not defined\n", name);
+			error("Macro argument '\\%c' not defined", name);
 		}
 		return str;
 	}
@@ -945,7 +945,7 @@ static void discardBlockComment() {
 
 		switch (c) {
 		case EOF:
-			error("Unterminated block comment\n");
+			error("Unterminated block comment");
 			return;
 		case '\r':
 			handleCRLF(c);
@@ -957,7 +957,7 @@ static void discardBlockComment() {
 			continue;
 		case '/':
 			if (peek() == '*') {
-				warning(WARNING_NESTED_COMMENT, "/* in block comment\n");
+				warning(WARNING_NESTED_COMMENT, "/* in block comment");
 			}
 			continue;
 		case '*':
@@ -999,7 +999,7 @@ static void discardLineContinuation() {
 		} else if (c == ';') {
 			discardComment();
 		} else {
-			error("Begun line continuation, but encountered character %s\n", printChar(c));
+			error("Begun line continuation, but encountered character %s", printChar(c));
 			break;
 		}
 	}
@@ -1041,7 +1041,7 @@ static uint32_t readFractionalPart(uint32_t integer) {
 				break;
 			}
 			if (divisor > (UINT32_MAX - (c - '0')) / 10) {
-				warning(WARNING_LARGE_CONSTANT, "Precision of fixed-point constant is too large\n");
+				warning(WARNING_LARGE_CONSTANT, "Precision of fixed-point constant is too large");
 				// Discard any additional digits
 				shiftChar();
 				while (c = peek(), (c >= '0' && c <= '9') || c == '_') {
@@ -1064,16 +1064,16 @@ static uint32_t readFractionalPart(uint32_t integer) {
 
 	if (precision == 0) {
 		if (state >= READFRACTIONALPART_PRECISION) {
-			error("Invalid fixed-point constant, no significant digits after 'q'\n");
+			error("Invalid fixed-point constant, no significant digits after 'q'");
 		}
 		precision = fixPrecision;
 	} else if (precision > 31) {
-		error("Fixed-point constant precision must be between 1 and 31\n");
+		error("Fixed-point constant precision must be between 1 and 31");
 		precision = fixPrecision;
 	}
 
 	if (integer >= (1ULL << (32 - precision))) {
-		warning(WARNING_LARGE_CONSTANT, "Magnitude of fixed-point constant is too large\n");
+		warning(WARNING_LARGE_CONSTANT, "Magnitude of fixed-point constant is too large");
 	}
 
 	// Cast to unsigned avoids undefined overflow behavior
@@ -1096,18 +1096,18 @@ static bool checkDigitErrors(char const *digits, size_t n, char const *type) {
 		char c = digits[i];
 
 		if (!isValidDigit(c)) {
-			error("Invalid digit for %s constant %s\n", type, printChar(c));
+			error("Invalid digit for %s constant %s", type, printChar(c));
 			return false;
 		}
 
 		if (c >= '0' && c < static_cast<char>(n + '0') && c != static_cast<char>(i + '0')) {
-			error("Changed digit for %s constant %s\n", type, printChar(c));
+			error("Changed digit for %s constant %s", type, printChar(c));
 			return false;
 		}
 
 		for (size_t j = i + 1; j < n; j++) {
 			if (c == digits[j]) {
-				error("Repeated digit for %s constant %s\n", type, printChar(c));
+				error("Repeated digit for %s constant %s", type, printChar(c));
 				return false;
 			}
 		}
@@ -1146,7 +1146,7 @@ static uint32_t readBinaryNumber() {
 			break;
 		}
 		if (value > (UINT32_MAX - bit) / 2) {
-			warning(WARNING_LARGE_CONSTANT, "Integer constant is too large\n");
+			warning(WARNING_LARGE_CONSTANT, "Integer constant is too large");
 		}
 		value = value * 2 + bit;
 
@@ -1154,7 +1154,7 @@ static uint32_t readBinaryNumber() {
 	}
 
 	if (empty) {
-		error("Invalid integer constant, no digits after '%%'\n");
+		error("Invalid integer constant, no digits after '%%'");
 	}
 
 	return value;
@@ -1176,7 +1176,7 @@ static uint32_t readOctalNumber() {
 		}
 
 		if (value > (UINT32_MAX - c) / 8) {
-			warning(WARNING_LARGE_CONSTANT, "Integer constant is too large\n");
+			warning(WARNING_LARGE_CONSTANT, "Integer constant is too large");
 		}
 		value = value * 8 + c;
 
@@ -1184,7 +1184,7 @@ static uint32_t readOctalNumber() {
 	}
 
 	if (empty) {
-		error("Invalid integer constant, no digits after '&'\n");
+		error("Invalid integer constant, no digits after '&'");
 	}
 
 	return value;
@@ -1206,7 +1206,7 @@ static uint32_t readDecimalNumber(int initial) {
 		}
 
 		if (value > (UINT32_MAX - c) / 10) {
-			warning(WARNING_LARGE_CONSTANT, "Integer constant is too large\n");
+			warning(WARNING_LARGE_CONSTANT, "Integer constant is too large");
 		}
 		value = value * 10 + c;
 
@@ -1214,7 +1214,7 @@ static uint32_t readDecimalNumber(int initial) {
 	}
 
 	if (empty) {
-		error("Invalid integer constant, no digits\n");
+		error("Invalid integer constant, no digits");
 	}
 
 	return value;
@@ -1240,7 +1240,7 @@ static uint32_t readHexNumber() {
 		}
 
 		if (value > (UINT32_MAX - c) / 16) {
-			warning(WARNING_LARGE_CONSTANT, "Integer constant is too large\n");
+			warning(WARNING_LARGE_CONSTANT, "Integer constant is too large");
 		}
 		value = value * 16 + c;
 
@@ -1248,7 +1248,7 @@ static uint32_t readHexNumber() {
 	}
 
 	if (empty) {
-		error("Invalid integer constant, no digits after '$'\n");
+		error("Invalid integer constant, no digits after '$'");
 	}
 
 	return value;
@@ -1286,11 +1286,11 @@ static uint32_t readGfxConstant() {
 	}
 
 	if (width == 0) {
-		error("Invalid graphics constant, no digits after '`'\n");
+		error("Invalid graphics constant, no digits after '`'");
 	} else if (width == 9) {
 		warning(
 		    WARNING_LARGE_CONSTANT,
-		    "Graphics constant is too long, only first 8 pixels considered\n"
+		    "Graphics constant is too long, only first 8 pixels considered"
 		);
 	}
 
@@ -1320,7 +1320,7 @@ static Token readIdentifier(char firstChar, bool raw) {
 	if (!raw) {
 		if (auto search = keywordDict.find(identifier); search != keywordDict.end()) {
 			if (search == ldio) {
-				warning(WARNING_OBSOLETE, "LDIO is deprecated; use LDH\n");
+				warning(WARNING_OBSOLETE, "LDIO is deprecated; use LDH");
 			}
 			return Token(search->second);
 		}
@@ -1338,7 +1338,7 @@ static Token readIdentifier(char firstChar, bool raw) {
 
 static std::shared_ptr<std::string> readInterpolation(size_t depth) {
 	if (depth > maxRecursionDepth) {
-		fatalerror("Recursion limit (%zu) exceeded\n", maxRecursionDepth);
+		fatalerror("Recursion limit (%zu) exceeded", maxRecursionDepth);
 	}
 
 	std::string fmtBuf;
@@ -1360,7 +1360,7 @@ static std::shared_ptr<std::string> readInterpolation(size_t depth) {
 			}
 			continue; // Restart, reading from the new buffer
 		} else if (c == EOF || c == '\r' || c == '\n' || c == '"') {
-			error("Missing }\n");
+			error("Missing }");
 			break;
 		} else if (c == '}') {
 			shiftChar();
@@ -1372,7 +1372,7 @@ static std::shared_ptr<std::string> readInterpolation(size_t depth) {
 			}
 			fmt.finishCharacters();
 			if (!fmt.isValid()) {
-				error("Invalid format spec '%s'\n", fmtBuf.c_str());
+				error("Invalid format spec '%s'", fmtBuf.c_str());
 			}
 			fmtBuf.clear(); // Now that format has been set, restart at beginning of string
 		} else {
@@ -1391,7 +1391,7 @@ static std::shared_ptr<std::string> readInterpolation(size_t depth) {
 		// Don't allow symbols that alias keywords without a '#' prefix.
 		error(
 		    "Interpolated symbol \"%s\" is a reserved keyword; add a '#' prefix to use it as a raw "
-		    "symbol\n",
+		    "symbol",
 		    fmtBuf.c_str()
 		);
 		return nullptr;
@@ -1401,9 +1401,9 @@ static std::shared_ptr<std::string> readInterpolation(size_t depth) {
 
 	if (!sym || !sym->isDefined()) {
 		if (sym_IsPurgedScoped(fmtBuf)) {
-			error("Interpolated symbol \"%s\" does not exist; it was purged\n", fmtBuf.c_str());
+			error("Interpolated symbol \"%s\" does not exist; it was purged", fmtBuf.c_str());
 		} else {
-			error("Interpolated symbol \"%s\" does not exist\n", fmtBuf.c_str());
+			error("Interpolated symbol \"%s\" does not exist", fmtBuf.c_str());
 		}
 	} else if (sym->type == SYM_EQUS) {
 		auto buf = std::make_shared<std::string>();
@@ -1414,7 +1414,7 @@ static std::shared_ptr<std::string> readInterpolation(size_t depth) {
 		fmt.appendNumber(*buf, sym->getConstantValue());
 		return buf;
 	} else {
-		error("Interpolated symbol \"%s\" is not a numeric or string symbol\n", fmtBuf.c_str());
+		error("Interpolated symbol \"%s\" is not a numeric or string symbol", fmtBuf.c_str());
 	}
 	return nullptr;
 }
@@ -1472,7 +1472,7 @@ static std::string readString(bool raw) {
 
 		// '\r', '\n' or EOF ends a single-line string early
 		if (c == EOF || (!multiline && (c == '\r' || c == '\n'))) {
-			error("Unterminated string\n");
+			error("Unterminated string");
 			return str;
 		}
 
@@ -1560,12 +1560,12 @@ static std::string readString(bool raw) {
 				continue; // Do not copy an additional character
 
 			case EOF: // Can't really print that one
-				error("Illegal character escape at end of input\n");
+				error("Illegal character escape at end of input");
 				c = '\\';
 				break;
 
 			default:
-				error("Illegal character escape %s\n", printChar(c));
+				error("Illegal character escape %s", printChar(c));
 				shiftChar();
 				break;
 			}
@@ -1616,7 +1616,7 @@ static void appendStringLiteral(std::string &str, bool raw) {
 
 		// '\r', '\n' or EOF ends a single-line string early
 		if (c == EOF || (!multiline && (c == '\r' || c == '\n'))) {
-			error("Unterminated string\n");
+			error("Unterminated string");
 			return;
 		}
 
@@ -1697,12 +1697,12 @@ static void appendStringLiteral(std::string &str, bool raw) {
 			}
 
 			case EOF: // Can't really print that one
-				error("Illegal character escape at end of input\n");
+				error("Illegal character escape at end of input");
 				c = '\\';
 				break;
 
 			default:
-				error("Illegal character escape %s\n", printChar(c));
+				error("Illegal character escape %s", printChar(c));
 				shiftChar();
 				break;
 			}
@@ -2077,9 +2077,9 @@ static Token yylex_NORMAL() {
 						garbage += ", ";
 						garbage += printChar(c);
 					}
-					error("Unknown characters %s\n", garbage.c_str());
+					error("Unknown characters %s", garbage.c_str());
 				} else {
-					error("Unknown character %s\n", printChar(c));
+					error("Unknown character %s", printChar(c));
 				}
 			}
 		}
@@ -2203,7 +2203,7 @@ backslash:
 				continue;
 
 			case EOF: // Can't really print that one
-				error("Illegal character escape at end of input\n");
+				error("Illegal character escape at end of input");
 				c = '\\';
 				break;
 
@@ -2211,7 +2211,7 @@ backslash:
 				// '\#', and '\0'-'\9' should not occur here.
 
 			default:
-				error("Illegal character escape %s\n", printChar(c));
+				error("Illegal character escape %s", printChar(c));
 				break;
 			}
 			[[fallthrough]];
@@ -2293,7 +2293,7 @@ static Token skipIfBlock(bool toEndc) {
 				case T_(POP_ELIF):
 					if (lexer_ReachedELSEBlock()) {
 						// This should be redundant, as the parser handles this error first.
-						fatalerror("Found ELIF after an ELSE block\n"); // LCOV_EXCL_LINE
+						fatalerror("Found ELIF after an ELSE block"); // LCOV_EXCL_LINE
 					}
 					if (!toEndc && lexer_GetIFDepth() == startingDepth) {
 						return token;
@@ -2302,7 +2302,7 @@ static Token skipIfBlock(bool toEndc) {
 
 				case T_(POP_ELSE):
 					if (lexer_ReachedELSEBlock()) {
-						fatalerror("Found ELSE after an ELSE block\n");
+						fatalerror("Found ELSE after an ELSE block");
 					}
 					lexer_ReachELSEBlock();
 					if (!toEndc && lexer_GetIFDepth() == startingDepth) {
@@ -2552,7 +2552,7 @@ Capture lexer_CaptureRept() {
 		// Just consume characters until EOL or EOF
 		for (;; c = nextChar()) {
 			if (c == EOF) {
-				error("Unterminated REPT/FOR block\n");
+				error("Unterminated REPT/FOR block");
 				endCapture(capture);
 				capture.span.ptr = nullptr; // Indicates that it reached EOF before an ENDR
 				return capture;
@@ -2595,7 +2595,7 @@ Capture lexer_CaptureMacro() {
 		// Just consume characters until EOL or EOF
 		for (;; c = nextChar()) {
 			if (c == EOF) {
-				error("Unterminated macro definition\n");
+				error("Unterminated macro definition");
 				endCapture(capture);
 				capture.span.ptr = nullptr; // Indicates that it reached EOF before an ENDM
 				return capture;

--- a/src/asm/macro.cpp
+++ b/src/asm/macro.cpp
@@ -52,7 +52,7 @@ std::shared_ptr<std::string> MacroArgs::getAllArgs() const {
 
 void MacroArgs::appendArg(std::shared_ptr<std::string> arg) {
 	if (arg->empty()) {
-		warning(WARNING_EMPTY_MACRO_ARG, "Empty macro argument\n");
+		warning(WARNING_EMPTY_MACRO_ARG, "Empty macro argument");
 	}
 	args.push_back(arg);
 }
@@ -60,10 +60,10 @@ void MacroArgs::appendArg(std::shared_ptr<std::string> arg) {
 void MacroArgs::shiftArgs(int32_t count) {
 	if (size_t nbArgs = args.size();
 	    count > 0 && (static_cast<uint32_t>(count) > nbArgs || shift > nbArgs - count)) {
-		warning(WARNING_MACRO_SHIFT, "Cannot shift macro arguments past their end\n");
+		warning(WARNING_MACRO_SHIFT, "Cannot shift macro arguments past their end");
 		shift = nbArgs;
 	} else if (count < 0 && shift < static_cast<uint32_t>(-count)) {
-		warning(WARNING_MACRO_SHIFT, "Cannot shift macro arguments past their beginning\n");
+		warning(WARNING_MACRO_SHIFT, "Cannot shift macro arguments past their beginning");
 		shift = 0;
 	} else {
 		shift += count;

--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <memory>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -109,6 +110,19 @@ static void printUsage() {
 	);
 }
 // LCOV_EXCL_STOP
+
+[[gnu::format(printf, 1, 2), noreturn]]
+static void fatalWithUsage(char const *fmt, ...) {
+	va_list ap;
+	fputs("FATAL: ", stderr);
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	putc('\n', stderr);
+
+	printUsage();
+	exit(1);
+}
 
 int main(int argc, char *argv[]) {
 	time_t now = time(nullptr);
@@ -389,15 +403,9 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (argc == musl_optind) {
-		fputs(
-		    "FATAL: Please specify an input file (pass `-` to read from standard input)\n", stderr
-		);
-		printUsage();
-		exit(1);
+		fatalWithUsage("Please specify an input file (pass `-` to read from standard input)");
 	} else if (argc != musl_optind + 1) {
-		fputs("FATAL: More than one input file specified\n", stderr);
-		printUsage();
-		exit(1);
+		fatalWithUsage("More than one input file specified");
 	}
 
 	std::string mainFileName = argv[musl_optind];

--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -3,6 +3,7 @@
 #include "asm/main.hpp"
 
 #include <algorithm>
+#include <errno.h>
 #include <limits.h>
 #include <memory>
 #include <stdlib.h>
@@ -198,7 +199,9 @@ int main(int argc, char *argv[]) {
 				dependFileName = "<stdout>";
 			}
 			if (dependFile == nullptr) {
-				err("Failed to open dependfile \"%s\"", dependFileName); // LCOV_EXCL_LINE
+				// LCOV_EXCL_START
+				errx("Failed to open dependfile \"%s\": %s", dependFileName, strerror(errno));
+				// LCOV_EXCL_STOP
 			}
 			break;
 

--- a/src/asm/opt.cpp
+++ b/src/asm/opt.cpp
@@ -47,7 +47,7 @@ void opt_R(size_t newDepth) {
 
 void opt_W(char const *flag) {
 	if (warnings.processWarningFlag(flag) == "numeric-string") {
-		warning(WARNING_OBSOLETE, "Warning flag \"numeric-string\" is deprecated\n");
+		warning(WARNING_OBSOLETE, "Warning flag \"numeric-string\" is deprecated");
 	}
 }
 
@@ -57,7 +57,7 @@ void opt_Parse(char const *s) {
 		if (strlen(&s[1]) == 2) {
 			opt_B(&s[1]);
 		} else {
-			error("Must specify exactly 2 characters for option 'b'\n");
+			error("Must specify exactly 2 characters for option 'b'");
 		}
 		break;
 
@@ -65,7 +65,7 @@ void opt_Parse(char const *s) {
 		if (strlen(&s[1]) == 4) {
 			opt_G(&s[1]);
 		} else {
-			error("Must specify exactly 4 characters for option 'g'\n");
+			error("Must specify exactly 4 characters for option 'g'");
 		}
 		break;
 
@@ -76,14 +76,14 @@ void opt_Parse(char const *s) {
 
 			result = sscanf(&s[1], "%x", &padByte);
 			if (result != 1) {
-				error("Invalid argument for option 'p'\n");
+				error("Invalid argument for option 'p'");
 			} else if (padByte > 0xFF) {
-				error("Argument for option 'p' must be between 0 and 0xFF\n");
+				error("Argument for option 'p' must be between 0 and 0xFF");
 			} else {
 				opt_P(padByte);
 			}
 		} else {
-			error("Invalid argument for option 'p'\n");
+			error("Invalid argument for option 'p'");
 		}
 		break;
 
@@ -99,14 +99,14 @@ void opt_Parse(char const *s) {
 
 			result = sscanf(precisionArg, "%u", &precision);
 			if (result != 1) {
-				error("Invalid argument for option 'Q'\n");
+				error("Invalid argument for option 'Q'");
 			} else if (precision < 1 || precision > 31) {
-				error("Argument for option 'Q' must be between 1 and 31\n");
+				error("Argument for option 'Q' must be between 1 and 31");
 			} else {
 				opt_Q(precision);
 			}
 		} else {
-			error("Invalid argument for option 'Q'\n");
+			error("Invalid argument for option 'Q'");
 		}
 		break;
 
@@ -117,7 +117,7 @@ void opt_Parse(char const *s) {
 		}
 
 		if (s[0] == '\0') {
-			error("Missing argument to option 'r'\n");
+			error("Missing argument to option 'r'");
 			break;
 		}
 
@@ -125,9 +125,9 @@ void opt_Parse(char const *s) {
 		unsigned long newDepth = strtoul(s, &endptr, 10);
 
 		if (*endptr != '\0') {
-			error("Invalid argument to option 'r' (\"%s\")\n", s);
+			error("Invalid argument to option 'r' (\"%s\")", s);
 		} else if (errno == ERANGE) {
-			error("Argument to 'r' is out of range (\"%s\")\n", s);
+			error("Argument to 'r' is out of range (\"%s\")", s);
 		} else {
 			opt_R(newDepth);
 		}
@@ -138,12 +138,12 @@ void opt_Parse(char const *s) {
 		if (strlen(&s[1]) > 0) {
 			opt_W(&s[1]);
 		} else {
-			error("Must specify an argument for option 'W'\n");
+			error("Must specify an argument for option 'W'");
 		}
 		break;
 
 	default:
-		error("Unknown option '%c'\n", s[0]);
+		error("Unknown option '%c'", s[0]);
 		break;
 	}
 }
@@ -168,7 +168,7 @@ void opt_Push() {
 
 void opt_Pop() {
 	if (stack.empty()) {
-		error("No entries in the option stack\n");
+		error("No entries in the option stack");
 		return;
 	}
 
@@ -187,6 +187,6 @@ void opt_Pop() {
 
 void opt_CheckStack() {
 	if (!stack.empty()) {
-		warning(WARNING_UNMATCHED_DIRECTIVE, "`PUSHO` without corresponding `POPO`\n");
+		warning(WARNING_UNMATCHED_DIRECTIVE, "`PUSHO` without corresponding `POPO`");
 	}
 }

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -324,7 +325,9 @@ void out_WriteObject() {
 		file = stdout;
 	}
 	if (!file) {
-		err("Failed to open object file '%s'", objectFileName.c_str()); // LCOV_EXCL_LINE
+		// LCOV_EXCL_START
+		errx("Failed to open object file '%s': %s", objectFileName.c_str(), strerror(errno));
+		// LCOV_EXCL_STOP
 	}
 	Defer closeFile{[&] { fclose(file); }};
 
@@ -524,7 +527,9 @@ void out_WriteState(std::string name, std::vector<StateFeature> const &features)
 		file = stdout;
 	}
 	if (!file) {
-		err("Failed to open state file '%s'", name.c_str()); // LCOV_EXCL_LINE
+		// LCOV_EXCL_START
+		errx("Failed to open state file '%s': %s", name.c_str(), strerror(errno));
+		// LCOV_EXCL_STOP
 	}
 	Defer closeFile{[&] { fclose(file); }};
 

--- a/src/asm/output.cpp
+++ b/src/asm/output.cpp
@@ -73,7 +73,7 @@ static uint32_t getSectIDIfAny(Section *sect) {
 	}
 
 	// Every section that exists should be in `sectionMap`
-	fatalerror("Unknown section '%s'\n", sect->name.c_str()); // LCOV_EXCL_LINE
+	fatalerror("Unknown section '%s'", sect->name.c_str()); // LCOV_EXCL_LINE
 }
 
 static void writePatch(Patch const &patch, FILE *file) {

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -438,12 +438,12 @@ diff_mark:
 	  %empty // OK
 	| OP_ADD {
 		::error(
-		    "syntax error, unexpected + at the beginning of the line (is it a leftover diff mark?)\n"
+		    "syntax error, unexpected + at the beginning of the line (is it a leftover diff mark?)"
 		);
 	}
 	| OP_SUB {
 		::error(
-		    "syntax error, unexpected - at the beginning of the line (is it a leftover diff mark?)\n"
+		    "syntax error, unexpected - at the beginning of the line (is it a leftover diff mark?)"
 		);
 	}
 ;
@@ -488,11 +488,11 @@ if:
 elif:
 	POP_ELIF iconst NEWLINE {
 		if (lexer_GetIFDepth() == 0) {
-			fatalerror("Found ELIF outside of an IF construct\n");
+			fatalerror("Found ELIF outside of an IF construct");
 		}
 		if (lexer_RanIFBlock()) {
 			if (lexer_ReachedELSEBlock()) {
-				fatalerror("Found ELIF after an ELSE block\n");
+				fatalerror("Found ELIF after an ELSE block");
 			}
 			lexer_SetMode(LEXER_SKIP_TO_ENDC);
 		} else if ($2) {
@@ -506,11 +506,11 @@ elif:
 else:
 	POP_ELSE NEWLINE {
 		if (lexer_GetIFDepth() == 0) {
-			fatalerror("Found ELSE outside of an IF construct\n");
+			fatalerror("Found ELSE outside of an IF construct");
 		}
 		if (lexer_RanIFBlock()) {
 			if (lexer_ReachedELSEBlock()) {
-				fatalerror("Found ELSE after an ELSE block\n");
+				fatalerror("Found ELSE after an ELSE block");
 			}
 			lexer_SetMode(LEXER_SKIP_TO_ENDC);
 		} else {
@@ -695,7 +695,7 @@ align:
 align_spec:
 	uconst {
 		if ($1 > 16) {
-			::error("Alignment must be between 0 and 16, not %u\n", $1);
+			::error("Alignment must be between 0 and 16, not %u", $1);
 			$$.alignment = $$.alignOfs = 0;
 		} else {
 			$$.alignment = $1;
@@ -704,11 +704,11 @@ align_spec:
 	}
 	| uconst COMMA iconst {
 		if ($1 > 16) {
-			::error("Alignment must be between 0 and 16, not %u\n", $1);
+			::error("Alignment must be between 0 and 16, not %u", $1);
 			$$.alignment = $$.alignOfs = 0;
 		} else if ($3 <= -(1 << $1) || $3 >= 1 << $1) {
 			::error(
-			    "The absolute alignment offset (%" PRIu32 ") must be less than alignment size (%d)\n",
+			    "The absolute alignment offset (%" PRIu32 ") must be less than alignment size (%d)",
 			    static_cast<uint32_t>($3 < 0 ? -$3 : $3),
 			    1 << $1
 			);
@@ -779,13 +779,13 @@ endsection:
 
 fail:
 	POP_FAIL string {
-		fatalerror("%s\n", $2.c_str());
+		fatalerror("%s", $2.c_str());
 	}
 ;
 
 warn:
 	POP_WARN string {
-		warning(WARNING_USER, "%s\n", $2.c_str());
+		warning(WARNING_USER, "%s", $2.c_str());
 	}
 ;
 
@@ -836,7 +836,7 @@ shift:
 		if (MacroArgs *macroArgs = fstk_GetCurrentMacroArgs(); macroArgs) {
 			macroArgs->shiftArgs($2);
 		} else {
-			::error("Cannot shift macro arguments outside of a macro\n");
+			::error("Cannot shift macro arguments outside of a macro");
 		}
 	}
 ;
@@ -1577,7 +1577,7 @@ relocexpr_no_str:
 	| OP_CHARSIZE LPAREN string RPAREN {
 		size_t charSize = charmap_CharSize($3);
 		if (charSize == 0) {
-			::error("CHARSIZE: No character mapping for \"%s\"\n", $3.c_str());
+			::error("CHARSIZE: No character mapping for \"%s\"", $3.c_str());
 		}
 		$$.makeNumber(charSize);
 	}
@@ -1589,13 +1589,13 @@ relocexpr_no_str:
 			} else {
 				warning(
 				    WARNING_BUILTIN_ARG,
-				    "CHARVAL: Index %" PRIu32 " is past the end of the character mapping\n",
+				    "CHARVAL: Index %" PRIu32 " is past the end of the character mapping",
 				    idx
 				);
 				$$.makeNumber(0);
 			}
 		} else {
-			::error("CHARVAL: No character mapping for \"%s\"\n", $3.c_str());
+			::error("CHARVAL: No character mapping for \"%s\"", $3.c_str());
 			$$.makeNumber(0);
 		}
 	}
@@ -1608,7 +1608,7 @@ uconst:
 	iconst {
 		$$ = $1;
 		if ($$ < 0) {
-			fatalerror("Constant must not be negative: %d\n", $$);
+			fatalerror("Constant must not be negative: %d", $$);
 		}
 	}
 ;
@@ -1626,7 +1626,7 @@ precision_arg:
 	| COMMA iconst {
 		$$ = $2;
 		if ($$ < 1 || $$ > 31) {
-			::error("Fixed-point precision must be between 1 and 31, not %" PRId32 "\n", $$);
+			::error("Fixed-point precision must be between 1 and 31, not %" PRId32, $$);
 			$$ = fix_Precision();
 		}
 	}
@@ -1675,9 +1675,9 @@ string_literal:
 		bool unique;
 		$$ = charmap_Reverse($3, unique);
 		if (!unique) {
-			::error("REVCHAR: Multiple character mappings to values\n");
+			::error("REVCHAR: Multiple character mappings to values");
 		} else if ($$.empty()) {
-			::error("REVCHAR: No character mapping to values\n");
+			::error("REVCHAR: No character mapping to values");
 		}
 	}
 	| OP_STRCAT LPAREN RPAREN {
@@ -1705,15 +1705,15 @@ string_literal:
 
 		if (!sym) {
 			if (sym_IsPurgedScoped($3)) {
-				fatalerror("Unknown symbol \"%s\"; it was purged\n", $3.c_str());
+				fatalerror("Unknown symbol \"%s\"; it was purged", $3.c_str());
 			} else {
-				fatalerror("Unknown symbol \"%s\"\n", $3.c_str());
+				fatalerror("Unknown symbol \"%s\"", $3.c_str());
 			}
 		}
 		Section const *section = sym->getSection();
 
 		if (!section) {
-			fatalerror("\"%s\" does not belong to any section\n", sym->name.c_str());
+			fatalerror("\"%s\" does not belong to any section", sym->name.c_str());
 		}
 		// Section names are capped by rgbasm's maximum string length,
 		// so this currently can't overflow.
@@ -1729,7 +1729,7 @@ string:
 		if (Symbol *sym = sym_FindScopedSymbol($1); sym && sym->type == SYM_EQUS) {
 			$$ = *sym->getEqus();
 		} else {
-			::error("'%s' is not a string symbol\n", $1.c_str());
+			::error("'%s' is not a string symbol", $1.c_str());
 		}
 	}
 ;
@@ -1833,7 +1833,7 @@ sect_org:
 	| LBRACK uconst RBRACK {
 		$$ = $2;
 		if ($$ < 0 || $$ > 0xFFFF) {
-			::error("Address $%x is not 16-bit\n", $$);
+			::error("Address $%x is not 16-bit", $$);
 			$$ = -1;
 		}
 	}
@@ -2088,7 +2088,7 @@ sm83_ldh:
 		if ($4.makeCheckHRAM()) {
 			warning(
 			    WARNING_OBSOLETE,
-			    "LDH is deprecated with values from $00 to $FF; use $FF00 to $FFFF\n"
+			    "LDH is deprecated with values from $00 to $FF; use $FF00 to $FFFF"
 			);
 		}
 
@@ -2099,7 +2099,7 @@ sm83_ldh:
 		if ($2.makeCheckHRAM()) {
 			warning(
 			    WARNING_OBSOLETE,
-			    "LDH is deprecated with values from $00 to $FF; use $FF00 to $FFFF\n"
+			    "LDH is deprecated with values from $00 to $FF; use $FF00 to $FFFF"
 			);
 		}
 
@@ -2126,7 +2126,7 @@ ff00_c_ind:
 	LBRACK relocexpr OP_ADD MODE_C RBRACK {
 		// This has to use `relocexpr`, not `iconst`, to avoid a shift/reduce conflict
 		if ($2.getConstVal() != 0xFF00) {
-			::error("Base value must be equal to $FF00 for $FF00+C\n");
+			::error("Base value must be equal to $FF00 for $FF00+C");
 		}
 	}
 ;
@@ -2148,7 +2148,7 @@ sm83_ld_hl:
 		sect_RelByte($5, 1);
 	}
 	| SM83_LD MODE_HL COMMA MODE_SP {
-		::error("LD HL, SP is not a valid instruction; use LD HL, SP + 0\n");
+		::error("LD HL, SP is not a valid instruction; use LD HL, SP + 0");
 	}
 	| SM83_LD MODE_HL COMMA reloc_16bit {
 		sect_ConstByte(0x01 | (REG_HL << 4));
@@ -2156,7 +2156,7 @@ sm83_ld_hl:
 	}
 	| SM83_LD MODE_HL COMMA reg_tt_no_af {
 		::error(
-		    "LD HL, %s is not a valid instruction; use LD H, %s and LD L, %s\n",
+		    "LD HL, %s is not a valid instruction; use LD H, %s and LD L, %s",
 		    reg_tt_names[$4],
 		    reg_tt_high_names[$4],
 		    reg_tt_low_names[$4]
@@ -2169,7 +2169,7 @@ sm83_ld_sp:
 		sect_ConstByte(0xF9);
 	}
 	| SM83_LD MODE_SP COMMA reg_bc_or_de {
-		::error("LD SP, %s is not a valid instruction\n", reg_tt_names[$4]);
+		::error("LD SP, %s is not a valid instruction", reg_tt_names[$4]);
 	}
 	| SM83_LD MODE_SP COMMA reloc_16bit {
 		sect_ConstByte(0x01 | (REG_SP << 4));
@@ -2193,7 +2193,7 @@ sm83_ld_c_ind:
 		sect_ConstByte(0xE2);
 	}
 	| SM83_LD c_ind COMMA MODE_A {
-		warning(WARNING_OBSOLETE, "LD [C], A is deprecated; use LDH [C], A\n");
+		warning(WARNING_OBSOLETE, "LD [C], A is deprecated; use LDH [C], A");
 		sect_ConstByte(0xE2);
 	}
 ;
@@ -2211,7 +2211,7 @@ sm83_ld_r_no_a:
 	}
 	| SM83_LD reg_r_no_a COMMA reg_r {
 		if ($2 == REG_HL_IND && $4 == REG_HL_IND) {
-			::error("LD [HL], [HL] is not a valid instruction\n");
+			::error("LD [HL], [HL] is not a valid instruction");
 		} else {
 			sect_ConstByte(0x40 | ($2 << 3) | $4);
 		}
@@ -2230,7 +2230,7 @@ sm83_ld_a:
 		sect_ConstByte(0xF2);
 	}
 	| SM83_LD reg_a COMMA c_ind {
-		warning(WARNING_OBSOLETE, "LD A, [C] is deprecated; use LDH A, [C]\n");
+		warning(WARNING_OBSOLETE, "LD A, [C] is deprecated; use LDH A, [C]");
 		sect_ConstByte(0xF2);
 	}
 	| SM83_LD reg_a COMMA reg_rr {
@@ -2249,7 +2249,7 @@ sm83_ld_ss:
 	}
 	| SM83_LD reg_bc_or_de COMMA reg_tt_no_af {
 		::error(
-		    "LD %s, %s is not a valid instruction; use LD %s, %s and LD %s, %s\n",
+		    "LD %s, %s is not a valid instruction; use LD %s, %s and LD %s, %s",
 		    reg_tt_names[$2],
 		    reg_tt_names[$4],
 		    reg_tt_high_names[$2],
@@ -2644,7 +2644,7 @@ hl_ind_dec:
 /******************** Semantic actions ********************/
 
 void yy::parser::error(std::string const &str) {
-	::error("%s\n", str.c_str());
+	::error("%s", str.c_str());
 }
 
 static uint32_t strToNum(std::vector<int32_t> const &s) {
@@ -2656,7 +2656,7 @@ static uint32_t strToNum(std::vector<int32_t> const &s) {
 		return static_cast<uint32_t>(s[0]);
 	}
 
-	warning(WARNING_OBSOLETE, "Treating multi-unit strings as numbers is deprecated\n");
+	warning(WARNING_OBSOLETE, "Treating multi-unit strings as numbers is deprecated");
 
 	for (int32_t v : s) {
 		if (!checkNBit(v, 8, "All character units")) {
@@ -2675,7 +2675,7 @@ static uint32_t strToNum(std::vector<int32_t> const &s) {
 }
 
 static void errorInvalidUTF8Byte(uint8_t byte, char const *functionName) {
-	error("%s: Invalid UTF-8 byte 0x%02hhX\n", functionName, byte);
+	error("%s: Invalid UTF-8 byte 0x%02hhX", functionName, byte);
 }
 
 static size_t strlenUTF8(std::string const &str, bool printErrors) {
@@ -2702,7 +2702,7 @@ static size_t strlenUTF8(std::string const &str, bool printErrors) {
 	// Check for partial code point.
 	if (state != 0) {
 		if (printErrors) {
-			error("STRLEN: Incomplete UTF-8 character\n");
+			error("STRLEN: Incomplete UTF-8 character");
 		}
 		len++;
 	}
@@ -2736,7 +2736,7 @@ static std::string strsliceUTF8(std::string const &str, uint32_t start, uint32_t
 	if (!ptr[index] && start > curIdx) {
 		warning(
 		    WARNING_BUILTIN_ARG,
-		    "STRSLICE: Start index %" PRIu32 " is past the end of the string\n",
+		    "STRSLICE: Start index %" PRIu32 " is past the end of the string",
 		    start
 		);
 	}
@@ -2759,14 +2759,14 @@ static std::string strsliceUTF8(std::string const &str, uint32_t start, uint32_t
 
 	// Check for partial code point.
 	if (state != 0) {
-		error("STRSLICE: Incomplete UTF-8 character\n");
+		error("STRSLICE: Incomplete UTF-8 character");
 		curIdx++;
 	}
 
 	if (curIdx < stop) {
 		warning(
 		    WARNING_BUILTIN_ARG,
-		    "STRSLICE: Stop index %" PRIu32 " is past the end of the string\n",
+		    "STRSLICE: Stop index %" PRIu32 " is past the end of the string",
 		    stop
 		);
 	}
@@ -2799,7 +2799,7 @@ static std::string strsubUTF8(std::string const &str, uint32_t pos, uint32_t len
 	// "Length too big" warning below if the length is nonzero.
 	if (!ptr[index] && pos > curPos) {
 		warning(
-		    WARNING_BUILTIN_ARG, "STRSUB: Position %" PRIu32 " is past the end of the string\n", pos
+		    WARNING_BUILTIN_ARG, "STRSUB: Position %" PRIu32 " is past the end of the string", pos
 		);
 	}
 
@@ -2822,12 +2822,12 @@ static std::string strsubUTF8(std::string const &str, uint32_t pos, uint32_t len
 
 	// Check for partial code point.
 	if (state != 0) {
-		error("STRSUB: Incomplete UTF-8 character\n");
+		error("STRSUB: Incomplete UTF-8 character");
 		curLen++;
 	}
 
 	if (curLen < len) {
-		warning(WARNING_BUILTIN_ARG, "STRSUB: Length too big: %" PRIu32 "\n", len);
+		warning(WARNING_BUILTIN_ARG, "STRSUB: Length too big: %" PRIu32, len);
 	}
 
 	return std::string(ptr + startIndex, ptr + index);
@@ -2856,7 +2856,7 @@ static std::string strcharUTF8(std::string const &str, uint32_t idx) {
 	if (!charmap_ConvertNext(view, nullptr)) {
 		warning(
 		    WARNING_BUILTIN_ARG,
-		    "STRCHAR: Index %" PRIu32 " is past the end of the string\n",
+		    "STRCHAR: Index %" PRIu32 " is past the end of the string",
 		    idx
 		);
 	}
@@ -2879,7 +2879,7 @@ static std::string charsubUTF8(std::string const &str, uint32_t pos) {
 	if (!charmap_ConvertNext(view, nullptr)) {
 		warning(
 		    WARNING_BUILTIN_ARG,
-		    "CHARSUB: Position %" PRIu32 " is past the end of the string\n",
+		    "CHARSUB: Position %" PRIu32 " is past the end of the string",
 		    pos
 		);
 	}
@@ -2922,7 +2922,7 @@ static uint32_t adjustNegativeIndex(int32_t idx, size_t len, char const *functio
 		idx += len;
 	}
 	if (idx < 0) {
-		warning(WARNING_BUILTIN_ARG, "%s: Index starts at 0\n", functionName);
+		warning(WARNING_BUILTIN_ARG, "%s: Index starts at 0", functionName);
 		idx = 0;
 	}
 	return static_cast<uint32_t>(idx);
@@ -2935,7 +2935,7 @@ static uint32_t adjustNegativePos(int32_t pos, size_t len, char const *functionN
 		pos += len + 1;
 	}
 	if (pos < 1) {
-		warning(WARNING_BUILTIN_ARG, "%s: Position starts at 1\n", functionName);
+		warning(WARNING_BUILTIN_ARG, "%s: Position starts at 1", functionName);
 		pos = 1;
 	}
 	return static_cast<uint32_t>(pos);
@@ -2943,7 +2943,7 @@ static uint32_t adjustNegativePos(int32_t pos, size_t len, char const *functionN
 
 static std::string strrpl(std::string_view str, std::string const &old, std::string const &rep) {
 	if (old.empty()) {
-		warning(WARNING_EMPTY_STRRPL, "STRRPL: Cannot replace an empty string\n");
+		warning(WARNING_EMPTY_STRRPL, "STRRPL: Cannot replace an empty string");
 		return std::string(str);
 	}
 
@@ -2994,13 +2994,13 @@ static std::string
 		}
 
 		if (fmt.isEmpty()) {
-			error("STRFMT: Illegal '%%' at end of format string\n");
+			error("STRFMT: Illegal '%%' at end of format string");
 			str += '%';
 			break;
 		}
 
 		if (!fmt.isValid()) {
-			error("STRFMT: Invalid format spec for argument %zu\n", argIndex + 1);
+			error("STRFMT: Invalid format spec for argument %zu", argIndex + 1);
 			str += '%';
 		} else if (argIndex >= args.size()) {
 			// Will warn after formatting is done.
@@ -3015,10 +3015,10 @@ static std::string
 	}
 
 	if (argIndex < args.size()) {
-		error("STRFMT: %zu unformatted argument(s)\n", args.size() - argIndex);
+		error("STRFMT: %zu unformatted argument(s)", args.size() - argIndex);
 	} else if (argIndex > args.size()) {
 		error(
-		    "STRFMT: Not enough arguments for format spec, got: %zu, need: %zu\n",
+		    "STRFMT: Not enough arguments for format spec, got: %zu, need: %zu",
 		    args.size(),
 		    argIndex
 		);
@@ -3041,12 +3041,12 @@ static void compoundAssignment(std::string const &symName, RPNCommand op, int32_
 static void failAssert(AssertionType type) {
 	switch (type) {
 	case ASSERT_FATAL:
-		fatalerror("Assertion failed\n");
+		fatalerror("Assertion failed");
 	case ASSERT_ERROR:
-		error("Assertion failed\n");
+		error("Assertion failed");
 		break;
 	case ASSERT_WARN:
-		warning(WARNING_ASSERT, "Assertion failed\n");
+		warning(WARNING_ASSERT, "Assertion failed");
 		break;
 	}
 }
@@ -3054,12 +3054,12 @@ static void failAssert(AssertionType type) {
 static void failAssertMsg(AssertionType type, std::string const &message) {
 	switch (type) {
 	case ASSERT_FATAL:
-		fatalerror("Assertion failed: %s\n", message.c_str());
+		fatalerror("Assertion failed: %s", message.c_str());
 	case ASSERT_ERROR:
-		error("Assertion failed: %s\n", message.c_str());
+		error("Assertion failed: %s", message.c_str());
 		break;
 	case ASSERT_WARN:
-		warning(WARNING_ASSERT, "Assertion failed: %s\n", message.c_str());
+		warning(WARNING_ASSERT, "Assertion failed: %s", message.c_str());
 		break;
 	}
 }

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -394,9 +394,7 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 			break;
 		case RPN_SHL:
 			if (rval < 0) {
-				warning(
-				    WARNING_SHIFT_AMOUNT, "Shifting left by negative amount %" PRId32, rval
-				);
+				warning(WARNING_SHIFT_AMOUNT, "Shifting left by negative amount %" PRId32, rval);
 			}
 
 			if (rval >= 32) {
@@ -411,9 +409,7 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 			}
 
 			if (rval < 0) {
-				warning(
-				    WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32, rval
-				);
+				warning(WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32, rval);
 			}
 
 			if (rval >= 32) {
@@ -424,9 +420,7 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 			break;
 		case RPN_USHR:
 			if (rval < 0) {
-				warning(
-				    WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32, rval
-				);
+				warning(WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32, rval);
 			}
 
 			if (rval >= 32) {
@@ -593,8 +587,7 @@ bool checkNBit(int32_t v, uint8_t n, char const *name) {
 	if (v < -(1 << n) || v >= 1 << n) {
 		warning(
 		    WARNING_TRUNCATION_1,
-		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit"
-		                    : "%s must be %u-bit",
+		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit" : "%s must be %u-bit",
 		    name ? name : "Expression",
 		    n
 		);
@@ -603,8 +596,7 @@ bool checkNBit(int32_t v, uint8_t n, char const *name) {
 	if (v < -(1 << (n - 1))) {
 		warning(
 		    WARNING_TRUNCATION_2,
-		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit"
-		                    : "%s must be %u-bit",
+		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit" : "%s must be %u-bit",
 		    name ? name : "Expression",
 		    n
 		);

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -39,7 +39,7 @@ uint8_t *Expression::reserveSpace(uint32_t size, uint32_t patchSize) {
 
 int32_t Expression::getConstVal() const {
 	if (!isKnown()) {
-		error("Expected constant expression: %s\n", data.get<std::string>().c_str());
+		error("Expected constant expression: %s", data.get<std::string>().c_str());
 		return 0;
 	}
 	return value();
@@ -73,10 +73,10 @@ void Expression::makeNumber(uint32_t value) {
 void Expression::makeSymbol(std::string const &symName) {
 	clear();
 	if (Symbol *sym = sym_FindScopedSymbol(symName); sym_IsPC(sym) && !sect_GetSymbolSection()) {
-		error("PC has no value outside of a section\n");
+		error("PC has no value outside of a section");
 		data = 0;
 	} else if (sym && !sym->isNumeric() && !sym->isLabel()) {
-		error("'%s' is not a numeric symbol\n", symName.c_str());
+		error("'%s' is not a numeric symbol", symName.c_str());
 		data = 0;
 	} else if (!sym || !sym->isConstant()) {
 		isSymbol = true;
@@ -103,7 +103,7 @@ void Expression::makeBankSymbol(std::string const &symName) {
 	if (Symbol const *sym = sym_FindScopedSymbol(symName); sym_IsPC(sym)) {
 		// The @ symbol is treated differently.
 		if (!currentSection) {
-			error("PC has no bank outside of a section\n");
+			error("PC has no bank outside of a section");
 			data = 1;
 		} else if (currentSection->bank == UINT32_MAX) {
 			data = "Current section's bank is not known";
@@ -114,7 +114,7 @@ void Expression::makeBankSymbol(std::string const &symName) {
 		}
 		return;
 	} else if (sym && !sym->isLabel()) {
-		error("BANK argument must be a label\n");
+		error("BANK argument must be a label");
 		data = 1;
 	} else {
 		sym = sym_Ref(symName);
@@ -395,29 +395,29 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 		case RPN_SHL:
 			if (rval < 0) {
 				warning(
-				    WARNING_SHIFT_AMOUNT, "Shifting left by negative amount %" PRId32 "\n", rval
+				    WARNING_SHIFT_AMOUNT, "Shifting left by negative amount %" PRId32, rval
 				);
 			}
 
 			if (rval >= 32) {
-				warning(WARNING_SHIFT_AMOUNT, "Shifting left by large amount %" PRId32 "\n", rval);
+				warning(WARNING_SHIFT_AMOUNT, "Shifting left by large amount %" PRId32, rval);
 			}
 
 			data = op_shift_left(lval, rval);
 			break;
 		case RPN_SHR:
 			if (lval < 0) {
-				warning(WARNING_SHIFT, "Shifting right negative value %" PRId32 "\n", lval);
+				warning(WARNING_SHIFT, "Shifting right negative value %" PRId32, lval);
 			}
 
 			if (rval < 0) {
 				warning(
-				    WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32 "\n", rval
+				    WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32, rval
 				);
 			}
 
 			if (rval >= 32) {
-				warning(WARNING_SHIFT_AMOUNT, "Shifting right by large amount %" PRId32 "\n", rval);
+				warning(WARNING_SHIFT_AMOUNT, "Shifting right by large amount %" PRId32, rval);
 			}
 
 			data = op_shift_right(lval, rval);
@@ -425,12 +425,12 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 		case RPN_USHR:
 			if (rval < 0) {
 				warning(
-				    WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32 "\n", rval
+				    WARNING_SHIFT_AMOUNT, "Shifting right by negative amount %" PRId32, rval
 				);
 			}
 
 			if (rval >= 32) {
-				warning(WARNING_SHIFT_AMOUNT, "Shifting right by large amount %" PRId32 "\n", rval);
+				warning(WARNING_SHIFT_AMOUNT, "Shifting right by large amount %" PRId32, rval);
 			}
 
 			data = op_shift_right_unsigned(lval, rval);
@@ -440,13 +440,13 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 			break;
 		case RPN_DIV:
 			if (rval == 0) {
-				fatalerror("Division by zero\n");
+				fatalerror("Division by zero");
 			}
 
 			if (lval == INT32_MIN && rval == -1) {
 				warning(
 				    WARNING_DIV,
-				    "Division of %" PRId32 " by -1 yields %" PRId32 "\n",
+				    "Division of %" PRId32 " by -1 yields %" PRId32,
 				    INT32_MIN,
 				    INT32_MIN
 				);
@@ -457,7 +457,7 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 			break;
 		case RPN_MOD:
 			if (rval == 0) {
-				fatalerror("Modulo by zero\n");
+				fatalerror("Modulo by zero");
 			}
 
 			if (lval == INT32_MIN && rval == -1) {
@@ -468,7 +468,7 @@ void Expression::makeBinaryOp(RPNCommand op, Expression &&src1, Expression const
 			break;
 		case RPN_EXP:
 			if (rval < 0) {
-				fatalerror("Exponentiation by negative power\n");
+				fatalerror("Exponentiation by negative power");
 			}
 
 			data = op_exponent(lval, rval);
@@ -551,7 +551,7 @@ bool Expression::makeCheckHRAM() {
 		// That range is valid, but deprecated
 		return true;
 	} else {
-		error("Source address $%" PRIx32 " not between $FF00 to $FFFF\n", val);
+		error("Source address $%" PRIx32 " not between $FF00 to $FFFF", val);
 	}
 	return false;
 }
@@ -561,7 +561,7 @@ void Expression::makeCheckRST() {
 		*reserveSpace(1) = RPN_RST;
 	} else if (int32_t val = value(); val & ~0x38) {
 		// A valid RST address must be masked with 0x38
-		error("Invalid address $%" PRIx32 " for RST\n", val);
+		error("Invalid address $%" PRIx32 " for RST", val);
 	}
 }
 
@@ -575,7 +575,7 @@ void Expression::makeCheckBitIndex(uint8_t mask) {
 	} else if (int32_t val = value(); val & ~0x07) {
 		// A valid bit index must be masked with 0x07
 		static char const *instructions[4] = {"instruction", "BIT", "RES", "SET"};
-		error("Invalid bit index %" PRId32 " for %s\n", val, instructions[mask >> 6]);
+		error("Invalid bit index %" PRId32 " for %s", val, instructions[mask >> 6]);
 	}
 }
 
@@ -593,8 +593,8 @@ bool checkNBit(int32_t v, uint8_t n, char const *name) {
 	if (v < -(1 << n) || v >= 1 << n) {
 		warning(
 		    WARNING_TRUNCATION_1,
-		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit\n"
-		                    : "%s must be %u-bit\n",
+		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit"
+		                    : "%s must be %u-bit",
 		    name ? name : "Expression",
 		    n
 		);
@@ -603,8 +603,8 @@ bool checkNBit(int32_t v, uint8_t n, char const *name) {
 	if (v < -(1 << (n - 1))) {
 		warning(
 		    WARNING_TRUNCATION_2,
-		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit\n"
-		                    : "%s must be %u-bit\n",
+		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit"
+		                    : "%s must be %u-bit",
 		    name ? name : "Expression",
 		    n
 		);

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -587,18 +587,20 @@ bool checkNBit(int32_t v, uint8_t n, char const *name) {
 	if (v < -(1 << n) || v >= 1 << n) {
 		warning(
 		    WARNING_TRUNCATION_1,
-		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit" : "%s must be %u-bit",
+		    "%s must be %u-bit%s",
 		    name ? name : "Expression",
-		    n
+		    n,
+		    n == 8 && !name ? "; use LOW() to force 8-bit" : ""
 		);
 		return false;
 	}
 	if (v < -(1 << (n - 1))) {
 		warning(
 		    WARNING_TRUNCATION_2,
-		    n == 8 && !name ? "%s must be %u-bit; use LOW() to force 8-bit" : "%s must be %u-bit",
+		    "%s must be %u-bit%s",
 		    name ? name : "Expression",
-		    n
+		    n,
+		    n == 8 && !name ? "; use LOW() to force 8-bit" : ""
 		);
 		return false;
 	}

--- a/src/asm/section.cpp
+++ b/src/asm/section.cpp
@@ -72,8 +72,7 @@ static bool requireCodeSection() {
 	}
 
 	error(
-	    "Section '%s' cannot contain code or data (not ROM0 or ROMX)",
-	    currentSection->name.c_str()
+	    "Section '%s' cannot contain code or data (not ROM0 or ROMX)", currentSection->name.c_str()
 	);
 	return false;
 }
@@ -172,8 +171,7 @@ static unsigned int
 		// If both are fixed, they must be the same
 		if (sect.org != UINT32_MAX && sect.org != curOrg) {
 			sectError(
-			    "Section already declared as fixed at incompatible address $%04" PRIx32,
-			    sect.org
+			    "Section already declared as fixed at incompatible address $%04" PRIx32, sect.org
 			);
 		} else if (sect.align != 0 && (mask(sect.align) & (curOrg - sect.alignOfs))) {
 			sectError(
@@ -503,9 +501,7 @@ void sect_SetLoadSection(
 
 void sect_EndLoadSection(char const *cause) {
 	if (cause) {
-		warning(
-		    WARNING_UNTERMINATED_LOAD, "`LOAD` block without `ENDL` terminated by `%s`", cause
-		);
+		warning(WARNING_UNTERMINATED_LOAD, "`LOAD` block without `ENDL` terminated by `%s`", cause);
 	}
 
 	if (!currentLoadSection) {
@@ -908,16 +904,12 @@ void sect_BinaryFile(std::string const &name, int32_t startPos) {
 		fseek(file, startPos, SEEK_SET);
 	} else {
 		if (errno != ESPIPE) {
-			error(
-			    "Error determining size of INCBIN file '%s': %s", name.c_str(), strerror(errno)
-			);
+			error("Error determining size of INCBIN file '%s': %s", name.c_str(), strerror(errno));
 		}
 		// The file isn't seekable, so we'll just skip bytes one at a time
 		while (startPos--) {
 			if (fgetc(file) == EOF) {
-				error(
-				    "Specified start position is greater than length of file '%s'", name.c_str()
-				);
+				error("Specified start position is greater than length of file '%s'", name.c_str());
 				return;
 			}
 		}
@@ -987,16 +979,12 @@ void sect_BinaryFileSlice(std::string const &name, int32_t startPos, int32_t len
 		fseek(file, startPos, SEEK_SET);
 	} else {
 		if (errno != ESPIPE) {
-			error(
-			    "Error determining size of INCBIN file '%s': %s", name.c_str(), strerror(errno)
-			);
+			error("Error determining size of INCBIN file '%s': %s", name.c_str(), strerror(errno));
 		}
 		// The file isn't seekable, so we'll just skip bytes one at a time
 		while (startPos--) {
 			if (fgetc(file) == EOF) {
-				error(
-				    "Specified start position is greater than length of file '%s'", name.c_str()
-				);
+				error("Specified start position is greater than length of file '%s'", name.c_str());
 				return;
 			}
 		}

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -3,6 +3,7 @@
 #include "asm/symbol.hpp"
 
 #include <algorithm>
+#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <unordered_map>
@@ -666,7 +667,7 @@ void sym_Init(time_t now) {
 
 	// LCOV_EXCL_START
 	if (now == static_cast<time_t>(-1)) {
-		warn("Failed to determine current time");
+		warnx("Failed to determine current time: %s", strerror(errno));
 		// Fall back by pretending we are at the Epoch
 		now = 0;
 	}

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -52,14 +52,14 @@ static int32_t NARGCallback() {
 	if (MacroArgs const *macroArgs = fstk_GetCurrentMacroArgs(); macroArgs) {
 		return macroArgs->nbArgs();
 	} else {
-		error("_NARG has no value outside of a macro\n");
+		error("_NARG has no value outside of a macro");
 		return 0;
 	}
 }
 
 static std::shared_ptr<std::string> globalScopeCallback() {
 	if (!globalScope) {
-		error("\".\" has no value outside of a label scope\n");
+		error("\".\" has no value outside of a label scope");
 		return std::make_shared<std::string>("");
 	}
 	return std::make_shared<std::string>(globalScope->name);
@@ -67,7 +67,7 @@ static std::shared_ptr<std::string> globalScopeCallback() {
 
 static std::shared_ptr<std::string> localScopeCallback() {
 	if (!localScope) {
-		error("\"..\" has no value outside of a local label scope\n");
+		error("\"..\" has no value outside of a local label scope");
 		return std::make_shared<std::string>("");
 	}
 	return std::make_shared<std::string>(localScope->name);
@@ -112,6 +112,7 @@ std::shared_ptr<std::string> Symbol::getEqus() const {
 }
 
 static void dumpFilename(Symbol const &sym) {
+	fputs(" at ", stderr);
 	if (sym.src) {
 		sym.src->dump(sym.fileLine);
 		putc('\n', stderr);
@@ -141,13 +142,12 @@ static bool isValidIdentifier(std::string const &s) {
 static void alreadyDefinedError(Symbol const &sym, char const *asType) {
 	if (sym.isBuiltin && !sym_FindScopedValidSymbol(sym.name)) {
 		// `DEF()` would return false, so we should not claim the symbol is already defined
-		error("'%s' is reserved for a built-in symbol\n", sym.name.c_str());
+		error("'%s' is reserved for a built-in symbol", sym.name.c_str());
 	} else {
-		error("'%s' already defined", sym.name.c_str());
+		errorNoNewline("'%s' already defined", sym.name.c_str());
 		if (asType) {
 			fprintf(stderr, " as %s", asType);
 		}
-		fputs(" at ", stderr);
 		dumpFilename(sym);
 		if (sym.type == SYM_EQUS) {
 			if (std::string const &contents = *sym.getEqus(); isValidIdentifier(contents)) {
@@ -165,9 +165,9 @@ static void redefinedError(Symbol const &sym) {
 	assume(sym.isBuiltin);
 	if (!sym_FindScopedValidSymbol(sym.name)) {
 		// `DEF()` would return false, so we should not imply the symbol is already defined
-		error("'%s' is reserved for a built-in symbol\n", sym.name.c_str());
+		error("'%s' is reserved for a built-in symbol", sym.name.c_str());
 	} else {
-		error("Built-in symbol '%s' cannot be redefined\n", sym.name.c_str());
+		error("Built-in symbol '%s' cannot be redefined", sym.name.c_str());
 	}
 }
 
@@ -216,12 +216,12 @@ static bool isAutoScoped(std::string const &symName) {
 
 	// Check for nothing after the dot
 	if (dotPos == symName.length() - 1) {
-		fatalerror("'%s' is a nonsensical reference to an empty local label\n", symName.c_str());
+		fatalerror("'%s' is a nonsensical reference to an empty local label", symName.c_str());
 	}
 
 	// Check for more than one dot
 	if (symName.find('.', dotPos + 1) != std::string::npos) {
-		fatalerror("'%s' is a nonsensical reference to a nested local label\n", symName.c_str());
+		fatalerror("'%s' is a nonsensical reference to a nested local label", symName.c_str());
 	}
 
 	// Check for already-qualified local label
@@ -231,7 +231,7 @@ static bool isAutoScoped(std::string const &symName) {
 
 	// Check for unqualifiable local label
 	if (!globalScope) {
-		fatalerror("Unqualified local label '%s' in main scope\n", symName.c_str());
+		fatalerror("Unqualified local label '%s' in main scope", symName.c_str());
 	}
 
 	return true;
@@ -280,19 +280,19 @@ void sym_Purge(std::string const &symName) {
 
 	if (!sym) {
 		if (sym_IsPurgedScoped(symName)) {
-			error("'%s' was already purged\n", symName.c_str());
+			error("'%s' was already purged", symName.c_str());
 		} else {
-			error("'%s' not defined\n", symName.c_str());
+			error("'%s' not defined", symName.c_str());
 		}
 	} else if (sym->isBuiltin) {
-		error("Built-in symbol '%s' cannot be purged\n", symName.c_str());
+		error("Built-in symbol '%s' cannot be purged", symName.c_str());
 	} else if (sym->ID != UINT32_MAX) {
-		error("Symbol \"%s\" is referenced and thus cannot be purged\n", symName.c_str());
+		error("Symbol \"%s\" is referenced and thus cannot be purged", symName.c_str());
 	} else {
 		if (sym->isExported) {
-			warning(WARNING_PURGE_1, "Purging an exported symbol \"%s\"\n", symName.c_str());
+			warning(WARNING_PURGE_1, "Purging an exported symbol \"%s\"", symName.c_str());
 		} else if (sym->isLabel()) {
-			warning(WARNING_PURGE_2, "Purging a label \"%s\"\n", symName.c_str());
+			warning(WARNING_PURGE_2, "Purging a label \"%s\"", symName.c_str());
 		}
 		// Do not keep a reference to the label after purging it
 		if (sym == globalScope) {
@@ -332,12 +332,12 @@ uint32_t Symbol::getConstantValue() const {
 
 	if (sym_IsPC(this)) {
 		if (!getSection()) {
-			error("PC has no value outside of a section\n");
+			error("PC has no value outside of a section");
 		} else {
-			error("PC does not have a constant value; the current section is not fixed\n");
+			error("PC does not have a constant value; the current section is not fixed");
 		}
 	} else {
-		error("\"%s\" does not have a constant value\n", name.c_str());
+		error("\"%s\" does not have a constant value", name.c_str());
 	}
 	return 0;
 }
@@ -372,7 +372,7 @@ static Symbol *createNonrelocSymbol(std::string const &symName, bool numeric) {
 		return nullptr; // Don't allow overriding the symbol, that'd be bad!
 	} else if (!numeric) {
 		// The symbol has already been referenced, but it's not allowed
-		error("'%s' already referenced at ", symName.c_str());
+		errorNoNewline("'%s' already referenced", symName.c_str());
 		dumpFilename(*sym);
 		return nullptr; // Don't allow overriding the symbol, that'd be bad!
 	}
@@ -438,7 +438,7 @@ Symbol *sym_RedefString(std::string const &symName, std::shared_ptr<std::string>
 		if (sym->isDefined()) {
 			alreadyDefinedError(*sym, "non-EQUS");
 		} else {
-			error("'%s' already referenced at ", symName.c_str());
+			errorNoNewline("'%s' already referenced", symName.c_str());
 			dumpFilename(*sym);
 		}
 		return nullptr;
@@ -494,7 +494,7 @@ static Symbol *addLabel(std::string const &symName) {
 	sym->section = sect_GetSymbolSection();
 
 	if (sym && !sym->section) {
-		error("Label \"%s\" created outside of a SECTION\n", symName.c_str());
+		error("Label \"%s\" created outside of a SECTION", symName.c_str());
 	}
 
 	return sym;
@@ -550,7 +550,7 @@ std::string sym_MakeAnonLabelName(uint32_t ofs, bool neg) {
 		if (ofs > anonLabelID) {
 			error(
 			    "Reference to anonymous label %" PRIu32 " before, when only %" PRIu32
-			    " ha%s been created so far\n",
+			    " ha%s been created so far",
 			    ofs,
 			    anonLabelID,
 			    anonLabelID == 1 ? "s" : "ve"
@@ -564,7 +564,7 @@ std::string sym_MakeAnonLabelName(uint32_t ofs, bool neg) {
 			// LCOV_EXCL_START
 			error(
 			    "Reference to anonymous label %" PRIu32 " after, when only %" PRIu32
-			    " may still be created\n",
+			    " may still be created",
 			    ofs + 1,
 			    UINT32_MAX - anonLabelID
 			);
@@ -581,7 +581,7 @@ void sym_Export(std::string const &symName) {
 	if (symName.starts_with('!')) {
 		// LCOV_EXCL_START
 		// The parser does not accept anonymous labels for an `EXPORT` directive
-		error("Anonymous labels cannot be exported\n");
+		error("Anonymous labels cannot be exported");
 		return;
 		// LCOV_EXCL_STOP
 	}

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -8,68 +8,22 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void vwarn(char const *fmt, va_list ap) {
-	char const *error = strerror(errno);
-
-	fprintf(stderr, "warning: ");
-	vfprintf(stderr, fmt, ap);
-	fprintf(stderr, ": %s\n", error);
-}
-
-static void vwarnx(char const *fmt, va_list ap) {
-	fprintf(stderr, "warning: ");
-	vfprintf(stderr, fmt, ap);
-	putc('\n', stderr);
-}
-
-[[noreturn]]
-static void verr(char const *fmt, va_list ap) {
-	char const *error = strerror(errno);
-
-	fprintf(stderr, "error: ");
-	vfprintf(stderr, fmt, ap);
-	fprintf(stderr, ": %s\n", error);
-	va_end(ap);
-	exit(1);
-}
-
-[[noreturn]]
-static void verrx(char const *fmt, va_list ap) {
-	fprintf(stderr, "error: ");
-	vfprintf(stderr, fmt, ap);
-	putc('\n', stderr);
-	va_end(ap);
-	exit(1);
-}
-
-void warn(char const *fmt, ...) {
-	va_list ap;
-
-	va_start(ap, fmt);
-	vwarn(fmt, ap);
-	va_end(ap);
-}
-
 void warnx(char const *fmt, ...) {
 	va_list ap;
-
+	fputs("warning: ", stderr);
 	va_start(ap, fmt);
-	vwarnx(fmt, ap);
+	vfprintf(stderr, fmt, ap);
 	va_end(ap);
-}
-
-[[noreturn]]
-void err(char const *fmt, ...) {
-	va_list ap;
-
-	va_start(ap, fmt);
-	verr(fmt, ap);
+	putc('\n', stderr);
 }
 
 [[noreturn]]
 void errx(char const *fmt, ...) {
 	va_list ap;
-
+	fputs("error: ", stderr);
 	va_start(ap, fmt);
-	verrx(fmt, ap);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	putc('\n', stderr);
+	exit(1);
 }

--- a/src/gfx/main.cpp
+++ b/src/gfx/main.cpp
@@ -23,6 +23,7 @@
 #include "gfx/pal_spec.hpp"
 #include "gfx/process.hpp"
 #include "gfx/reverse.hpp"
+#include "gfx/warning.hpp"
 
 using namespace std::literals::string_view_literals;
 
@@ -37,51 +38,6 @@ static struct LocalOptions {
 	bool groupOutputs;
 	bool reverse;
 } localOptions;
-
-static uintmax_t nbErrors;
-
-[[noreturn]]
-void giveUp() {
-	fprintf(stderr, "Conversion aborted after %ju error%s\n", nbErrors, nbErrors == 1 ? "" : "s");
-	exit(1);
-}
-
-void requireZeroErrors() {
-	if (nbErrors != 0) {
-		giveUp();
-	}
-}
-
-void error(char const *fmt, ...) {
-	va_list ap;
-
-	fputs("error: ", stderr);
-	va_start(ap, fmt);
-	vfprintf(stderr, fmt, ap);
-	va_end(ap);
-	putc('\n', stderr);
-
-	if (nbErrors != std::numeric_limits<decltype(nbErrors)>::max()) {
-		nbErrors++;
-	}
-}
-
-[[noreturn]]
-void fatal(char const *fmt, ...) {
-	va_list ap;
-
-	fputs("FATAL: ", stderr);
-	va_start(ap, fmt);
-	vfprintf(stderr, fmt, ap);
-	va_end(ap);
-	putc('\n', stderr);
-
-	if (nbErrors != std::numeric_limits<decltype(nbErrors)>::max()) {
-		nbErrors++;
-	}
-
-	giveUp();
-}
 
 void Options::verbosePrint(uint8_t level, char const *fmt, ...) const {
 	// LCOV_EXCL_START

--- a/src/gfx/main.cpp
+++ b/src/gfx/main.cpp
@@ -14,6 +14,7 @@
 #include <string_view>
 #include <vector>
 
+#include "error.hpp"
 #include "extern/getopt.hpp"
 #include "file.hpp"
 #include "platform.hpp"
@@ -51,16 +52,6 @@ void requireZeroErrors() {
 	}
 }
 
-void warning(char const *fmt, ...) {
-	va_list ap;
-
-	fputs("warning: ", stderr);
-	va_start(ap, fmt);
-	vfprintf(stderr, fmt, ap);
-	va_end(ap);
-	putc('\n', stderr);
-}
-
 void error(char const *fmt, ...) {
 	va_list ap;
 
@@ -69,14 +60,6 @@ void error(char const *fmt, ...) {
 	vfprintf(stderr, fmt, ap);
 	va_end(ap);
 	putc('\n', stderr);
-
-	if (nbErrors != std::numeric_limits<decltype(nbErrors)>::max()) {
-		nbErrors++;
-	}
-}
-
-void errorMessage(char const *msg) {
-	fprintf(stderr, "error: %s\n", msg);
 
 	if (nbErrors != std::numeric_limits<decltype(nbErrors)>::max()) {
 		nbErrors++;
@@ -361,7 +344,7 @@ static char *parseArgv(int argc, char *argv[]) {
 		case 'a':
 			localOptions.autoAttrmap = false;
 			if (!options.attrmap.empty()) {
-				warning("Overriding attrmap file %s", options.attrmap.c_str());
+				warnx("Overriding attrmap file %s", options.attrmap.c_str());
 			}
 			options.attrmap = musl_optarg;
 			break;
@@ -438,7 +421,7 @@ static char *parseArgv(int argc, char *argv[]) {
 			// LCOV_EXCL_STOP
 		case 'i':
 			if (!options.inputTileset.empty()) {
-				warning("Overriding input tileset file %s", options.inputTileset.c_str());
+				warnx("Overriding input tileset file %s", options.inputTileset.c_str());
 			}
 			options.inputTileset = musl_optarg;
 			break;
@@ -548,7 +531,7 @@ static char *parseArgv(int argc, char *argv[]) {
 			break;
 		case 'o':
 			if (!options.output.empty()) {
-				warning("Overriding tile data file %s", options.output.c_str());
+				warnx("Overriding tile data file %s", options.output.c_str());
 			}
 			options.output = musl_optarg;
 			break;
@@ -558,7 +541,7 @@ static char *parseArgv(int argc, char *argv[]) {
 		case 'p':
 			localOptions.autoPalettes = false;
 			if (!options.palettes.empty()) {
-				warning("Overriding palettes file %s", options.palettes.c_str());
+				warnx("Overriding palettes file %s", options.palettes.c_str());
 			}
 			options.palettes = musl_optarg;
 			break;
@@ -568,7 +551,7 @@ static char *parseArgv(int argc, char *argv[]) {
 		case 'q':
 			localOptions.autoPalmap = false;
 			if (!options.palmap.empty()) {
-				warning("Overriding palette map file %s", options.palmap.c_str());
+				warnx("Overriding palette map file %s", options.palmap.c_str());
 			}
 			options.palmap = musl_optarg;
 			break;
@@ -596,7 +579,7 @@ static char *parseArgv(int argc, char *argv[]) {
 		case 't':
 			localOptions.autoTilemap = false;
 			if (!options.tilemap.empty()) {
-				warning("Overriding tilemap file %s", options.tilemap.c_str());
+				warnx("Overriding tilemap file %s", options.tilemap.c_str());
 			}
 			options.tilemap = musl_optarg;
 			break;

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -21,6 +21,7 @@
 #include "platform.hpp"
 
 #include "gfx/main.hpp"
+#include "gfx/warning.hpp"
 
 using namespace std::string_view_literals;
 

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -16,6 +16,7 @@
 #include <string_view>
 #include <tuple>
 
+#include "error.hpp"
 #include "helpers.hpp"
 #include "platform.hpp"
 
@@ -60,7 +61,7 @@ void parseInlinePalSpec(char const * const rawArg) {
 		assume(ofs <= arg.length());
 		assume(len <= arg.length());
 
-		errorMessage(msg);
+		error("%s", msg); // `format_` and `-Wformat-security` would complain about `error(msg);`
 		fprintf(
 		    stderr,
 		    "In inline palette spec: %s\n"
@@ -286,7 +287,7 @@ static void parsePSPFile(std::filebuf &file) {
 
 	if (uint16_t nbPalColors = options.nbColorsPerPal * options.nbPalettes;
 	    *nbColors > nbPalColors) {
-		warning(
+		warnx(
 		    "PSP file contains %" PRIu16 " colors, but there can only be %" PRIu16
 		    "; ignoring extra",
 		    *nbColors,
@@ -368,7 +369,7 @@ static void parseGPLFile(std::filebuf &file) {
 	}
 
 	if (nbColors > maxNbColors) {
-		warning(
+		warnx(
 		    "GPL file contains %" PRIu16 " colors, but there can only be %" PRIu16
 		    "; ignoring extra",
 		    nbColors,
@@ -416,7 +417,7 @@ static void parseHEXFile(std::filebuf &file) {
 	}
 
 	if (nbColors > maxNbColors) {
-		warning(
+		warnx(
 		    "HEX file contains %" PRIu16 " colors, but there can only be %" PRIu16
 		    "; ignoring extra",
 		    nbColors,
@@ -445,7 +446,7 @@ static void parseACTFile(std::filebuf &file) {
 
 	if (uint16_t nbPalColors = options.nbColorsPerPal * options.nbPalettes;
 	    nbColors > nbPalColors) {
-		warning(
+		warnx(
 		    "ACT file contains %" PRIu16 " colors, but there can only be %" PRIu16
 		    "; ignoring extra",
 		    nbColors,
@@ -499,7 +500,7 @@ static void parseACOFile(std::filebuf &file) {
 
 	if (uint16_t nbPalColors = options.nbColorsPerPal * options.nbPalettes;
 	    nbColors > nbPalColors) {
-		warning(
+		warnx(
 		    "ACO file contains %" PRIu16 " colors, but there can only be %" PRIu16
 		    "; ignoring extra",
 		    nbColors,

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -25,6 +25,7 @@
 #include "gfx/pal_packing.hpp"
 #include "gfx/pal_sorting.hpp"
 #include "gfx/proto_palette.hpp"
+#include "gfx/warning.hpp"
 
 static bool isBgColorTransparent() {
 	return options.bgColor.has_value() && options.bgColor->isTransparent();

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "defaultinitvec.hpp"
+#include "error.hpp"
 #include "file.hpp"
 #include "helpers.hpp"
 #include "itertools.hpp"
@@ -92,7 +93,7 @@ class Png {
 	static void handleWarning(png_structp png, char const *msg) {
 		Png *self = reinterpret_cast<Png *>(png_get_error_ptr(png));
 
-		warning("In input image (\"%s\"): %s", self->c_str(), msg);
+		warnx("In input image (\"%s\"): %s", self->c_str(), msg);
 	}
 
 	static void readData(png_structp png, png_bytep data, size_t length) {
@@ -385,7 +386,7 @@ public:
 				    std::tuple conflicting{color.toCSS(), other->toCSS()};
 				    // Do not report combinations twice
 				    if (std::find(RANGE(conflicts), conflicting) == conflicts.end()) {
-					    warning(
+					    warnx(
 					        "Fusing colors #%08x and #%08x into Game Boy color $%04x [first seen "
 					        "at x: %" PRIu32 ", y: %" PRIu32 "]",
 					        std::get<0>(conflicting),

--- a/src/gfx/reverse.cpp
+++ b/src/gfx/reverse.cpp
@@ -18,6 +18,7 @@
 #include "helpers.hpp" // assume
 
 #include "gfx/main.hpp"
+#include "gfx/warning.hpp"
 
 static DefaultInitVec<uint8_t> readInto(std::string const &path) {
 	File file;

--- a/src/gfx/reverse.cpp
+++ b/src/gfx/reverse.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "defaultinitvec.hpp"
+#include "error.hpp"
 #include "file.hpp"
 #include "helpers.hpp" // assume
 
@@ -59,7 +60,7 @@ static void pngError(png_structp png, char const *msg) {
 }
 
 static void pngWarning(png_structp png, char const *msg) {
-	warning(
+	warnx(
 	    "While writing reversed image (\"%s\"): %s",
 	    static_cast<char const *>(png_get_error_ptr(png)),
 	    msg
@@ -106,19 +107,19 @@ void reverse() {
 	}
 
 	if (options.allowDedup && options.tilemap.empty()) {
-		warning("Tile deduplication is enabled, but no tilemap is provided?");
+		warnx("Tile deduplication is enabled, but no tilemap is provided?");
 	}
 
 	if (options.useColorCurve) {
-		warning("The color curve is not yet supported in reverse mode...");
+		warnx("The color curve is not yet supported in reverse mode...");
 	}
 
 	if (options.inputSlice.left != 0 || options.inputSlice.top != 0
 	    || options.inputSlice.height != 0) {
-		warning("\"Sliced-off\" pixels are ignored in reverse mode");
+		warnx("\"Sliced-off\" pixels are ignored in reverse mode");
 	}
 	if (options.inputSlice.width != 0 && options.inputSlice.width != options.reversedWidth * 8) {
-		warning(
+		warnx(
 		    "Specified input slice width (%" PRIu16
 		    ") doesn't match provided reversing width (%" PRIu16 " * 8)",
 		    options.inputSlice.width,
@@ -152,7 +153,7 @@ void reverse() {
 		fatal("Cannot generate empty image");
 	}
 	if (mapSize > options.maxNbTiles[0] + options.maxNbTiles[1]) {
-		warning(
+		warnx(
 		    "Total number of tiles (%zu) is more than the limit of %" PRIu16 " + %" PRIu16,
 		    mapSize,
 		    options.maxNbTiles[0],
@@ -234,7 +235,7 @@ void reverse() {
 		} while (nbRead != 0);
 
 		if (palettes.size() > options.nbPalettes) {
-			warning(
+			warnx(
 			    "Read %zu palettes, more than the specified limit of %" PRIu16,
 			    palettes.size(),
 			    options.nbPalettes
@@ -242,7 +243,7 @@ void reverse() {
 		}
 
 		if (options.palSpecType == Options::EXPLICIT && palettes != options.palSpec) {
-			warning("Colors in the palette file do not match those specified with `-c`!");
+			warnx("Colors in the palette file do not match those specified with `-c`!");
 			// This spacing aligns "...versus with `-c`" above the column of `-c` palettes
 			fputs("Colors specified in the palette file:         ...versus with `-c`:\n", stderr);
 			for (size_t i = 0; i < palettes.size() && i < options.palSpec.size(); ++i) {
@@ -263,8 +264,8 @@ void reverse() {
 			palettes[0][i] = grayColors[options.dmgValue(i)];
 		}
 	} else if (options.palSpecType == Options::EMBEDDED) {
-		warning("An embedded palette was requested, but no palette file was specified; ignoring "
-		        "request.");
+		warnx("An embedded palette was requested, but no palette file was specified; ignoring "
+		      "request.");
 	} else if (options.palSpecType == Options::EXPLICIT) {
 		palettes = std::move(options.palSpec); // We won't be using it again.
 	}
@@ -303,7 +304,7 @@ void reverse() {
 
 			if (!tilemap) {
 				if (bank) {
-					warning(
+					warnx(
 					    "Attribute map assigns tile at (%zu, %zu) to bank 1, but no tilemap "
 					    "specified; "
 					    "ignoring the bank bit",

--- a/src/gfx/warning.cpp
+++ b/src/gfx/warning.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+#include "gfx/warning.hpp"
+
+#include <limits>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static uintmax_t nbErrors;
+
+[[noreturn]]
+void giveUp() {
+	fprintf(stderr, "Conversion aborted after %ju error%s\n", nbErrors, nbErrors == 1 ? "" : "s");
+	exit(1);
+}
+
+void requireZeroErrors() {
+	if (nbErrors != 0) {
+		giveUp();
+	}
+}
+
+void error(char const *fmt, ...) {
+	va_list ap;
+	fputs("error: ", stderr);
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	putc('\n', stderr);
+
+	if (nbErrors != std::numeric_limits<decltype(nbErrors)>::max()) {
+		nbErrors++;
+	}
+}
+
+[[noreturn]]
+void fatal(char const *fmt, ...) {
+	va_list ap;
+	fputs("FATAL: ", stderr);
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	putc('\n', stderr);
+
+	if (nbErrors != std::numeric_limits<decltype(nbErrors)>::max()) {
+		nbErrors++;
+	}
+
+	giveUp();
+}

--- a/src/link/assign.cpp
+++ b/src/link/assign.cpp
@@ -19,6 +19,7 @@
 #include "link/output.hpp"
 #include "link/section.hpp"
 #include "link/symbol.hpp"
+#include "link/warning.hpp"
 
 struct MemoryLocation {
 	uint16_t address;

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -118,6 +118,19 @@ static void printUsage() {
 }
 // LCOV_EXCL_STOP
 
+[[gnu::format(printf, 1, 2), noreturn]]
+static void fatalWithUsage(char const *fmt, ...) {
+	va_list ap;
+	fputs("FATAL: ", stderr);
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	putc('\n', stderr);
+
+	printUsage();
+	exit(1);
+}
+
 enum ScrambledRegion {
 	SCRAMBLE_ROMX,
 	SCRAMBLE_SRAM,
@@ -354,11 +367,7 @@ int main(int argc, char *argv[]) {
 
 	// If no input files were specified, the user must have screwed up
 	if (curArgIndex == argc) {
-		fputs(
-		    "FATAL: Please specify an input file (pass `-` to read from standard input)\n", stderr
-		);
-		printUsage();
-		exit(1);
+		fatalWithUsage("Please specify an input file (pass `-` to read from standard input)");
 	}
 
 	// Patch the size array depending on command-line options

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -445,7 +445,7 @@ void obj_ReadFile(char const *fileName, unsigned int fileID) {
 		file = stdin;
 	}
 	if (!file) {
-		err("Failed to open file \"%s\"", fileName);
+		errx("Failed to open file \"%s\": %s", fileName, strerror(errno));
 	}
 	Defer closeFile{[&] { fclose(file); }};
 

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -24,6 +24,7 @@
 #include "link/sdas_obj.hpp"
 #include "link/section.hpp"
 #include "link/symbol.hpp"
+#include "link/warning.hpp"
 
 static std::deque<std::vector<Symbol>> symbolLists;
 static std::vector<std::vector<FileStackNode>> nodes;

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -21,6 +21,7 @@
 #include "link/main.hpp"
 #include "link/section.hpp"
 #include "link/symbol.hpp"
+#include "link/warning.hpp"
 
 static constexpr size_t BANK_SIZE = 0x4000;
 

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -211,7 +212,7 @@ static void writeROM() {
 			outputFile = stdout;
 		}
 		if (!outputFile) {
-			err("Failed to open output file \"%s\"", outputFileName);
+			errx("Failed to open output file \"%s\": %s", outputFileName, strerror(errno));
 		}
 	}
 	Defer closeOutputFile{[&] {
@@ -229,7 +230,7 @@ static void writeROM() {
 			overlayFile = stdin;
 		}
 		if (!overlayFile) {
-			err("Failed to open overlay file \"%s\"", overlayFileName);
+			errx("Failed to open overlay file \"%s\": %s", overlayFileName, strerror(errno));
 		}
 	}
 	Defer closeOverlayFile{[&] {
@@ -572,7 +573,7 @@ static void writeSym() {
 		symFile = stdout;
 	}
 	if (!symFile) {
-		err("Failed to open sym file \"%s\"", symFileName);
+		errx("Failed to open sym file \"%s\": %s", symFileName, strerror(errno));
 	}
 	Defer closeSymFile{[&] { fclose(symFile); }};
 
@@ -623,7 +624,7 @@ static void writeMap() {
 		mapFile = stdout;
 	}
 	if (!mapFile) {
-		err("Failed to open map file \"%s\"", mapFileName);
+		errx("Failed to open map file \"%s\": %s", mapFileName, strerror(errno));
 	}
 	Defer closeMapFile{[&] { fclose(mapFile); }};
 

--- a/src/link/patch.cpp
+++ b/src/link/patch.cpp
@@ -14,6 +14,7 @@
 #include "link/main.hpp"
 #include "link/section.hpp"
 #include "link/symbol.hpp"
+#include "link/warning.hpp"
 
 std::deque<Assertion> assertions;
 

--- a/src/link/script.y
+++ b/src/link/script.y
@@ -30,6 +30,7 @@
 
 	#include "link/main.hpp"
 	#include "link/section.hpp"
+	#include "link/warning.hpp"
 
 	using namespace std::literals;
 

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -431,7 +431,7 @@ void sdobj_ReadFile(FileStackNode const &where, FILE *file, std::vector<Symbol> 
 					    || (symbolSection && !symbolSection->isAddressFixed)) {
 						sym_AddSymbol(symbol); // This will error out
 					} else if (otherValue != symbolValue) {
-						errorNoNewline(
+						errorNoDump(
 						    "\"%s\" is defined as %" PRId32 " at ", symbol.name.c_str(), symbolValue
 						);
 						symbol.src->dump(symbol.lineNo);

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -432,9 +432,7 @@ void sdobj_ReadFile(FileStackNode const &where, FILE *file, std::vector<Symbol> 
 						sym_AddSymbol(symbol); // This will error out
 					} else if (otherValue != symbolValue) {
 						errorNoNewline(
-						    "\"%s\" is defined as %" PRId32 " at ",
-						    symbol.name.c_str(),
-						    symbolValue
+						    "\"%s\" is defined as %" PRId32 " at ", symbol.name.c_str(), symbolValue
 						);
 						symbol.src->dump(symbol.lineNo);
 						fprintf(stderr, ", but as %" PRId32 " at ", otherValue);

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -17,6 +17,7 @@
 #include "link/main.hpp"
 #include "link/section.hpp"
 #include "link/symbol.hpp"
+#include "link/warning.hpp"
 
 enum NumberType {
 	HEX = 16, // X

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -308,7 +308,7 @@ void sdobj_ReadFile(FileStackNode const &where, FILE *file, std::vector<Symbol> 
 			getToken(nullptr, "'A' line is too short");
 			tmp = parseNumber(where, lineNo, token, numberType);
 			if (tmp & (1 << AREA_PAGING)) {
-				fatal(&where, lineNo, "Internal error: paging is not supported");
+				fatal(&where, lineNo, "Paging is not supported");
 			}
 			curSection->isAddressFixed = tmp & (1 << AREA_ISABS);
 			curSection->isBankFixed = curSection->isAddressFixed;
@@ -431,9 +431,8 @@ void sdobj_ReadFile(FileStackNode const &where, FILE *file, std::vector<Symbol> 
 					    || (symbolSection && !symbolSection->isAddressFixed)) {
 						sym_AddSymbol(symbol); // This will error out
 					} else if (otherValue != symbolValue) {
-						fprintf(
-						    stderr,
-						    "error: \"%s\" is defined as %" PRId32 " at ",
+						errorNoNewline(
+						    "\"%s\" is defined as %" PRId32 " at ",
 						    symbol.name.c_str(),
 						    symbolValue
 						);

--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -24,7 +24,7 @@ void sect_ForEach(void (*callback)(Section &)) {
 static void checkAgainstFixedAddress(Section const &target, Section const &other, uint16_t org) {
 	if (target.isAddressFixed) {
 		if (target.org != org) {
-			errorNoNewline(
+			errorNoDump(
 			    "Section \"%s\" is defined with address $%04" PRIx16 " at ",
 			    target.name.c_str(),
 			    target.org
@@ -37,7 +37,7 @@ static void checkAgainstFixedAddress(Section const &target, Section const &other
 		}
 	} else if (target.isAlignFixed) {
 		if ((org - target.alignOfs) & target.alignMask) {
-			errorNoNewline(
+			errorNoDump(
 			    "Section \"%s\" is defined with %d-byte alignment (offset %" PRIu16 ") at ",
 			    target.name.c_str(),
 			    target.alignMask + 1,
@@ -55,7 +55,7 @@ static void checkAgainstFixedAddress(Section const &target, Section const &other
 static bool checkAgainstFixedAlign(Section const &target, Section const &other, int32_t ofs) {
 	if (target.isAddressFixed) {
 		if ((target.org - ofs) & other.alignMask) {
-			errorNoNewline(
+			errorNoDump(
 			    "Section \"%s\" is defined with address $%04" PRIx16 " at ",
 			    target.name.c_str(),
 			    target.org
@@ -74,7 +74,7 @@ static bool checkAgainstFixedAlign(Section const &target, Section const &other, 
 		return false;
 	} else if (target.isAlignFixed
 	           && (other.alignMask & target.alignOfs) != (target.alignMask & ofs)) {
-		errorNoNewline(
+		errorNoDump(
 		    "Section \"%s\" is defined with %d-byte alignment (offset %" PRIu16 ") at ",
 		    target.name.c_str(),
 		    target.alignMask + 1,
@@ -129,7 +129,7 @@ static void checkFragmentCompat(Section &target, Section &other) {
 
 static void mergeSections(Section &target, std::unique_ptr<Section> &&other) {
 	if (target.modifier != other->modifier) {
-		errorNoNewline(
+		errorNoDump(
 		    "Section \"%s\" is defined as SECTION %s at ",
 		    target.name.c_str(),
 		    sectionModNames[target.modifier]
@@ -140,14 +140,14 @@ static void mergeSections(Section &target, std::unique_ptr<Section> &&other) {
 		putc('\n', stderr);
 		exit(1);
 	} else if (other->modifier == SECTION_NORMAL) {
-		errorNoNewline("Section \"%s\" is defined at ", target.name.c_str());
+		errorNoDump("Section \"%s\" is defined at ", target.name.c_str());
 		target.src->dump(target.lineNo);
 		fputs(", but also at ", stderr);
 		other->src->dump(other->lineNo);
 		putc('\n', stderr);
 		exit(1);
 	} else if (target.type != other->type) {
-		errorNoNewline(
+		errorNoDump(
 		    "Section \"%s\" is defined with type %s at ",
 		    target.name.c_str(),
 		    sectionTypeInfo[target.type].name.c_str()
@@ -164,7 +164,7 @@ static void mergeSections(Section &target, std::unique_ptr<Section> &&other) {
 			target.isBankFixed = true;
 			target.bank = other->bank;
 		} else if (target.bank != other->bank) {
-			errorNoNewline(
+			errorNoDump(
 			    "Section \"%s\" is defined with bank %" PRIu32 " at ",
 			    target.name.c_str(),
 			    target.bank

--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 
 #include "link/section.hpp"
-#include "link/warning.hpp"
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -10,6 +9,8 @@
 
 #include "error.hpp"
 #include "helpers.hpp"
+
+#include "link/warning.hpp"
 
 std::vector<std::unique_ptr<Section>> sectionList;
 std::unordered_map<std::string, size_t> sectionMap; // Indexes into `sectionList`

--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "link/section.hpp"
+#include "link/warning.hpp"
 
 #include <inttypes.h>
 #include <stdlib.h>

--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -24,9 +24,8 @@ void sect_ForEach(void (*callback)(Section &)) {
 static void checkAgainstFixedAddress(Section const &target, Section const &other, uint16_t org) {
 	if (target.isAddressFixed) {
 		if (target.org != org) {
-			fprintf(
-			    stderr,
-			    "error: Section \"%s\" is defined with address $%04" PRIx16 " at ",
+			errorNoNewline(
+			    "Section \"%s\" is defined with address $%04" PRIx16 " at ",
 			    target.name.c_str(),
 			    target.org
 			);
@@ -38,9 +37,8 @@ static void checkAgainstFixedAddress(Section const &target, Section const &other
 		}
 	} else if (target.isAlignFixed) {
 		if ((org - target.alignOfs) & target.alignMask) {
-			fprintf(
-			    stderr,
-			    "error: Section \"%s\" is defined with %d-byte alignment (offset %" PRIu16 ") at ",
+			errorNoNewline(
+			    "Section \"%s\" is defined with %d-byte alignment (offset %" PRIu16 ") at ",
 			    target.name.c_str(),
 			    target.alignMask + 1,
 			    target.alignOfs
@@ -57,9 +55,8 @@ static void checkAgainstFixedAddress(Section const &target, Section const &other
 static bool checkAgainstFixedAlign(Section const &target, Section const &other, int32_t ofs) {
 	if (target.isAddressFixed) {
 		if ((target.org - ofs) & other.alignMask) {
-			fprintf(
-			    stderr,
-			    "error: Section \"%s\" is defined with address $%04" PRIx16 " at ",
+			errorNoNewline(
+			    "Section \"%s\" is defined with address $%04" PRIx16 " at ",
 			    target.name.c_str(),
 			    target.org
 			);
@@ -77,9 +74,8 @@ static bool checkAgainstFixedAlign(Section const &target, Section const &other, 
 		return false;
 	} else if (target.isAlignFixed
 	           && (other.alignMask & target.alignOfs) != (target.alignMask & ofs)) {
-		fprintf(
-		    stderr,
-		    "error: Section \"%s\" is defined with %d-byte alignment (offset %" PRIu16 ") at ",
+		errorNoNewline(
+		    "Section \"%s\" is defined with %d-byte alignment (offset %" PRIu16 ") at ",
 		    target.name.c_str(),
 		    target.alignMask + 1,
 		    target.alignOfs
@@ -133,9 +129,8 @@ static void checkFragmentCompat(Section &target, Section &other) {
 
 static void mergeSections(Section &target, std::unique_ptr<Section> &&other) {
 	if (target.modifier != other->modifier) {
-		fprintf(
-		    stderr,
-		    "error: Section \"%s\" is defined as SECTION %s at ",
+		errorNoNewline(
+		    "Section \"%s\" is defined as SECTION %s at ",
 		    target.name.c_str(),
 		    sectionModNames[target.modifier]
 		);
@@ -145,16 +140,15 @@ static void mergeSections(Section &target, std::unique_ptr<Section> &&other) {
 		putc('\n', stderr);
 		exit(1);
 	} else if (other->modifier == SECTION_NORMAL) {
-		fprintf(stderr, "error: Section \"%s\" is defined at ", target.name.c_str());
+		errorNoNewline("Section \"%s\" is defined at ", target.name.c_str());
 		target.src->dump(target.lineNo);
 		fputs(", but also at ", stderr);
 		other->src->dump(other->lineNo);
 		putc('\n', stderr);
 		exit(1);
 	} else if (target.type != other->type) {
-		fprintf(
-		    stderr,
-		    "error: Section \"%s\" is defined with type %s at ",
+		errorNoNewline(
+		    "Section \"%s\" is defined with type %s at ",
 		    target.name.c_str(),
 		    sectionTypeInfo[target.type].name.c_str()
 		);
@@ -170,9 +164,8 @@ static void mergeSections(Section &target, std::unique_ptr<Section> &&other) {
 			target.isBankFixed = true;
 			target.bank = other->bank;
 		} else if (target.bank != other->bank) {
-			fprintf(
-			    stderr,
-			    "error: Section \"%s\" is defined with bank %" PRIu32 " at ",
+			errorNoNewline(
+			    "Section \"%s\" is defined with bank %" PRIu32 " at ",
 			    target.name.c_str(),
 			    target.bank
 			);

--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -37,7 +37,7 @@ void sym_AddSymbol(Symbol &symbol) {
 
 	// Check if the symbol already exists with a different value
 	if (other && !(symValue && otherValue && *symValue == *otherValue)) {
-		errorNoNewline("\"%s\" is defined as ", symbol.name.c_str());
+		errorNoDump("\"%s\" is defined as ", symbol.name.c_str());
 		if (symValue) {
 			fprintf(stderr, "%" PRId32, *symValue);
 		} else {

--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -37,7 +37,7 @@ void sym_AddSymbol(Symbol &symbol) {
 
 	// Check if the symbol already exists with a different value
 	if (other && !(symValue && otherValue && *symValue == *otherValue)) {
-		fprintf(stderr, "error: \"%s\" is defined as ", symbol.name.c_str());
+		errorNoNewline("\"%s\" is defined as ", symbol.name.c_str());
 		if (symValue) {
 			fprintf(stderr, "%" PRId32, *symValue);
 		} else {

--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 
 #include "link/symbol.hpp"
-#include "link/warning.hpp"
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -12,6 +11,7 @@
 
 #include "link/main.hpp"
 #include "link/section.hpp"
+#include "link/warning.hpp"
 
 std::unordered_map<std::string, Symbol *> symbols;
 std::unordered_map<std::string, std::vector<Symbol *>> localSymbols;

--- a/src/link/symbol.cpp
+++ b/src/link/symbol.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "link/symbol.hpp"
+#include "link/warning.hpp"
 
 #include <inttypes.h>
 #include <stdlib.h>

--- a/src/link/warning.cpp
+++ b/src/link/warning.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 
+#include "link/warning.hpp"
+
 #include <inttypes.h>
 
 #include "link/main.hpp"
-#include "link/warning.hpp"
 
 static uint32_t nbErrors = 0;
 

--- a/src/link/warning.cpp
+++ b/src/link/warning.cpp
@@ -39,13 +39,9 @@ void error(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) {
 	}
 }
 
-void errorNoDump(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) {
+void errorNoDump(char const *fmt, ...) {
 	va_list args;
 	fputs("error: ", stderr);
-	if (where) {
-		where->dump(lineNo);
-		fputs(": ", stderr);
-	}
 	va_start(args, fmt);
 	vfprintf(stderr, fmt, args);
 	va_end(args);

--- a/src/link/warning.cpp
+++ b/src/link/warning.cpp
@@ -3,6 +3,7 @@
 #include "link/warning.hpp"
 
 #include <inttypes.h>
+#include <stdarg.h>
 
 #include "link/main.hpp"
 

--- a/src/link/warning.cpp
+++ b/src/link/warning.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+
+#include <inttypes.h>
+
+#include "link/main.hpp"
+#include "link/warning.hpp"
+
+static uint32_t nbErrors = 0;
+
+static void printDiag(
+    char const *fmt, va_list args, char const *type, FileStackNode const *where, uint32_t lineNo
+) {
+	fputs(type, stderr);
+	fputs(": ", stderr);
+	if (where) {
+		where->dump(lineNo);
+		fputs(": ", stderr);
+	}
+	vfprintf(stderr, fmt, args);
+	putc('\n', stderr);
+}
+
+void warning(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+	printDiag(fmt, args, "warning", where, lineNo);
+	va_end(args);
+}
+
+void error(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+	printDiag(fmt, args, "error", where, lineNo);
+	va_end(args);
+
+	if (nbErrors != UINT32_MAX) {
+		nbErrors++;
+	}
+}
+
+void argErr(char flag, char const *fmt, ...) {
+	va_list args;
+	fprintf(stderr, "error: Invalid argument for option '%c': ", flag);
+	va_start(args, fmt);
+	vfprintf(stderr, fmt, args);
+	va_end(args);
+	putc('\n', stderr);
+
+	if (nbErrors != UINT32_MAX) {
+		nbErrors++;
+	}
+}
+
+[[noreturn]]
+void fatal(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+	printDiag(fmt, args, "FATAL", where, lineNo);
+	va_end(args);
+
+	if (nbErrors != UINT32_MAX) {
+		nbErrors++;
+	}
+
+	fprintf(
+	    stderr, "Linking aborted after %" PRIu32 " error%s\n", nbErrors, nbErrors == 1 ? "" : "s"
+	);
+	exit(1);
+}
+
+void requireZeroErrors() {
+	if (nbErrors != 0) {
+		fprintf(
+		    stderr, "Linking failed with %" PRIu32 " error%s\n", nbErrors, nbErrors == 1 ? "" : "s"
+		);
+		exit(1);
+	}
+}

--- a/src/link/warning.cpp
+++ b/src/link/warning.cpp
@@ -39,7 +39,7 @@ void error(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) {
 	}
 }
 
-void errorNoNewline(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) {
+void errorNoDump(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) {
 	va_list args;
 	fputs("error: ", stderr);
 	if (where) {

--- a/src/link/warning.cpp
+++ b/src/link/warning.cpp
@@ -39,6 +39,22 @@ void error(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) {
 	}
 }
 
+void errorNoNewline(FileStackNode const *where, uint32_t lineNo, char const *fmt, ...) {
+	va_list args;
+	fputs("error: ", stderr);
+	if (where) {
+		where->dump(lineNo);
+		fputs(": ", stderr);
+	}
+	va_start(args, fmt);
+	vfprintf(stderr, fmt, args);
+	va_end(args);
+
+	if (nbErrors != UINT32_MAX) {
+		nbErrors++;
+	}
+}
+
 void argErr(char flag, char const *fmt, ...) {
 	va_list args;
 	fprintf(stderr, "error: Invalid argument for option '%c': ", flag);

--- a/test/fix/incompatible-features.err
+++ b/test/fix/incompatible-features.err
@@ -1,5 +1,5 @@
 error: Features incompatible with MBC ("mbc1+multirumble")
-Accepted combinations:
+Accepted MBC names:
 	ROM ($00) [aka ROM_ONLY]
 	MBC1 ($01), MBC1+RAM ($02), MBC1+RAM+BATTERY ($03)
 	MBC2 ($05), MBC2+BATTERY ($06)


### PR DESCRIPTION
With this PR, RGBASM, RGBLINK, and RGBGFX all use error.cpp's `errx` (error and exit) and `warnx` (warning and continue) functions. They also each have their own `error` and `warning` functions, which do different things (such as outputting fstack info, or counting total errors). RGBFIX does not (yet) use error.cpp's functions.

- The `err` and `warn` functions were unnecessary alternatives to `errx` and `warnx` that appended `strerror(errno)` themselves. I find it hard to remember which is which, and we manually use `strerror(errno)` elsewhere, so it's not worth providing two extra functions for.
- The `v(err|warn)x?` static functions were unnecessarily factored out from the `v`-less ones.
- RGBGFX's `warning` function was identical to `warnx`, and also occupied the name "`warning`" which would be better for RGBASM-style diagnostics.
- RGBASM's `error/warning/fatal` functions did not append newlines, while all the rest did. We've had multiple extra/missing newline mistakes because of this.
