### PR TITLE
Make file.hpp independent of gfx

### DIFF
--- a/include/file.hpp
+++ b/include/file.hpp
@@ -15,8 +15,6 @@
 #include "helpers.hpp" // assume
 #include "platform.hpp"
 
-#include "gfx/warning.hpp"
-
 class File {
 	std::variant<std::streambuf *, std::filebuf> _file;
 
@@ -32,11 +30,7 @@ public:
 			assume(!(mode & std::ios_base::out));
 			_file.emplace<std::streambuf *>(std::cin.rdbuf());
 			if (setmode(STDIN_FILENO, (mode & std::ios_base::binary) ? O_BINARY : O_TEXT) == -1) {
-				fatal(
-				    "Failed to set stdin to %s mode: %s",
-				    mode & std::ios_base::binary ? "binary" : "text",
-				    strerror(errno)
-				);
+				return nullptr;
 			}
 		} else {
 			assume(mode & std::ios_base::out);

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <charconv>
+#include <errno.h>
 #include <fstream>
 #include <inttypes.h>
 #include <limits.h>
@@ -612,7 +613,7 @@ void parseExternalPalSpec(char const *arg) {
 	std::filebuf file;
 	// Some parsers read the file in text mode, others in binary mode
 	if (!file.open(path, std::ios::in | std::get<2>(*iter))) {
-		error("Failed to open palette file \"%s\"", path);
+		fatal("Failed to open palette file \"%s\": %s", path, strerror(errno));
 		return;
 	}
 


### PR DESCRIPTION
Every failed call to `File::open` does its own `fatal` error logging `strerror(errno)` anyway. We only use file.hpp in gfx so far, but in principle it could be useful elsewhere.