### PR TITLE
Refactor to reduce nesting depth some more

### DIFF
--- a/src/extern/getopt.cpp
+++ b/src/extern/getopt.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-// This implementation was taken from musl and modified for RGBDS
+// This implementation was taken from musl and modified for RGBDS.
 
 #include "extern/getopt.hpp"
 

--- a/src/extern/utf8decoder.cpp
+++ b/src/extern/utf8decoder.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-// UTF-8 decoder: http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+// This implementation was taken from
+// http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+// and modified for RGBDS.
 
 #include "extern/utf8decoder.hpp"
 
@@ -33,10 +35,8 @@ static uint8_t const utf8d[] = {
 };
 
 uint32_t decode(uint32_t *state, uint32_t *codep, uint8_t byte) {
-	uint32_t type = utf8d[byte];
-
-	*codep = (*state != 0) ? (byte & 0x3FU) | (*codep << 6) : (0xFF >> type) & (byte);
-
-	*state = utf8d[256 + *state * 16 + type];
+	uint8_t type = utf8d[byte];
+	*codep = *state != 0 ? (byte & 0b111111) | (*codep << 6) : byte & (0xFF >> type);
+	*state = utf8d[0x100 + *state * 0x10 + type];
 	return *state;
 }

--- a/src/fix/main.cpp
+++ b/src/fix/main.cpp
@@ -461,10 +461,7 @@ static MbcType parseMBC(char const *name) {
 					break;
 				case 'A':
 				case 'a':
-					if (*ptr != 'M' && *ptr != 'm') {
-						return MBC_BAD;
-					}
-					ptr++;
+					tryReadSlice("M");
 					features |= RAM;
 					break;
 				default:


### PR DESCRIPTION
```console
% git grep -nP '^\t{6}[^\t]' -- 'src/**/*.cpp' 'include/**/*.hpp' ':!src/link/sdas_obj.cpp' | sed -E 's/\t+/ /g'
src/asm/lexer.cpp:2074: std::shared_ptr<std::string> str = sym->getEqus();
src/asm/lexer.cpp:2076: assume(str);
src/asm/lexer.cpp:2077: beginExpansion(str, sym->name);
src/asm/lexer.cpp:2078: continue; // Restart, reading from the new buffer
src/extern/getopt.cpp:228: return '?';
src/extern/getopt.cpp:244: return ':';
src/extern/getopt.cpp:247: return '?';
src/gfx/process.cpp:434: assignColor(x, y, Rgba(ptr[0], ptr[1], ptr[2], ptr[3]));
src/gfx/process.cpp:435: ptr += 4;
src/gfx/reverse.cpp:541: gray = gray << pngDepth | (pixel.red & ((1 << pngDepth) - 1));
src/gfx/reverse.cpp:543: *ptr++ = palID * 4 + colorID;
src/gfx/reverse.cpp:545: *ptr++ = pixel.red;
src/gfx/reverse.cpp:546: *ptr++ = pixel.green;
src/gfx/reverse.cpp:547: *ptr++ = pixel.blue;
src/gfx/reverse.cpp:548: *ptr++ = pixel.alpha;
src/link/output.cpp:285: ++ptr;
```