### PR TITLE
Add gb-starter-kit to test suite, excluding it on Windows, macOS, and BSD

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
           test/fetch-test-deps.sh --get-deps ubuntu
       - name: Generate coverage report
         run: |
-          contrib/coverage.bash false
+          contrib/coverage.bash ubuntu-ci
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          CXX=${{ matrix.cxx }} test/run-tests.sh
+          CXX=${{ matrix.cxx }} test/run-tests.sh --os ${{ matrix.os }}
 
   macos-static:
     runs-on: macos-14
@@ -121,7 +121,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          test/run-tests.sh
+          test/run-tests.sh --os macos
 
   windows:
     strategy:
@@ -212,7 +212,7 @@ jobs:
         run: |
           cp bins/* .
           cp bins/*.dll test/gfx
-          test/run-tests.sh
+          test/run-tests.sh --os ${{ matrix.os }}
 
   windows-mingw-build:
     strategy:
@@ -319,7 +319,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          test/run-tests.sh
+          test/run-tests.sh --os ${{ matrix.os }}
 
   cygwin:
     strategy:
@@ -382,7 +382,7 @@ jobs:
               git \
               png
           run: | # FreeBSD `c++` compiler does not support `make develop` sanitizers ASan or UBSan
-            cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=c++ -DUSE_EXTERNAL_TESTS=OFF
+            cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=c++ -DUSE_EXTERNAL_TESTS=OFF -DOS=bsd
             cmake --build build -j4 --verbose
             cmake --install build --verbose
             cmake --build build --target test

--- a/contrib/coverage.bash
+++ b/contrib/coverage.bash
@@ -7,7 +7,11 @@ make coverage -j
 # Run the tests
 pushd test
 ./fetch-test-deps.sh
-./run-tests.sh
+if [[ $# -eq 0 ]]; then
+  ./run-tests.sh
+else
+  ./run-tests.sh --os "$1"
+fi
 popd
 
 # Generate coverage logs
@@ -21,7 +25,7 @@ lcov -r "$COVERAGE_INFO" src/asm/parser.{hpp,cpp} src/link/script.{hpp,cpp} -o "
 genhtml --dark-mode -f -s -o coverage/ "$COVERAGE_INFO"
 
 # Check whether running from coverage.yml workflow
-if [ "$1" != "false" ]; then
+if [ "$1" != "ubuntu-ci" ]; then
   # Open report in web browser
   if [ "$(uname)" == "Darwin" ]; then
     open coverage/index.html

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,3 +1,4 @@
+/gb-starter-kit/
 /LADX-Disassembly/
 /libbet/
 /pokecrystal/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,9 @@ endif()
 if(NOT USE_EXTERNAL_TESTS)
   set(ONLY_INTERNAL "--only-internal")
 endif()
+if(DEFINED OS)
+  set(OS_NAME "--os" "${OS}")
+endif()
 
 add_executable(randtilegen gfx/randtilegen.cpp)
 add_executable(rgbgfx_test gfx/rgbgfx_test.cpp)
@@ -31,6 +34,6 @@ foreach(TARGET randtilegen rgbgfx_test)
 endforeach()
 
 add_test(NAME all
-         COMMAND ./run-tests.sh ${ONLY_FREE} ${ONLY_INTERNAL}
+         COMMAND ./run-tests.sh ${ONLY_FREE} ${ONLY_INTERNAL} ${OS_NAME}
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/test/fetch-test-deps.sh
+++ b/test/fetch-test-deps.sh
@@ -91,7 +91,7 @@ case "$actionname" in
 
 		action() { # owner repo shallow-since commit
 			if [ ! -d "$2" ]; then
-				git clone "https://github.com/$1/$2.git" --shallow-since="$3" --single-branch
+				git clone "https://github.com/$1/$2.git" --recursive --shallow-since="$3" --single-branch
 			fi
 			pushd "$2"
 			git checkout -f "$4"
@@ -111,6 +111,7 @@ if "$nonfree"; then
 	action pret  pokered          2025-06-29 1e997474be15950eb3176864b346b96504760e67
 	action zladx LADX-Disassembly 2025-05-30 f685f6aaff2f2e0e36d1856d4ed8fd58f833a1f2
 fi
-action AntonioND ucity   2025-05-30 83e5c697cbd9e10a0bc72b02bcb6146c35e2c328
-action pinobatch libbet  2025-05-20 bb6cfc026644aa1034eee6d9c49bb4705601c9f6
-action LIJI32    SameBoy 2025-06-28 33d237706e18d92fb79e3fd7313d5181d8a806cd
+action AntonioND ucity          2025-05-30 83e5c697cbd9e10a0bc72b02bcb6146c35e2c328
+action pinobatch libbet         2025-05-20 bb6cfc026644aa1034eee6d9c49bb4705601c9f6
+action LIJI32    SameBoy        2025-06-28 33d237706e18d92fb79e3fd7313d5181d8a806cd
+action ISSOtm    gb-starter-kit 2025-06-13 3cce3215b0bcb559a5cf4ca5916e2d817d53ff29

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export LC_ALL=C
+
+# Game Boy release date, 1989-04-21T12:34:56Z (for reproducible test results)
+export SOURCE_DATE_EPOCH=609165296
+
 cd "$(dirname "$0")"
 
 usage() {
@@ -20,6 +25,7 @@ nonfree=true
 internal=true
 external=true
 installedrgbds=false
+osname=
 FETCH_TEST_DEPS="fetch-test-deps.sh"
 RGBDS_PATH="RGBDS=../../"
 while [[ $# -gt 0 ]]; do
@@ -42,6 +48,10 @@ while [[ $# -gt 0 ]]; do
 		--installed-rgbds)
 			installedrgbds=true
 			RGBDS_PATH=
+			;;
+		--os)
+			shift
+			osname="$1"
 			;;
 		--)
 			break
@@ -122,3 +132,8 @@ fi
 test_downstream AntonioND ucity   all      ucity.gbc d2f4a7db48ee208b1bd69a78bd492a1c9ac4a030
 test_downstream pinobatch libbet  all      libbet.gb f117089aa056600e2d404bbcbac96b016fc64611
 test_downstream LIJI32    SameBoy bootroms build/bin/BootROMs/cgb_boot.bin 113903775a9d34b798c2f8076672da6626815a91
+# gb-starter kit make fails on Windows: https://github.com/ISSOtm/gb-starter-kit/issues/1
+# gb-starter-kit fails with macOS/BSD make: https://github.com/ISSOtm/gb-starter-kit/issues/29
+if [[ "${osname%-*}" != "windows" && "${osname%-*}" != "macos" && "${osname%-*}" != "bsd" ]]; then
+	test_downstream ISSOtm gb-starter-kit all bin/boilerplate.gb b4f130169ba73284e0d0e71b53e7baa4eca2f7fe
+fi


### PR DESCRIPTION
Fixes #849

gb-starter-kit does not build on Windows (https://github.com/ISSOtm/gb-starter-kit/issues/1) nor on macOS or BSD with BSD `make` (https://github.com/ISSOtm/gb-starter-kit/issues/29), so it's excluded from those platforms.