### PR TITLE
Support `SIZEOF(reg)` to distinguish 8- and 16-bit registers

### DIFF
--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -715,6 +715,9 @@ is a string, this function returns the size of the section named
 If
 .Ar arg
 is a section type keyword, it returns the size of that section type.
+If
+.Ar arg
+is an 8-bit or 16-bit register, it returns the size of that register.
 The result is not constant, since only RGBLINK can compute its value.
 .It Fn STARTOF arg Ta If
 .Ar arg

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -1520,6 +1520,12 @@ relocexpr_no_str:
 	| OP_STARTOF LPAREN sect_type RPAREN {
 		$$.makeStartOfSectionType($3);
 	}
+	| OP_SIZEOF LPAREN MODE_R8 RPAREN {
+		$$.makeNumber(1);
+	}
+	| OP_SIZEOF LPAREN MODE_R16 RPAREN {
+		$$.makeNumber(2);
+	}
 	| OP_DEF {
 		lexer_ToggleStringExpansion(false);
 	} LPAREN scoped_sym RPAREN {
@@ -2550,6 +2556,29 @@ op_sp_offset:
 ;
 
 // Registers and condition codes.
+
+MODE_R8:
+	  MODE_A
+	| MODE_B
+	| MODE_C
+	| MODE_D
+	| MODE_E
+	| MODE_H
+	| MODE_L
+	| LBRACK MODE_BC RBRACK
+	| LBRACK MODE_DE RBRACK
+	| LBRACK MODE_HL RBRACK
+	| hl_ind_inc
+	| hl_ind_dec
+;
+
+MODE_R16:
+	  MODE_AF
+	| MODE_BC
+	| MODE_DE
+	| MODE_HL
+	| MODE_SP
+;
 
 MODE_A:
 	  TOKEN_A

--- a/test/asm/sizeof-reg.asm
+++ b/test/asm/sizeof-reg.asm
@@ -1,0 +1,30 @@
+assert sizeof(a) == 1
+assert sizeof(b) == 1
+assert sizeof(c) == 1
+assert sizeof(d) == 1
+assert sizeof(e) == 1
+assert sizeof(h) == 1
+assert sizeof(l) == 1
+
+assert sizeof([bc]) == 1
+assert sizeof([de]) == 1
+assert sizeof([hl]) == 1
+
+assert sizeof([hli]) == 1
+assert sizeof([hl+]) == 1
+assert sizeof([hld]) == 1
+assert sizeof([hl-]) == 1
+
+assert sizeof(af) == 2
+assert sizeof(bc) == 2
+assert sizeof(de) == 2
+assert sizeof(hl) == 2
+assert sizeof(sp) == 2
+
+assert sizeof(high(af)) == 1
+assert sizeof(high(bc)) == 1
+assert sizeof(low(bc)) == 1
+assert sizeof(high(de)) == 1
+assert sizeof(low(de)) == 1
+assert sizeof(high(hl)) == 1
+assert sizeof(low(hl)) == 1


### PR DESCRIPTION
Fixes #1756