### PR TITLE
Deprecate treating strings as numbers

### DIFF
--- a/man/rgbasm-old.5
+++ b/man/rgbasm-old.5
@@ -135,6 +135,12 @@ Deprecated in 0.9.0, removed in 1.0.0.
 Instead, use a multi-value
 .Ic CHARMAP ,
 or explicitly combine the values of individual characters.
+.Ss Treating strings as numbers
+Deprecated in 1.0.0.
+.Pp
+Instead, use character constants or the
+.Ic CHARVAL
+function.
 .Ss rgbgfx -f/--fix and -F/--fix-and-save
 Removed in 0.6.0.
 .Pp

--- a/src/asm/actions.cpp
+++ b/src/asm/actions.cpp
@@ -166,6 +166,7 @@ uint32_t act_CharToNum(std::string const &str) {
 }
 
 uint32_t act_StringToNum(std::string const &str) {
+	warning(WARNING_OBSOLETE, "Treating strings as numbers is deprecated");
 	if (std::vector<int32_t> units = charmap_Convert(str); units.size() == 1) {
 		// The string is a single character with a single unit value,
 		// which can be used directly as a number.

--- a/test/asm/charlen-strchar.asm
+++ b/test/asm/charlen-strchar.asm
@@ -1,4 +1,4 @@
-	opt Wno-unmapped-char
+	opt Wno-unmapped-char, Wno-obsolete
 	charmap "<NULL>", $00
 	charmap "A", $10
 	charmap "B", $20

--- a/test/asm/db-dw-dl-string.asm
+++ b/test/asm/db-dw-dl-string.asm
@@ -8,6 +8,6 @@ SECTION "Test", ROM0
 	dw 0, "DEF", -1
 	dl 0, "DEF", -1
 
-	db "A" + 1
-	dw "A" + 1
-	dl "A" + 1
+	db 'A' + 1
+	dw 'A' + 1
+	dl 'A' + 1

--- a/test/asm/empty-strings.err
+++ b/test/asm/empty-strings.err
@@ -1,3 +1,5 @@
+warning: empty-strings.asm(5): [-Wobsolete]
+    Treating strings as numbers is deprecated
 error: empty-strings.asm(5):
     Strings as numbers must be a single charmap unit
 Assembly aborted with 1 error!

--- a/test/asm/equ-charmap.asm
+++ b/test/asm/equ-charmap.asm
@@ -1,4 +1,4 @@
 	charmap "A", 1
 SECTION "sec", ROM0[0]
-DEF _A_ EQU "A"
+DEF _A_ EQU 'A'
 	db _A_

--- a/test/asm/multiple-charmaps.asm
+++ b/test/asm/multiple-charmaps.asm
@@ -1,4 +1,4 @@
-opt Wno-unmapped-char
+opt Wno-unmapped-char, Wno-obsolete
 
 MACRO new_
 	IF _NARG > 1

--- a/test/asm/multivalue-charmap.err
+++ b/test/asm/multivalue-charmap.err
@@ -1,5 +1,9 @@
 warning: multivalue-charmap.asm(11): [-Wtruncation]
     All character units must be 8-bit
+warning: multivalue-charmap.asm(20): [-Wobsolete]
+    Treating strings as numbers is deprecated
+warning: multivalue-charmap.asm(21): [-Wobsolete]
+    Treating strings as numbers is deprecated
 warning: multivalue-charmap.asm(22): [-Wtruncation]
     All character units must be 8-bit
 warning: multivalue-charmap.asm(34): [-Wtruncation]

--- a/test/asm/nested-bad-interpolation.err
+++ b/test/asm/nested-bad-interpolation.err
@@ -6,12 +6,16 @@ error: nested-bad-interpolation.asm(1):
     syntax error, unexpected end of line
 error: nested-bad-interpolation.asm(2):
     Interpolated symbol "b" is a reserved keyword; add a '#' prefix to use it as a raw symbol
+warning: nested-bad-interpolation.asm(2): [-Wobsolete]
+    Treating strings as numbers is deprecated
 error: nested-bad-interpolation.asm(2):
     Strings as numbers must be a single charmap unit
 error: nested-bad-interpolation.asm(3):
     Interpolated symbol "c" is a reserved keyword; add a '#' prefix to use it as a raw symbol
 error: nested-bad-interpolation.asm(3):
     Interpolated symbol "" does not exist
+warning: nested-bad-interpolation.asm(3): [-Wobsolete]
+    Treating strings as numbers is deprecated
 error: nested-bad-interpolation.asm(3):
     Strings as numbers must be a single charmap unit
 Assembly aborted with 8 errors!

--- a/test/asm/raw-string-symbol-errors.err
+++ b/test/asm/raw-string-symbol-errors.err
@@ -1,3 +1,5 @@
+warning: raw-string-symbol-errors.asm(7): [-Wobsolete]
+    Treating strings as numbers is deprecated
 error: raw-string-symbol-errors.asm(7):
     Strings as numbers must be a single charmap unit
 error: raw-string-symbol-errors.asm(8):
@@ -8,6 +10,8 @@ error: raw-string-symbol-errors.asm(13):
     'm' is not a string symbol
 error: raw-string-symbol-errors.asm(14):
     'u' is not a string symbol
+warning: raw-string-symbol-errors.asm(17): [-Wobsolete]
+    Treating strings as numbers is deprecated
 error: raw-string-symbol-errors.asm(17):
     Strings as numbers must be a single charmap unit
 error: raw-string-symbol-errors.asm(18):

--- a/test/asm/raw-string-symbols.asm
+++ b/test/asm/raw-string-symbols.asm
@@ -1,4 +1,4 @@
-opt Wno-unmapped-char
+opt Wno-unmapped-char, Wno-obsolete
 
 def hello equs "world"
 def name equs "hello"

--- a/test/asm/state-file/a.asm
+++ b/test/asm/state-file/a.asm
@@ -21,6 +21,6 @@ MACRO mac2
 ENDM
 
 newcharmap map2, main
-charmap "\0\n\t\r", "\t", "\r", "\0", "\n"
+charmap "\0\n\t\r", '\t', '\r', '\0', '\n'
 
 REDEF string EQUS "goodbye~"

--- a/test/asm/string-concat.asm
+++ b/test/asm/string-concat.asm
@@ -19,7 +19,7 @@ charmap "a", 1
 charmap "b", 2
 charmap "ab", 12
 assert "a" + "b" == 3
-assert "a" ++ "b" == 12
+assert charval("a" ++ "b") == 12
 
 ; errors
 assert 2 ++ 2 == 4

--- a/test/asm/string-concat.err
+++ b/test/asm/string-concat.err
@@ -1,3 +1,7 @@
+warning: string-concat.asm(21): [-Wobsolete]
+    Treating strings as numbers is deprecated
+warning: string-concat.asm(21): [-Wobsolete]
+    Treating strings as numbers is deprecated
 error: string-concat.asm(25):
     syntax error, unexpected ++
 error: string-concat.asm(26):


### PR DESCRIPTION
Fixes #1686

In the future, removing strings-as-numbers will allow us to simplify the parser a lot. For now, if this would be too disruptive to projects which want to use RGBDS 1.0.0, `-Wno-obsolete` is an option.