### PR TITLE
Deprecate `__DATE__` and `__TIME__`

### DIFF
--- a/man/rgbasm-old.5
+++ b/man/rgbasm-old.5
@@ -129,6 +129,11 @@ Deprecated in 0.5.0, removed in 0.6.0.
 .Pp
 Instead, use
 .Ql 3.141592653 .
+.Ss __DATE__ and __TIME__
+Deprecated in 1.0.0.
+.Pp
+Instead, use
+.Ql __ISO_8601_LOCAL__ .
 .Ss Treating multi-character strings as numbers
 Deprecated in 0.9.0, removed in 1.0.0.
 .Pp

--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -1710,8 +1710,6 @@ The following symbols are defined by the assembler:
 .It Dv .. Ta Ic EQUS Ta The current local label scope
 .It Dv _RS Ta Ic = Ta _RS Counter
 .It Dv _NARG Ta Ic EQU Ta Number of arguments passed to macro, updated by Ic SHIFT
-.It Dv __DATE__ Ta Ic EQUS Ta Today's date
-.It Dv __TIME__ Ta Ic EQUS Ta The current time
 .It Dv __ISO_8601_LOCAL__ Ta Ic EQUS Ta ISO 8601 timestamp (local)
 .It Dv __ISO_8601_UTC__ Ta Ic EQUS Ta ISO 8601 timestamp (UTC)
 .It Dv __UTC_YEAR__ Ta Ic EQU Ta Today's year

--- a/src/asm/symbol.cpp
+++ b/src/asm/symbol.cpp
@@ -696,8 +696,22 @@ void sym_Init(time_t now) {
 	    time_utc
 	);
 
-	sym_AddString("__TIME__"s, std::make_shared<std::string>(savedTIME))->isBuiltin = true;
-	sym_AddString("__DATE__"s, std::make_shared<std::string>(savedDATE))->isBuiltin = true;
+	Symbol *timeSymbol = &createSymbol("__TIME__"s);
+	timeSymbol->type = SYM_EQUS;
+	timeSymbol->data = []() {
+		warning(WARNING_OBSOLETE, "`__TIME__` is deprecated; use `__ISO_8601_LOCAL__`");
+		return std::make_shared<std::string>(savedTIME);
+	};
+	timeSymbol->isBuiltin = true;
+
+	Symbol *dateSymbol = &createSymbol("__DATE__"s);
+	dateSymbol->type = SYM_EQUS;
+	dateSymbol->data = []() {
+		warning(WARNING_OBSOLETE, "`__DATE__` is deprecated; use `__ISO_8601_LOCAL__`");
+		return std::make_shared<std::string>(savedDATE);
+	};
+	dateSymbol->isBuiltin = true;
+
 	sym_AddString(
 	    "__ISO_8601_LOCAL__"s, std::make_shared<std::string>(savedTIMESTAMP_ISO8601_LOCAL)
 	)

--- a/test/asm/date-time.asm
+++ b/test/asm/date-time.asm
@@ -1,0 +1,3 @@
+; these have unpredictable values depending on the locale
+assert STRLEN(__DATE__)
+assert STRLEN(__TIME__)

--- a/test/asm/date-time.err
+++ b/test/asm/date-time.err
@@ -1,0 +1,4 @@
+warning: date-time.asm(2): [-Wobsolete]
+    `__DATE__` is deprecated; use `__ISO_8601_LOCAL__`
+warning: date-time.asm(3): [-Wobsolete]
+    `__TIME__` is deprecated; use `__ISO_8601_LOCAL__`


### PR DESCRIPTION
These have unpredictable values depending on the current language, time zone, locale format, etc.

If you want a timestamp for logging or embedding in a build, use `__ISO_8601_LOCAL__` or `__ISO_8601_UTC__` (both in <code><i>yyyy</i>-<i>MM</i>-<i>dd</i>T<i>hh</i>:<i>mm</i>:<i>ssZZZ</i></code> format).