### PR TITLE
Add 0/1/2 warning levels to `rgblink -Wtruncation`

### DIFF
--- a/include/link/warning.hpp
+++ b/include/link/warning.hpp
@@ -27,11 +27,14 @@ enum WarningID {
 	WARNING_OBSOLETE,     // Obsolete/deprecated things
 	WARNING_SHIFT,        // Undefined `SHIFT` behavior
 	WARNING_SHIFT_AMOUNT, // Strange `SHIFT` amount
-	WARNING_TRUNCATION,   // Implicit truncation loses some bits
 
 	NB_PLAIN_WARNINGS,
 
-	NB_WARNINGS = NB_PLAIN_WARNINGS,
+	// Implicit truncation loses some bits
+	WARNING_TRUNCATION_1 = NB_PLAIN_WARNINGS,
+	WARNING_TRUNCATION_2,
+
+	NB_WARNINGS,
 };
 
 extern Diagnostics<WarningLevel, WarningID> warnings;

--- a/man/rgblink.1
+++ b/man/rgblink.1
@@ -318,11 +318,20 @@ This warning is enabled by
 Warn when a shift's operand is negative or greater than 32.
 This warning is enabled by
 .Fl Wall .
-.It Fl Wno-truncation
+.It Fl Wtruncation=
 Warn when an implicit truncation (for example,
 .Ic db
 to an 8-bit value) loses some bits.
-This occurs when an N-bit value is 2**N or greater, or less than -2**N.
+.Fl Wtruncation=0
+or
+.Fl Wno-truncation
+disables this warning.
+.Fl Wtruncation=1
+warns when an N-bit value is 2**N or greater, or less than -2**N.
+.Fl Wtruncation=2
+or just
+.Fl Wtruncation
+also warns when an N-bit value is less than -2**(N-1), which will not fit in two's complement encoding.
 .El
 .Sh EXAMPLES
 All you need for a basic ROM is an object file, which can be made into a ROM image like so:

--- a/src/link/warning.cpp
+++ b/src/link/warning.cpp
@@ -26,9 +26,13 @@ Diagnostics<WarningLevel, WarningID> warnings = {
         {"obsolete",     LEVEL_DEFAULT   },
         {"shift",        LEVEL_ALL       },
         {"shift-amount", LEVEL_ALL       },
+        // Parametric warnings
         {"truncation",   LEVEL_DEFAULT   },
+        {"truncation",   LEVEL_EVERYTHING},
     },
-    .paramWarnings = {},
+    .paramWarnings = {
+        {WARNING_TRUNCATION_1, WARNING_TRUNCATION_2, 2},
+    },
     .state = DiagnosticsState<WarningID>(),
     .nbErrors = 0,
 };

--- a/test/link/test.sh
+++ b/test/link/test.sh
@@ -439,6 +439,22 @@ rgblinkQuiet "$otemp" "$gbtemp" "$gbtemp2" "$outtemp" "$outtemp2" 2>"$outtemp3"
 tryDiff "$test"/out.err "$outtemp3"
 evaluateTest
 
+test="truncation/level1"
+startTest
+"$RGBASM" -o "$otemp" "$test"/a.asm
+continueTest
+rgblinkQuiet -Wtruncation=1 -o "$gbtemp" "$otemp" 2>"$outtemp"
+tryDiff "$test"/out.err "$outtemp"
+evaluateTest
+
+test="truncation/level2"
+startTest
+"$RGBASM" -o "$otemp" "$test"/a.asm
+continueTest
+rgblinkQuiet -Wtruncation=2 -o "$gbtemp" "$otemp" 2>"$outtemp"
+tryDiff "$test"/out.err "$outtemp"
+evaluateTest
+
 if [[ "$failed" -eq 0 ]]; then
 	echo "${bold}${green}All ${tests} tests passed!${rescolors}${resbold}"
 else

--- a/test/link/truncation/level1/a.asm
+++ b/test/link/truncation/level1/a.asm
@@ -1,0 +1,6 @@
+section "rom", rom0
+ld bc, -wLabel
+ld de, -(wLabel * 2)
+
+section "ram", wram0
+wLabel::

--- a/test/link/truncation/level1/out.err
+++ b/test/link/truncation/level1/out.err
@@ -1,0 +1,2 @@
+warning: Value $fffe8000 (may be negative?) is not 16-bit [-Wtruncation]
+    at truncation/level1/a.asm(3)

--- a/test/link/truncation/level2/a.asm
+++ b/test/link/truncation/level2/a.asm
@@ -1,0 +1,6 @@
+section "rom", rom0
+ld bc, -wLabel
+ld de, -(wLabel * 2)
+
+section "ram", wram0
+wLabel::

--- a/test/link/truncation/level2/out.err
+++ b/test/link/truncation/level2/out.err
@@ -1,0 +1,4 @@
+warning: Value $fffe8000 (may be negative?) is not 16-bit [-Wtruncation]
+    at truncation/level2/a.asm(3)
+warning: Value $ffff4000 (may be negative?) is not 16-bit [-Wtruncation]
+    at truncation/level2/a.asm(2)


### PR DESCRIPTION
Fixes #1815