### PR TITLE
Fix RPN patches for all commands

### DIFF
--- a/man/rgbds.5
+++ b/man/rgbds.5
@@ -405,9 +405,6 @@ Checks if the value is a valid bit index
 .Pq see e.g. Do BIT u3, r8 Dc in Xr gbz80 7 ,
 that is, from 0 to 7.
 The value is then ORed with the instruction's mask.
-.It Li $80 Ta Integer literal; followed by the
-.Cm LONG
-integer.
 .It Li $70 Ta Cm HIGH
 byte.
 .It Li $71 Ta Cm LOW
@@ -416,6 +413,9 @@ byte.
 value.
 .It Li $73 Ta Cm TZCOUNT
 value.
+.It Li $80 Ta Integer literal; followed by the
+.Cm LONG
+integer.
 .It Li $81 Ta A symbol's value; followed by the symbol's
 .Cm LONG
 ID.

--- a/test/asm/rpn-undefined.asm
+++ b/test/asm/rpn-undefined.asm
@@ -1,0 +1,4 @@
+section "test", rom0
+db UNDEFINED         ; 4-byte ID
+db BANK("Undefined") ; N-byte string
+bit UNDEFINED, a     ; 1-byte value


### PR DESCRIPTION
Fixes #1817

The problem was that `writeRpn` did not have a `case` for `RPN_BIT_INDEX`. (It also did not have `case`s for `RPN_SIZEOF_SECTTYPE` or `RPN_STARTOF_SECTTYPE`, but those are always known at asm time so they never caused issues.)

I refactored `writeRpn` and inlined it into `initPatch`.