### PR TITLE
Use a vector of RPN values instead of byte-encoding them in a different way than the actual object output's RPN buffer

### DIFF
--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -12,15 +12,18 @@
 
 struct Symbol;
 
+struct RPNValue {
+	RPNCommand command;
+	std::variant<std::monostate, uint8_t, uint32_t, std::string> data;
+};
+
 struct Expression {
 	std::variant<
 	    int32_t,    // If the expression's value is known, it's here
 	    std::string // Why the expression is not known, if it isn't
 	    >
 	    data = 0;
-	bool isSymbol = false; // Whether the expression represents a symbol suitable for const diffing
-	std::vector<uint8_t> rpn{}; // Bytes serializing the RPN expression
-	uint32_t rpnPatchSize = 0;  // Size the expression will take in the object file
+	std::vector<RPNValue> rpn{}; // Values to be serialized into the RPN expression
 
 	bool isKnown() const { return std::holds_alternative<int32_t>(data); }
 	int32_t value() const { return std::get<int32_t>(data); }
@@ -45,11 +48,6 @@ struct Expression {
 	void makeCheckBitIndex(uint8_t mask);
 
 	void checkNBit(uint8_t n) const;
-
-private:
-	void clear();
-	uint8_t *reserveSpace(uint32_t size);
-	uint8_t *reserveSpace(uint32_t size, uint32_t patchSize);
 };
 
 bool checkNBit(int32_t v, uint8_t n, char const *name);


### PR DESCRIPTION
RGBASM encodes expressions as RPN buffers of raw bytes for object file output, which are then read by RGBLINK. However, currently it also has a *different* kind of byte encoding, used for intermediate expression build-up. For example, the intermediate encoding saves `RPN_SYM` followed by the bytes of a symbol's name (including a terminating `'\0'`), while the final output encoding is `RPN_SYM` followed by the four-byte little-endian symbol ID. This intermediate encoding may have been chosen for convenience in C, but now C++ makes it easy to have a "dynamic array (`std::vector`) of heterogeneous values (`std::variant`)". And the intermediate encoding is more fragile, easier to make mistakes, since raw byte buffers have no type-checking (as #1819 found).

This will need to be performance-tested and probably optimized, but that could be done in subsequent commits. Some ideas:

- Assume the RPN vector is empty instead of `clear`ing it, when appropriate
- Use `emplace_back` instead of `push_back` (so `RPNValue` will need constructors)
- `reserve` space in vectors before `insert`ing or `push_back`ing many values

Edit: Actually performance for building pokecrystal is indistinguishable from before (5.19 instead of 5.20).