### PR TITLE
Allow `charmap` to map `'characters'` as well as `"strings"`

### DIFF
--- a/man/rgbasm.5
+++ b/man/rgbasm.5
@@ -638,12 +638,12 @@ and the values of a charmap entry are counted by
 When writing text strings that are meant to be displayed on the Game Boy, the character encoding in the ROM may need to be different than the source file encoding.
 For example, the tiles used for uppercase letters may be placed starting at tile index 128, which differs from ASCII starting at 65.
 .Pp
-Character maps allow mapping strings to arbitrary sequences of numbers:
+Character maps allow mapping strings or character literals to arbitrary sequences of numbers:
 .Bd -literal -offset indent
 CHARMAP "A", 42
-CHARMAP ":)", 39
+CHARMAP ':)', 39
 CHARMAP "<br>", 13, 10
-CHARMAP "&euro;", $20ac
+CHARMAP '&euro;', $20ac
 .Ed
 .Pp
 This would result in

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -1049,6 +1049,9 @@ charmap:
 	POP_CHARMAP string COMMA charmap_args trailing_comma {
 		charmap_Add($2, std::move($4));
 	}
+	| POP_CHARMAP CHARACTER COMMA charmap_args trailing_comma {
+		charmap_Add($2, std::move($4));
+	}
 ;
 
 charmap_args:

--- a/test/asm/character-literals.asm
+++ b/test/asm/character-literals.asm
@@ -1,13 +1,13 @@
 def s equs "d"
 
-charmap "A", 1
-charmap "B", 2
-charmap "c{s}e", 3
-charmap "F", 4, 5, 6
+charmap 'A', 1
+charmap 'B', 2
+charmap 'c{s}e', 3
+charmap 'F', 4, 5, 6
 charmap "'", 42
-charmap "\"", 1234
-charmap "\n\r\t\0", 1337
-charmap "',\",\\", 99
+charmap '"', 1234
+charmap '\n\r\t\0', 1337
+charmap '\',\",\\', 99
 
 MACRO char
 	assert (\1) == (\2)


### PR DESCRIPTION
Fixes https://github.com/ISSOtm/rsgbds/issues/19