### PR TITLE
Make CLI and `OPT` options `-p` and `-Q` more consistent

### DIFF
--- a/src/asm/main.cpp
+++ b/src/asm/main.cpp
@@ -402,7 +402,7 @@ int main(int argc, char *argv[]) {
 			char *endptr;
 			unsigned long precision = strtoul(precisionArg, &endptr, 0);
 
-			if (musl_optarg[0] == '\0' || *endptr != '\0') {
+			if (precisionArg[0] == '\0' || *endptr != '\0') {
 				fatal("Invalid argument for option '-Q'");
 			}
 

--- a/test/asm/invalid-opt.err
+++ b/test/asm/invalid-opt.err
@@ -20,15 +20,15 @@ error: Repeated digit for graphics constant 'y'
     at invalid-opt.asm(10)
 error: Invalid argument for option 'p'
     at invalid-opt.asm(11)
-error: Invalid argument for option 'p'
+error: Argument for option 'p' must be between 0 and 0xFF
     at invalid-opt.asm(12)
 error: Invalid argument for option 'Q'
     at invalid-opt.asm(13)
-error: Invalid argument for option 'Q'
+error: Argument for option 'Q' must be between 1 and 31
     at invalid-opt.asm(14)
 error: Argument for option 'Q' must be between 1 and 31
     at invalid-opt.asm(15)
-error: Argument for option 'r' is out of range ("99999999999999999999999999")
+error: Argument for option 'r' is out of range
     at invalid-opt.asm(16)
 error: Must specify an argument for option 'W'
     at invalid-opt.asm(17)

--- a/test/asm/opt-r.err
+++ b/test/asm/opt-r.err
@@ -1,6 +1,6 @@
-error: Missing argument for option 'r'
+error: Invalid argument for option 'r'
     at opt-r.asm(5)
-error: Invalid argument for option 'r' ("2a")
+error: Invalid argument for option 'r'
     at opt-r.asm(6)
 FATAL: Recursion limit (0) exceeded
     at opt-r.asm(13)

--- a/test/asm/opt.asm
+++ b/test/asm/opt.asm
@@ -1,7 +1,8 @@
 SECTION "test", ROM0
 
 pusho
-	opt p42, -Q.4, Wno-div
+	opt p66, -Q.4, Wno-div
+	opt -p  0x42, Q  .0x04, -W  no-div ; idempotent
 	ds 1
 	println $8000_0000 / -1
 	def n = 3.14
@@ -13,6 +14,6 @@ popo
 	def n = 3.14
 	println "{x:n} = {f:n}"
 
-pusho -p99
+pusho -p153
 	ds 1
 popo

--- a/test/asm/opt.err
+++ b/test/asm/opt.err
@@ -1,2 +1,2 @@
 warning: Division of -2147483648 by -1 yields -2147483648 [-Wdiv]
-    at opt.asm(12)
+    at opt.asm(13)


### PR DESCRIPTION
Fixes #1833

- `opt p` was parsing its argument with `sscanf("%x")`, expecting exactly two hex digits, unlike the CLI `strtoul`.
- `opt Q` was parsing its argument with `sscanf("%u")`, expecting one or two decimal digits, unlike the CLI `strtoul`.
- `opt r` was skipping any leading space, but none of the others were.
- `opt r` was parsing its argument with `strtoul` in base 10, unlike the CLI base-unspecified `strtoul`.
