### PR TITLE
Use `musttail` attribute to guarantee tail recursion

### DIFF
--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -60,4 +60,13 @@
 	#define _POSIX_C_SOURCE 200809L
 #endif
 
+// gcc and clang have their own `musttail` attributes for tail recursion
+#if defined(__clang__) && __has_cpp_attribute(clang::musttail)
+	#define MUSTTAIL [[clang::musttail]]
+#elif defined(__GNUC__) && __has_cpp_attribute(gnu::musttail)
+	#define MUSTTAIL [[gnu::musttail]]
+#else
+	#define MUSTTAIL
+#endif
+
 #endif // RGBDS_PLATFORM_HPP

--- a/src/link/assign.cpp
+++ b/src/link/assign.cpp
@@ -15,6 +15,7 @@
 #include "helpers.hpp"
 #include "itertools.hpp"
 #include "linkdefs.hpp"
+#include "platform.hpp" // MUSTTAIL
 #include "verbosity.hpp"
 
 #include "link/main.hpp"
@@ -203,7 +204,7 @@ static std::optional<size_t> getPlacement(Section const &section, MemoryLocation
 		return std::nullopt;
 	}
 
-	return getPlacement(section, location); // Tail recursion
+	MUSTTAIL return getPlacement(section, location);
 }
 
 static std::string getSectionDescription(Section const &section) {


### PR DESCRIPTION
This has been supported since clang 13 and since gcc 15.1.