### PR TITLE
Fix some rgblink object file input bugs found via fuzzing with AFL++

### DIFF
--- a/include/linkdefs.hpp
+++ b/include/linkdefs.hpp
@@ -120,7 +120,7 @@ enum SectionModifier { SECTION_NORMAL, SECTION_UNION, SECTION_FRAGMENT };
 
 extern char const * const sectionModNames[];
 
-enum ExportLevel { SYMTYPE_LOCAL, SYMTYPE_IMPORT, SYMTYPE_EXPORT };
+enum ExportLevel { SYMTYPE_LOCAL, SYMTYPE_IMPORT, SYMTYPE_EXPORT, SYMTYPE_INVALID };
 
 enum PatchType {
 	PATCHTYPE_BYTE,

--- a/src/link/assign.cpp
+++ b/src/link/assign.cpp
@@ -119,6 +119,15 @@ static std::optional<size_t> getPlacement(Section const &section, MemoryLocation
 	SectionTypeInfo const &typeInfo = sectionTypeInfo[section.type];
 
 	for (;;) {
+		if (location.bank < typeInfo.firstBank
+		    || location.bank >= memory[section.type].size() + typeInfo.firstBank) {
+			fatal(
+			    "Invalid bank for %s section: 0x%02x",
+			    sectionTypeInfo[section.type].name.c_str(),
+			    location.bank
+			);
+		}
+
 		// Switch to the beginning of the next bank
 		std::deque<FreeSpace> &bankMem = memory[section.type][location.bank - typeInfo.firstBank];
 		size_t spaceIdx = 0;


### PR DESCRIPTION
- ID numbers (for fstack nodes, sections, symbols, patches, etc) might be too large for their associated collection
- Enum values might be invalid
- Bank values might be out of range for their section types