### PR TITLE
Fix bug where an object's invalid ROMX bank of 0 could break rgblink

### DIFF
--- a/src/link/assign.cpp
+++ b/src/link/assign.cpp
@@ -122,8 +122,9 @@ static std::optional<size_t> getPlacement(Section const &section, MemoryLocation
 		if (location.bank < typeInfo.firstBank
 		    || location.bank >= memory[section.type].size() + typeInfo.firstBank) {
 			fatal(
-			    "Invalid bank for %s section: 0x%02x",
+			    "Invalid bank for %s section \"%s\": %" PRIu32,
 			    sectionTypeInfo[section.type].name.c_str(),
+			    section.name.c_str(),
 			    location.bank
 			);
 		}

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -71,9 +71,7 @@ void out_AddSection(Section const &section) {
 	};
 
 	uint32_t targetBank = section.bank - sectionTypeInfo[section.type].firstBank;
-	uint32_t minNbBanks = targetBank + 1;
-
-	if (minNbBanks > maxNbBanks[section.type]) {
+	if (targetBank >= maxNbBanks[section.type]) {
 		fatal(
 		    "Section \"%s\" has an invalid bank range (%" PRIu32 " > %" PRIu32 ")",
 		    section.name.c_str(),
@@ -81,16 +79,14 @@ void out_AddSection(Section const &section) {
 		    maxNbBanks[section.type] - 1
 		);
 	}
-
-	for (uint32_t i = sections[section.type].size(); i < minNbBanks; ++i) {
-		sections[section.type].emplace_back();
+	if (sections[section.type].size() <= targetBank) {
+		sections[section.type].resize(targetBank + 1);
 	}
 
+	// Insert section while keeping the list sorted by increasing org
 	std::deque<Section const *> &bankSections =
 	    section.size ? sections[section.type][targetBank].sections
 	                 : sections[section.type][targetBank].zeroLenSections;
-
-	// Insert section while keeping the list sorted by increasing org
 	auto pos = bankSections.begin();
 	while (pos != bankSections.end() && (*pos)->org < section.org) {
 		++pos;


### PR DESCRIPTION
This also simplifies multiple `emplace_back`s into one `resize`.