### PR TITLE
Specify `-std=c++20` not `c++2a`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ WARNFLAGS := -Wall -pedantic -Wno-unknown-warning-option -Wno-gnu-zero-variadic-
 # Overridable CXXFLAGS
 CXXFLAGS     ?= -O3 -flto -DNDEBUG
 # Non-overridable CXXFLAGS
-REALCXXFLAGS := ${CXXFLAGS} ${WARNFLAGS} -std=c++2a -I include -fno-exceptions -fno-rtti
+REALCXXFLAGS := ${CXXFLAGS} ${WARNFLAGS} -std=c++20 -I include -fno-exceptions -fno-rtti
 # Overridable LDFLAGS
 LDFLAGS      ?=
 # Non-overridable LDFLAGS
@@ -254,7 +254,7 @@ tidy: src/asm/parser.hpp src/link/script.hpp
 iwyu:
 	$Qenv ${MAKE} \
 		CXX="include-what-you-use" \
-		REALCXXFLAGS="-std=c++2a -I include"
+		REALCXXFLAGS="-std=c++20 -I include"
 
 # Targets for the project maintainer to easily create Windows exes.
 # This is not for Windows users!

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,4 +1,4 @@
--std=c++2a
+-std=c++20
 -I
 include
 -fno-exceptions


### PR DESCRIPTION
"C++2a" was the draft name for the C++20 standard. gcc 9 required `-std=c++2a` for preliminary C++20 support. However, ever since #1660 we no longer support building with gcc 9, so we should be able to specify `-std=c++20`. (For CMake we already have `set(CMAKE_CXX_STANDARD 20)`.) gcc 10 and clang 11 both support `-std=c++20`.