### PR TITLE
Avoid the workaround for uploading a single directory as an artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,9 +27,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report
-          # Workaround for keeping the top-level coverage/ directory
-          # https://github.com/actions/upload-artifact/issues/174
-          path: |
-            coverage
-            dummy-file-to-keep-directory-structure.txt
+          # The top-level coverage/ directory is preserved after the wildcard pattern.
+          path: */coverage/
           if-no-files-found: error


### PR DESCRIPTION
Fixes #1911

As of `actions/upload-artifact@v7`, "If a wildcard pattern is used, the path hierarchy will be preserved after the first wildcard pattern." This means we no longer need to rely on the dummy file workaround ("If multiple paths are provided as input, the least common ancestor of all the search paths will be used as the root directory of the artifact").