### PR TITLE
Avoid specifying bash as the command shell in CI

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -10,7 +10,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Install deps
-        shell: bash
         run: |
           ./.github/scripts/install_deps.sh ubuntu-latest
       - name: Static analysis

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,14 +10,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Install deps
-        shell: bash
         run: |
           ./.github/scripts/install_deps.sh ubuntu
       - name: Install LCOV
         run: |
           sudo apt-get install lcov
       - name: Install test dependency dependencies
-        shell: bash
         run: |
           test/fetch-test-deps.sh --get-deps ubuntu
       - name: Generate coverage report

--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           bash .github/scripts/install_deps.sh windows
       - name: Build Windows binaries
-        shell: bash
         run: |
           cmake -S . -B build --preset msvc${{ matrix.bits }} -DFETCHCONTENT_BASE_DIR="${{ env.DEPS_ROOT_DIR }}"
           cmake --build build --config Release
@@ -53,7 +52,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Install deps
-        shell: bash
         run: |
           ./.github/scripts/install_deps.sh macos
       - name: Build libpng
@@ -80,7 +78,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Install deps
-        shell: bash
         run: |
           ./.github/scripts/install_deps.sh ubuntu-22.04
       - name: Build binaries

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ env:
   # otherwise they can trigger `-Werror=dev` (from the `develop` preset).
   DEPS_ROOT_DIR: ~/_deps # Note that this needs to be used in a position where Bash will trigger tilde expansion!
 
-# We'd rather stick to a single syntax across all OSes (and, we shamelessly are Unix devs).
+# We use bash syntax across OSes for consistency unless otherwise specified
 defaults:
   run:
     shell: bash

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,6 +20,11 @@ env:
   # otherwise they can trigger `-Werror=dev` (from the `develop` preset).
   DEPS_ROOT_DIR: ~/_deps # Note that this needs to be used in a position where Bash will trigger tilde expansion!
 
+# We'd rather stick to a single syntax across all OSes (and, we shamelessly are Unix devs).
+defaults:
+  run:
+    shell: bash
+
 jobs:
   unix:
     strategy:
@@ -35,7 +40,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Install deps
-        shell: bash
         run: |
           ./.github/scripts/install_deps.sh ${{ matrix.os }}
       - name: Build & install using Make
@@ -66,7 +70,6 @@ jobs:
           if-no-files-found: error
       - name: Compute test dependency cache params
         id: test-deps-cache-params
-        shell: bash
         run: |
           paths=$(test/fetch-test-deps.sh --get-paths)
           hash=$(test/fetch-test-deps.sh --get-hash)
@@ -84,12 +87,10 @@ jobs:
         run: |
           test/fetch-test-deps.sh
       - name: Install test dependency dependencies
-        shell: bash
         run: |
           test/fetch-test-deps.sh --get-deps ${{ matrix.os }}
       - name: Run tests using our script
         if: matrix.buildsys == 'make'
-        shell: bash
         run: |
           CXX=${{ matrix.cxx }} test/run-tests.sh --os ${{ matrix.os }}
       - name: Run tests using CTest
@@ -103,7 +104,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Install deps
-        shell: bash
         run: |
           ./.github/scripts/install_deps.sh macos
       - name: Build libpng
@@ -124,7 +124,6 @@ jobs:
           if-no-files-found: error
       - name: Compute test dependency cache params
         id: test-deps-cache-params
-        shell: bash
         run: |
           paths=$(test/fetch-test-deps.sh --get-paths)
           hash=$(test/fetch-test-deps.sh --get-hash)
@@ -142,11 +141,9 @@ jobs:
         run: |
           test/fetch-test-deps.sh
       - name: Install test dependency dependencies
-        shell: bash
         run: |
           test/fetch-test-deps.sh --get-deps macos
       - name: Run tests
-        shell: bash
         run: |
           test/run-tests.sh --os macos
 
@@ -175,7 +172,6 @@ jobs:
           cmake --build build
       - name: Package binaries
         working-directory: build
-        shell: bash
         run: |
           cpack -DCPACK_PACKAGE_FILE_NAME=rgbds-win${{ matrix.bits }} -G ZIP -C Debug --verbose
       - name: Upload Windows binaries
@@ -186,7 +182,6 @@ jobs:
           if-no-files-found: error
       - name: Compute test dependency cache params
         id: test-deps-cache-params
-        shell: bash
         run: |
           paths=$(test/fetch-test-deps.sh --get-paths)
           hash=$(test/fetch-test-deps.sh --get-hash)
@@ -200,16 +195,13 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.bits }}-${{ steps.test-deps-cache-params.outputs.hash }}
       - name: Fetch test dependency repositories
         if: steps.test-deps-cache.outputs.cache-hit != 'true'
-        shell: bash
         continue-on-error: true
         run: |
           test/fetch-test-deps.sh
       - name: Install test dependency dependencies
-        shell: bash
         run: |
           test/fetch-test-deps.sh --get-deps ${{ matrix.os }}
       - name: Run tests
-        shell: bash
         run: |
           test/run-tests.sh --os ${{ matrix.os }}
 
@@ -232,7 +224,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Install deps
-        shell: bash
         run: |
           ./.github/scripts/install_deps.sh ubuntu
       - name: Install MinGW
@@ -289,13 +280,11 @@ jobs:
           name: testing-programs-mingw-win${{ matrix.bits }}
           path: test/gfx
       - name: Extract binaries
-        shell: bash
         run: |
           cp bins/* .
           cp bins/*.dll test/gfx
       - name: Compute test dependency cache params
         id: test-deps-cache-params
-        shell: bash
         run: |
           paths=$(test/fetch-test-deps.sh --get-paths)
           hash=$(test/fetch-test-deps.sh --get-hash)
@@ -309,16 +298,13 @@ jobs:
           key: mingw-${{ matrix.bits }}-${{ steps.test-deps-cache-params.outputs.hash }}
       - name: Fetch test dependency repositories
         if: steps.test-deps-cache.outputs.cache-hit != 'true'
-        shell: bash
         continue-on-error: true
         run: |
           test/fetch-test-deps.sh
       - name: Install test dependency dependencies
-        shell: bash
         run: |
           test/fetch-test-deps.sh --get-deps ${{ matrix.os }}
       - name: Run tests
-        shell: bash
         run: |
           test/run-tests.sh --os ${{ matrix.os }}
 


### PR DESCRIPTION
It is the default outside of Windows, thus a no-op; and even there, it's terser to just call `bash` on scripts as necessary.