### PR TITLE
Overhaul `checkdiff` CI

### DIFF
--- a/.github/workflows/checkdiff.yml
+++ b/.github/workflows/checkdiff.yml
@@ -5,14 +5,17 @@ jobs:
   checkdiff:
     runs-on: ubuntu-slim
     steps:
-      - name: Set up repo
-        run: |
-          git clone -b "${{ github.event.pull_request.head.ref }}" "${{ github.event.pull_request.head.repo.clone_url }}" rgbds
-          cd rgbds
-          git remote add upstream "${{ github.event.pull_request.base.repo.clone_url }}"
-          git fetch upstream
+      - name: Clone repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check diff
-        working-directory: rgbds
         shell: bash # Bash is the default, but specifying it explicitly enables `-o pipefail`.
         run: |
-          make -s checkdiff BASE_REF=${{ github.event.pull_request.base.sha }} | sed -E 's/^/::warning::/'
+          MERGE_BASE=$(gh api "/repos/{owner}/{repo}/compare/$BASE_SHA...$HEAD_SHA" --jq '.merge_base_commit.sha')
+          git fetch origin "$MERGE_BASE"
+          contrib/checkdiff.bash "$MERGE_BASE" | sed -E 's/^/::warning::/'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/checkdiff.yml
+++ b/.github/workflows/checkdiff.yml
@@ -13,5 +13,6 @@ jobs:
           git fetch upstream
       - name: Check diff
         working-directory: rgbds
+        shell: bash # Bash is the default, but specifying it explicitly enables `-o pipefail`.
         run: |
-          make checkdiff "BASE_REF=${{ github.event.pull_request.base.sha }}" Q=
+          make -s checkdiff BASE_REF=${{ github.event.pull_request.base.sha }} | sed -E 's/^/::warning::/'

--- a/.github/workflows/checkdiff.yml
+++ b/.github/workflows/checkdiff.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   checkdiff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Set up repo
         run: |

--- a/.github/workflows/checkdiff.yml
+++ b/.github/workflows/checkdiff.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Check diff
         working-directory: rgbds
         run: |
-          make checkdiff "BASE_REF=${{ github.event.pull_request.base.sha }}" Q= | tee log
+          make checkdiff "BASE_REF=${{ github.event.pull_request.base.sha }}" Q=

--- a/contrib/checkdiff.bash
+++ b/contrib/checkdiff.bash
@@ -3,17 +3,17 @@
 # SPDX-License-Identifier: MIT
 
 declare -A FILES
-while read -r -d '' file; do
-	FILES["$file"]="true"
+while IFS= read -r -d '' file; do
+	FILES["$file"]=true
 done < <(git diff --name-only -z "$1" HEAD)
 
 edited () {
-	${FILES["$1"]:-"false"}
+	${FILES["$1"]:-false}
 }
 
 dependency () {
 	if edited "$1" && ! edited "$2"; then
-		echo "'$1' was modified, but not '$2'! $3" | xargs
+		echo "'$1' was modified, but not '$2'! $3"
 	fi
 }
 


### PR DESCRIPTION
Closes #1935, which is just an example of how the new script behaves.

<img width="756" height="522" alt="image" src="https://github.com/user-attachments/assets/e82c537c-9a57-4c8f-bcf0-455fa154fd09" />
