### PR TITLE
Stop trying to explicitly install pkg-config in CI

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -5,7 +5,7 @@ set -eu
 case "${1%-*}" in
 	ubuntu)
 		sudo apt-get -qq update
-		sudo apt-get install -yq bison libpng-dev pkg-config
+		sudo apt-get install -yq bison libpng-dev
 		;;
 	macos)
 		# macOS bundles GNU Make 3.81, which doesn't support synced output.


### PR DESCRIPTION
Turns out it's already installed by default, but under a different name that's causing extra ops for no real gain.