### PR TITLE
Target an even older version of macOS

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -30,10 +30,18 @@ case "${OS%%-*}" in
 		sudo apt-get install -yq $pkgs
 		;;
 	macos)
+		pkgs=bison
+		case $TOOLSET in
+			'' | lld)
+				pkgs="$pkgs $TOOLSET"
+				TOOLSET=
+			;;
+		esac
 		# macOS bundles GNU Make 3.81, which doesn't support synced output.
 		# We leave it as the default in `PATH`, to test that our Makefile works with it.
 		# However, CMake automatically uses Homebrew's `gmake`, so our CI has synced output.
-		brew install bison make
+		# shellcheck disable=SC2086 # (This word splitting is intentional.)
+		brew install $pkgs make
 		# Export `bison` to allow using the version we install from Homebrew,
 		# instead of the outdated one preinstalled on macOS (which doesn't even support `-Wall`...).
 		export PATH="$(brew --prefix)/opt/bison/bin:$PATH"

--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -64,7 +64,7 @@ jobs:
           cmake --build build
           strip rgb{asm,link,fix,gfx}
         env:
-          LDFLAGS: -fuse-ld=lld # See the preset's comments for rationale.
+          LDFLAGS: -fuse-ld=lld # cmake/macos-static.cmake comments explain why we use lld.
       - name: Package binaries
         run: |
           zip --junk-paths rgbds-macos.zip rgb{asm,link,fix,gfx} man/* .github/scripts/install.sh

--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -57,12 +57,14 @@ jobs:
         uses: actions/checkout@v6
       - name: Install deps
         run: |
-          ./.github/scripts/install_deps.sh macos
+          ./.github/scripts/install_deps.sh macos lld
       - name: Build binaries
         run: |
           cmake -S . -B build --preset macos-static -DFETCHCONTENT_BASE_DIR="${{ env.DEPS_ROOT_DIR }}"
           cmake --build build
           strip rgb{asm,link,fix,gfx}
+        env:
+          LDFLAGS: -fuse-ld=lld # See the preset's comments for rationale.
       - name: Package binaries
         run: |
           zip --junk-paths rgbds-macos.zip rgb{asm,link,fix,gfx} man/* .github/scripts/install.sh

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Install deps
         run: |
           ./.github/scripts/install_deps.sh macos
+          brew install lld
       - name: Cache library deps
         uses: actions/cache@v5
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -125,7 +125,7 @@ jobs:
           cmake -S . -B build --preset macos-static -DFETCHCONTENT_BASE_DIR="${{ env.DEPS_ROOT_DIR }}" -DTESTS_OS_NAME=macos
           cmake --build build
         env:
-          LDFLAGS: -fuse-ld=lld # See the preset's comments for rationale.
+          LDFLAGS: -fuse-ld=lld # cmake/macos-static.cmake comments explain why we use lld.
       - name: Package binaries
         run: |
           mkdir bins

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Install deps
         run: |
-          .github/scripts/install_deps.sh macos
+          .github/scripts/install_deps.sh macos lld
       - name: Cache library deps
         uses: actions/cache@v5
         with:
@@ -124,6 +124,8 @@ jobs:
         run: |
           cmake -S . -B build --preset macos-static -DFETCHCONTENT_BASE_DIR="${{ env.DEPS_ROOT_DIR }}" -DTESTS_OS_NAME=macos
           cmake --build build
+        env:
+          LDFLAGS: -fuse-ld=lld # See the preset's comments for rationale.
       - name: Package binaries
         run: |
           mkdir bins

--- a/cmake/macos-static.cmake
+++ b/cmake/macos-static.cmake
@@ -2,12 +2,12 @@
 # in order to generate executables compatible with old macOS versions.
 # See our `macos-static` CMake preset for how it's meant to be used.
 
-# The `-mmacosx-version-min=10.9` flag ensures that the binary only uses APIs available on Mac OS X 10.9 Mavericks.
+# The `-mmacosx-version-min=10.4` flag ensures that the binary only uses APIs available on Mac OS X 10.4 Tiger.
 # The `-arch` flags build a "fat binary" that works on both Apple architectures:
 # older Intel x64 Macs and newer ARM "Apple Silicon" ones.
-set(secret_sauce -mmacosx-version-min=10.9 "SHELL:-arch x86_64" "SHELL:-arch arm64") # Avoid `-arch` being dedup'd.
+set(secret_sauce -mmacosx-version-min=10.4 "SHELL:-arch x86_64" "SHELL:-arch arm64") # Avoid `-arch` being dedup'd.
 add_compile_options(${secret_sauce})
-add_link_options(${secret_sauce})
+add_link_options(${secret_sauce} -fuse-ld=lld) # Apple's linker just crashes.
 set(PNG_HARDWARE_OPTIMIZATIONS OFF) # These do not play well with a dual-arch build.
 
 # Mac OS X has always provided zlib, so we can safely link dynamically against it.

--- a/cmake/macos-static.cmake
+++ b/cmake/macos-static.cmake
@@ -2,10 +2,9 @@
 # in order to generate executables compatible with old macOS versions.
 # See our `macos-static` CMake preset for how it's meant to be used.
 
-# Note that targeting old enough versions of macOS on recent enough versions of macOS
+# Note that targeting old enough versions of Mac OS X on recent enough versions of macOS
 # triggers some poorly-tested code paths within Apple's linker, which then crashes.
-# This can be worked around by using LLD (install it e.g. via Brew, and pass `-fuse-ld=lld`
-# when linking).
+# This can be worked around by using LLVM's LLD linker and passing `-fuse-ld=lld` when linking.
 
 # The `-mmacosx-version-min=10.4` flag ensures that the binary only uses APIs available on Mac OS X 10.4 Tiger.
 # The `-arch` flags build a "fat binary" that works on both Apple architectures:

--- a/cmake/macos-static.cmake
+++ b/cmake/macos-static.cmake
@@ -2,10 +2,15 @@
 # in order to generate executables compatible with old macOS versions.
 # See our `macos-static` CMake preset for how it's meant to be used.
 
-# The `-mmacosx-version-min=10.9` flag ensures that the binary only uses APIs available on Mac OS X 10.9 Mavericks.
+# Note that targeting old enough versions of macOS on recent enough versions of macOS
+# triggers some poorly-tested code paths within Apple's linker, which then crashes.
+# This can be worked around by using LLD (install it e.g. via Brew, and pass `-fuse-ld=lld`
+# when linking).
+
+# The `-mmacosx-version-min=10.4` flag ensures that the binary only uses APIs available on Mac OS X 10.4 Tiger.
 # The `-arch` flags build a "fat binary" that works on both Apple architectures:
 # older Intel x64 Macs and newer ARM "Apple Silicon" ones.
-set(secret_sauce -mmacosx-version-min=10.9 "SHELL:-arch x86_64" "SHELL:-arch arm64") # Avoid `-arch` being dedup'd.
+set(secret_sauce -mmacosx-version-min=10.4 "SHELL:-arch x86_64" "SHELL:-arch arm64") # Avoid `-arch` being dedup'd.
 add_compile_options(${secret_sauce})
 add_link_options(${secret_sauce})
 set(PNG_HARDWARE_OPTIMIZATIONS OFF) # These do not play well with a dual-arch build.


### PR DESCRIPTION
We can, so let's not ask if we should!

<details><summary>

Okay, so, turns out that Apple's linker just... [throws an assertion failure](https://github.com/ISSOtm/rgbds/actions/runs/24371230011/job/71175112198#step:5:190):

</summary>

```
ld: warning: support for macOS with 10.4 minimum deployment target is deprecated and will be removed in future release
0  0x104707474  __assert_rtn + 140
1  0x104714158  ld::passes::stubs::arm::StubHelperAtom::StubHelperAtom(ld::passes::stubs::Pass&, ld::Atom const&, ld::Atom const*, bool) (.cold.1) + 0
2  0x10465ea48  ld::passes::stubs::x86_64::classic::StubHelperAtom::~StubHelperAtom() + 0
3  0x10465bcd4  ld::passes::stubs::Pass::makeStub(ld::Atom const&, bool) + 4740
4  0x10465cef4  ld::passes::stubs::Pass::process(ld::Internal&) + 1396
5  0x10465d42c  ld::passes::stubs::doPass(Options const&, ld::Internal&) + 100
6  0x1044ff028  main + 664
A linker snapshot was created at:
    /tmp/script-x86_64.out-2026-04-13-230001.ld-snapshot
ld: Assertion failed: (targetAtom != NULL), function Fixup, file ld.hpp, line 1045.
```

</details>

So we have to use LLD instead, which needs to be installed explicitly. I'm doing it as a bodge in the initial version of this PR, as I want to use the “toolset” mechanism from #1906 to do that properly.