### PR TITLE
Set up Cygwin before cloning our repo

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -327,19 +327,25 @@ jobs:
       run:
         shell: C:\cygwin\bin\env.exe CYGWIN_NOWINPATH=1 CHERE_INVOKING=1 C:\cygwin\bin\bash.exe -o igncr '{0}'
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
       - name: Setup Cygwin
         uses: cygwin/cygwin-install-action@v6
         with:
           platform: ${{ matrix.arch }}
           packages: >-
+            ca-certificates
             bison
             gcc-g++
             git
             libpng-devel
             make
             pkg-config
+      - name: Reset directory ownership
+        working-directory: ..
+        run: |
+          rmdir rgbds
+          mkdir rgbds
+      - name: Checkout repo
+        uses: actions/checkout@v6
       - name: Build & install using Make
         run: | # Cygwin does not support `make develop` sanitizers ASan or UBSan
           make -kj Q=

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -332,19 +332,25 @@ jobs:
       run:
         shell: C:\cygwin\bin\env.exe CYGWIN_NOWINPATH=1 CHERE_INVOKING=1 C:\cygwin\bin\bash.exe -o igncr '{0}'
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
       - name: Setup Cygwin
         uses: cygwin/cygwin-install-action@v6
         with:
           platform: ${{ matrix.arch }}
           packages: >-
             bison
+            ca-certificates
             gcc-g++
             git
             libpng-devel
             make
             pkg-config
+      - name: Reset directory ownership
+        working-directory: ..
+        run: |
+          rmdir rgbds
+          mkdir rgbds
+      - name: Checkout repo
+        uses: actions/checkout@v6
       - name: Build & install using Make
         run: | # Cygwin does not support `make develop` sanitizers ASan or UBSan
           make -kj Q=

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -332,25 +332,23 @@ jobs:
       run:
         shell: C:\cygwin\bin\env.exe CYGWIN_NOWINPATH=1 CHERE_INVOKING=1 C:\cygwin\bin\bash.exe -o igncr '{0}'
     steps:
+      - name: Save Windows git location for the PATH
+        shell: pwsh
+        run: | # The `cygwin/cygwin-install-action` step will override the PATH with Cygwin's binaries
+          "ORIGINAL_GIT_DIR=$(Split-Path (Get-Command git).Source)" >> $env:GITHUB_ENV
+      - name: Checkout repo
+        uses: actions/checkout@v6
       - name: Setup Cygwin
         uses: cygwin/cygwin-install-action@v6
         with:
           platform: ${{ matrix.arch }}
           packages: >-
             bison
-            ca-certificates
             gcc-g++
             git
             libpng-devel
             make
             pkg-config
-      - name: Reset directory ownership
-        working-directory: ..
-        run: |
-          rmdir rgbds
-          mkdir rgbds
-      - name: Checkout repo
-        uses: actions/checkout@v6
       - name: Build & install using Make
         run: | # Cygwin does not support `make develop` sanitizers ASan or UBSan
           make -kj Q=
@@ -358,6 +356,10 @@ jobs:
       - name: Run tests
         run: |
           test/run-tests.sh --only-internal
+      - name: Use Windows git location in the PATH
+        shell: pwsh
+        run: | # Prevents the `actions/checkout` post-job cleanup from using Cygwin's git binary
+          "$env:ORIGINAL_GIT_DIR" >> $env:GITHUB_PATH
 
   freebsd:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Without this PR, the "Post Checkout repo"  step of Cygwin CI exits with an error:

```
Post job cleanup.
D:\cygwin\bin\git.exe version
git version 2.38.1
Temporarily overriding HOME='D:\a\_temp\2cb78824-35d4-43a5-b9ae-49e577df7ed7' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
D:\cygwin\bin\git.exe config --global --add safe.directory D:\a\rgbds\rgbds
Removing SSH command configuration
D:\cygwin\bin\git.exe config --local --name-only --get-regexp core\.sshCommand
fatal: --local can only be used inside a git repository
D:\cygwin\bin\git.exe submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
fatal: detected dubious ownership in repository at '/cygdrive/d/a/rgbds/rgbds'
To add an exception for this directory, call:

	git config --global --add safe.directory /cygdrive/d/a/rgbds/rgbds
Warning: The process 'D:\cygwin\bin\git.exe' failed with exit code 128
```