### PR TITLE
Explicitly specify build and test jobs parallelism count

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
           test/fetch-test-deps.sh --get-deps ubuntu
       - name: Generate coverage report
         run: |
-          contrib/coverage.bash ubuntu-ci
+          contrib/coverage.bash --os ubuntu-ci --jobs $(getconf _NPROCESSORS_ONLN)
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -52,7 +52,7 @@ jobs:
         if: matrix.buildsys == 'make'
         run: |
           make develop -kj Q= CXX=${{ matrix.cxx }}
-          sudo make install -j Q=
+          sudo make install -j4 Q=
       - name: Build & install using CMake
         if: matrix.buildsys == 'cmake'
         # Since GitHub's runners are basically kitchen sinks,
@@ -98,7 +98,7 @@ jobs:
       - name: Run tests using our script
         if: matrix.buildsys == 'make'
         run: |
-          CXX=${{ matrix.cxx }} test/run-tests.sh --os ${{ matrix.os }}
+          CXX=${{ matrix.cxx }} test/run-tests.sh --os ${{ matrix.os }} --jobs 4
       - name: Run tests using CTest
         if: matrix.buildsys == 'cmake'
         run: |
@@ -311,7 +311,7 @@ jobs:
           test/fetch-test-deps.sh --get-deps ${{ matrix.os }}
       - name: Run tests
         run: |
-          test/run-tests.sh --os ${{ matrix.os }}
+          test/run-tests.sh --os ${{ matrix.os }} --jobs 4
 
   cygwin:
     strategy:
@@ -345,10 +345,10 @@ jobs:
       - name: Build & install using Make
         run: | # Cygwin does not support `make develop` sanitizers ASan or UBSan
           make -kj Q=
-          make install -j Q=
+          make install -j4 Q=
       - name: Run tests
         run: |
-          test/run-tests.sh --only-internal
+          test/run-tests.sh --jobs 4 --only-internal
 
   freebsd:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -52,7 +52,7 @@ jobs:
         if: matrix.buildsys == 'make'
         run: |
           make develop -kj Q= CXX=${{ matrix.cxx }}
-          sudo make install -j4 Q=
+          sudo make install Q=
       - name: Build & install using CMake
         if: matrix.buildsys == 'cmake'
         # Since GitHub's runners are basically kitchen sinks,
@@ -98,7 +98,7 @@ jobs:
       - name: Run tests using our script
         if: matrix.buildsys == 'make'
         run: |
-          CXX=${{ matrix.cxx }} test/run-tests.sh --os ${{ matrix.os }} --jobs 4
+          CXX=${{ matrix.cxx }} test/run-tests.sh --os ${{ matrix.os }} --jobs $(getconf _NPROCESSORS_ONLN)
       - name: Run tests using CTest
         if: matrix.buildsys == 'cmake'
         run: |
@@ -311,7 +311,7 @@ jobs:
           test/fetch-test-deps.sh --get-deps ${{ matrix.os }}
       - name: Run tests
         run: |
-          test/run-tests.sh --os ${{ matrix.os }} --jobs 4
+          test/run-tests.sh --os ${{ matrix.os }} --jobs $(getconf _NPROCESSORS_ONLN)
 
   cygwin:
     strategy:
@@ -344,11 +344,11 @@ jobs:
             pkg-config
       - name: Build & install using Make
         run: | # Cygwin does not support `make develop` sanitizers ASan or UBSan
-          make -kj Q=
-          make install -j4 Q=
+          make -k -j $(getconf _NPROCESSORS_ONLN) Q=
+          make install Q=
       - name: Run tests
         run: |
-          test/run-tests.sh --jobs 4 --only-internal
+          test/run-tests.sh --jobs $(getconf _NPROCESSORS_ONLN) --only-internal
 
   freebsd:
     runs-on: ubuntu-latest
@@ -371,6 +371,6 @@ jobs:
             .github/scripts/install_deps.sh freebsd
           run: | # Leak detection is not supported on FreeBSD, so disable it.
             cmake -B build --preset develop -DTESTS_OS_NAME=freebsd
-            cmake --build build --verbose -- -k -j 4
+            cmake --build build --verbose -- -k -j $(getconf _NPROCESSORS_ONLN)
             ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build --schedule-random --label-exclude external
             cmake --install build --verbose

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ env:
   CMAKE_CONFIG_TYPE: Debug # `cmake --build` now implies `--config Debug`.
   # Approximate number of CPU cores in GitHub's runners as of 2026-03-18:
   # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-  CTEST_PARALLEL_LEVEL: 0 # `ctest` now implies `--parallel 0` (number of logical CPUs).
+  CTEST_PARALLEL_LEVEL: 4 # `ctest` now implies `--parallel 4`.
   CTEST_NO_TESTS_ACTION: error # Make CTest fail if it cannot find any tests. (That should never happen.)
   CTEST_OUTPUT_ON_FAILURE: ON # CTest reports test program output on failure.
 
@@ -371,6 +371,6 @@ jobs:
             .github/scripts/install_deps.sh freebsd
           run: | # Leak detection is not supported on FreeBSD, so disable it.
             cmake -B build --preset develop -DTESTS_OS_NAME=freebsd
-            cmake --build build --verbose -- -k -j $(getconf _NPROCESSORS_ONLN)
+            cmake --build build --verbose -- -k -j $(getconf NPROCESSORS_ONLN)
             ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build --schedule-random --label-exclude external
             cmake --install build --verbose

--- a/contrib/coverage.bash
+++ b/contrib/coverage.bash
@@ -8,9 +8,9 @@ make coverage -j
 pushd test
 ./fetch-test-deps.sh
 if [[ $# -eq 0 ]]; then
-  ./run-tests.sh
+  ./run-tests.sh --jobs 4
 else
-  ./run-tests.sh --os "$1"
+  ./run-tests.sh --os "$1" --jobs 4
 fi
 popd
 

--- a/contrib/coverage.bash
+++ b/contrib/coverage.bash
@@ -2,16 +2,12 @@
 set -e
 
 # Build RGBDS with gcov support
-make coverage -j
+make coverage -j $(getconf _NPROCESSORS_ONLN)
 
-# Run the tests
+# Run the tests, forwarding all script arguments
 pushd test
 ./fetch-test-deps.sh
-if [[ $# -eq 0 ]]; then
-  ./run-tests.sh --jobs 4
-else
-  ./run-tests.sh --os "$1" --jobs 4
-fi
+./run-tests.sh "$@"
 popd
 
 # Generate coverage logs
@@ -24,12 +20,5 @@ lcov -c --no-external -d . -o "$COVERAGE_INFO"
 lcov -r "$COVERAGE_INFO" src/asm/parser.{hpp,cpp} src/link/script.{hpp,cpp} -o "$COVERAGE_INFO"
 genhtml --dark-mode --num-spaces 4 -f -s -o coverage/ "$COVERAGE_INFO"
 
-# Check whether running from coverage.yml workflow
-if [ "$1" != "ubuntu-ci" ]; then
-  # Open report in web browser
-  if [ "$(uname)" == "Darwin" ]; then
-    open coverage/index.html
-  else
-    xdg-open coverage/index.html
-  fi
-fi
+# Output the path to the report
+echo "Open $PWD/coverage/index.html"

--- a/contrib/coverage.bash
+++ b/contrib/coverage.bash
@@ -1,13 +1,57 @@
 #!/usr/bin/env bash
 set -e
 
+usage() {
+  cat <<"EOF"
+Generates LCOV code coverage report for RGBDS.
+Options:
+    -h, --help     show this help message
+    -o, --open     open the HTML report in the preferred application
+    --os <os>      specify <os> for test/run-tests.sh (e.g. `macos-14`)
+    --jobs <n>     build with `make -j<n>`
+EOF
+}
+
+# Parse options in pure Bash because macOS `getopt` is stuck
+# in what util-linux `getopt` calls `GETOPT_COMPATIBLE` mode
+runtests_args=
+make_jobs=
+open_report=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -o|--open)
+      open_report=true
+      ;;
+    --jobs)
+      shift
+      runtests_args="$runtests_args --jobs $1"
+      make_jobs="-j$1"
+      ;;
+    --os)
+      shift
+      runtests_os="$runtests_args --os $1"
+      ;;
+    *)
+      echo "$(basename "$0"): unknown option '$1'"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 # Build RGBDS with gcov support
-make coverage -j $(getconf _NPROCESSORS_ONLN)
+# shellcheck disable=SC2086 # (This word splitting is intentional.)
+make coverage $make_jobs
 
 # Run the tests, forwarding all script arguments
 pushd test
 ./fetch-test-deps.sh
-./run-tests.sh "$@"
+# shellcheck disable=SC2086 # (This word splitting is intentional.)
+./run-tests.sh $runtests_args
 popd
 
 # Generate coverage logs
@@ -20,5 +64,14 @@ lcov -c --no-external -d . -o "$COVERAGE_INFO"
 lcov -r "$COVERAGE_INFO" src/asm/parser.{hpp,cpp} src/link/script.{hpp,cpp} -o "$COVERAGE_INFO"
 genhtml --dark-mode --num-spaces 4 -f -s -o coverage/ "$COVERAGE_INFO"
 
-# Output the path to the report
-echo "Open $PWD/coverage/index.html"
+if "$open_report"; then
+  # Open the report in preferred web browser
+  if [ "$(uname)" == "Darwin" ]; then
+    open coverage/index.html
+  else
+    xdg-open coverage/index.html
+  fi
+else
+  # Output the path to the report
+  echo "Open $PWD/coverage/index.html"
+fi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,7 @@ foreach(component "asm" "link" "fix" "gfx")
            COMMAND bash -- test.sh
            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${component}")
   set_tests_properties("rgb${component}" PROPERTIES REQUIRED_FILES "$<TARGET_FILE:rgb${component}>"
-                                                    PROCESSORS 1
+                                                    PROCESSORS ${CMAKE_BUILD_PARALLEL_LEVEL}
                                                     LABELS "rgb${component}")
 endforeach()
 set_tests_properties(rgbgfx PROPERTIES REQUIRED_FILES "$<TARGET_FILE:rgbgfx>;$<TARGET_FILE:randtilegen>;$<TARGET_FILE:rgbgfx_test>")
@@ -44,9 +44,9 @@ add_test(NAME fetch-test-deps
 set_tests_properties(fetch-test-deps PROPERTIES FIXTURES_SETUP "external-repos"
                                                 LABELS "external")
 add_test(NAME external
-         COMMAND bash -- run-tests.sh --only-external ${ONLY_FREE} ${OS_NAME}
+         COMMAND bash -- run-tests.sh --jobs ${CMAKE_BUILD_PARALLEL_LEVEL} --only-external ${ONLY_FREE} ${OS_NAME}
          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 set_tests_properties(external PROPERTIES DEPENDS "rgbasm;rgblink;rgbfix;rgbgfx" # Only attempt building whole projects if each tool passes muster on its own.
-                                         PROCESSORS 4
+                                         PROCESSORS ${CMAKE_BUILD_PARALLEL_LEVEL}
                                          FIXTURES_REQUIRED "external-repos"
                                          LABELS "external") # Allow filtering out external tests.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,7 @@ foreach(component "asm" "link" "fix" "gfx")
            COMMAND bash -- test.sh
            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${component}")
   set_tests_properties("rgb${component}" PROPERTIES REQUIRED_FILES "$<TARGET_FILE:rgb${component}>"
-                                                    PROCESSORS $ENV{CTEST_PARALLEL_LEVEL}
+                                                    PROCESSORS 1 # This test is entirely serial.
                                                     LABELS "rgb${component}")
 endforeach()
 set_tests_properties(rgbgfx PROPERTIES REQUIRED_FILES "$<TARGET_FILE:rgbgfx>;$<TARGET_FILE:randtilegen>;$<TARGET_FILE:rgbgfx_test>")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,7 @@ foreach(component "asm" "link" "fix" "gfx")
            COMMAND bash -- test.sh
            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${component}")
   set_tests_properties("rgb${component}" PROPERTIES REQUIRED_FILES "$<TARGET_FILE:rgb${component}>"
-                                                    PROCESSORS ${CTEST_PARALLEL_LEVEL}
+                                                    PROCESSORS $ENV{CTEST_PARALLEL_LEVEL}
                                                     LABELS "rgb${component}")
 endforeach()
 set_tests_properties(rgbgfx PROPERTIES REQUIRED_FILES "$<TARGET_FILE:rgbgfx>;$<TARGET_FILE:randtilegen>;$<TARGET_FILE:rgbgfx_test>")
@@ -44,9 +44,9 @@ add_test(NAME fetch-test-deps
 set_tests_properties(fetch-test-deps PROPERTIES FIXTURES_SETUP "external-repos"
                                                 LABELS "external")
 add_test(NAME external
-         COMMAND bash -- run-tests.sh --jobs ${CTEST_PARALLEL_LEVEL} --only-external ${ONLY_FREE} ${OS_NAME}
+         COMMAND bash -- run-tests.sh --jobs $ENV{CTEST_PARALLEL_LEVEL} --only-external ${ONLY_FREE} ${OS_NAME}
          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 set_tests_properties(external PROPERTIES DEPENDS "rgbasm;rgblink;rgbfix;rgbgfx" # Only attempt building whole projects if each tool passes muster on its own.
-                                         PROCESSORS ${CTEST_PARALLEL_LEVEL}
+                                         PROCESSORS $ENV{CTEST_PARALLEL_LEVEL}
                                          FIXTURES_REQUIRED "external-repos"
                                          LABELS "external") # Allow filtering out external tests.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,7 @@ foreach(component "asm" "link" "fix" "gfx")
            COMMAND bash -- test.sh
            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${component}")
   set_tests_properties("rgb${component}" PROPERTIES REQUIRED_FILES "$<TARGET_FILE:rgb${component}>"
-                                                    PROCESSORS ${CMAKE_BUILD_PARALLEL_LEVEL}
+                                                    PROCESSORS ${CTEST_PARALLEL_LEVEL}
                                                     LABELS "rgb${component}")
 endforeach()
 set_tests_properties(rgbgfx PROPERTIES REQUIRED_FILES "$<TARGET_FILE:rgbgfx>;$<TARGET_FILE:randtilegen>;$<TARGET_FILE:rgbgfx_test>")
@@ -44,9 +44,9 @@ add_test(NAME fetch-test-deps
 set_tests_properties(fetch-test-deps PROPERTIES FIXTURES_SETUP "external-repos"
                                                 LABELS "external")
 add_test(NAME external
-         COMMAND bash -- run-tests.sh --jobs ${CMAKE_BUILD_PARALLEL_LEVEL} --only-external ${ONLY_FREE} ${OS_NAME}
+         COMMAND bash -- run-tests.sh --jobs ${CTEST_PARALLEL_LEVEL} --only-external ${ONLY_FREE} ${OS_NAME}
          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 set_tests_properties(external PROPERTIES DEPENDS "rgbasm;rgblink;rgbfix;rgbgfx" # Only attempt building whole projects if each tool passes muster on its own.
-                                         PROCESSORS ${CMAKE_BUILD_PARALLEL_LEVEL}
+                                         PROCESSORS ${CTEST_PARALLEL_LEVEL}
                                          FIXTURES_REQUIRED "external-repos"
                                          LABELS "external") # Allow filtering out external tests.

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -19,6 +19,7 @@ Options:
     --os <os>             skip tests known to fail on <os> (e.g. `macos-14`)
     --installed-rgbds     use the system installed RGBDS
                           (only compatible with external codebases)
+    --jobs <n>            build external codebases with `make -j<n>`
 EOF
 }
 
@@ -29,6 +30,7 @@ internal=true
 external=true
 installedrgbds=false
 osname=
+make_jobs=4
 FETCH_TEST_DEPS="fetch-test-deps.sh"
 RGBDS_PATH="RGBDS=../../"
 while [[ $# -gt 0 ]]; do
@@ -51,6 +53,10 @@ while [[ $# -gt 0 ]]; do
 		--installed-rgbds)
 			installedrgbds=true
 			RGBDS_PATH=
+			;;
+		--jobs)
+			shift
+			make_jobs="$1"
 			;;
 		--os)
 			shift
@@ -117,8 +123,8 @@ test_downstream() { # owner repo make-target build-file build-hash
 		echo >&2 'Please run `'"$FETCH_TEST_DEPS"'` before running the test suite'
 		return 1
 	fi
-	make clean $RGBDS_PATH
-	make -j4 "$3" $RGBDS_PATH
+	make clean "$RGBDS_PATH"
+	make "-j$make_jobs" "$3" "$RGBDS_PATH"
 	hash="$(sha1sum -b "$4" | head -c 40)"
 	if [ "$hash" != "$5" ]; then
 		echo >&2 'SHA-1 hash of '"$4"' did not match: '"$hash"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -124,7 +124,8 @@ test_downstream() { # owner repo make-target build-file build-hash
 		return 1
 	fi
 	make clean "$RGBDS_PATH"
-	make "$make_jobs" "$3" "$RGBDS_PATH"
+	# shellcheck disable=SC2086 # (This word splitting is intentional.)
+	make $make_jobs "$3" "$RGBDS_PATH"
 	hash="$(sha1sum -b "$4" | head -c 40)"
 	if [ "$hash" != "$5" ]; then
 		echo >&2 'SHA-1 hash of '"$4"' did not match: '"$hash"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -30,7 +30,7 @@ internal=true
 external=true
 installedrgbds=false
 osname=
-make_jobs=4
+make_jobs=
 FETCH_TEST_DEPS="fetch-test-deps.sh"
 RGBDS_PATH="RGBDS=../../"
 while [[ $# -gt 0 ]]; do
@@ -56,7 +56,7 @@ while [[ $# -gt 0 ]]; do
 			;;
 		--jobs)
 			shift
-			make_jobs="$1"
+			make_jobs="-j$1"
 			;;
 		--os)
 			shift
@@ -124,7 +124,7 @@ test_downstream() { # owner repo make-target build-file build-hash
 		return 1
 	fi
 	make clean "$RGBDS_PATH"
-	make "-j$make_jobs" "$3" "$RGBDS_PATH"
+	make "$make_jobs" "$3" "$RGBDS_PATH"
 	hash="$(sha1sum -b "$4" | head -c 40)"
 	if [ "$hash" != "$5" ]; then
 		echo >&2 'SHA-1 hash of '"$4"' did not match: '"$hash"


### PR DESCRIPTION
Fixes #1944

This PR uses [`getconf _NPROCESSORS_ONLN`](https://stackoverflow.com/a/23569003) to set the job counts because `nproc` is not available on macOS.