### PR TITLE
Restore support for GCC 9

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -20,8 +20,12 @@ case "${OS%%-*}" in
 				pkgs="$pkgs libz-mingw-w64-dev g++-mingw-w64-x86-64-win32"
 				TOOLSET=
 			;;
-			'' | lcov)
+			g++-9 | lcov)
 				pkgs="$pkgs libpng-dev pkgconf $TOOLSET"
+				TOOLSET=
+			;;
+			'' | g++ | clang++)
+				pkgs="$pkgs libpng-dev pkgconf"
 				TOOLSET=
 			;;
 		esac
@@ -32,8 +36,11 @@ case "${OS%%-*}" in
 	macos)
 		pkgs=bison
 		case $TOOLSET in
-			'' | lld)
+			lld)
 				pkgs="$pkgs $TOOLSET"
+				TOOLSET=
+			;;
+			clang++)
 				TOOLSET=
 			;;
 		esac

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,6 +40,9 @@ jobs:
         exclude: # Don't use `g++` on macOS; it's just an alias to `clang++`.
           - { os: macos-15-intel, cxx: g++ }
           - { os: macos-26, cxx: g++ }
+        include: # Use `g++-9`, the earliest GCC version we support, on the earliest Ubuntu runner.
+          - { os: ubuntu-22.04, cxx: g++-9, buildsys: make }
+          - { os: ubuntu-22.04, cxx: g++-9, buildsys: cmake }
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -47,7 +50,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Install deps
         run: |
-          .github/scripts/install_deps.sh ${{ matrix.os }}
+          .github/scripts/install_deps.sh ${{ matrix.os }} ${{ matrix.cxx }}
       - name: Build & install using Make
         if: matrix.buildsys == 'make'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ WARNFLAGS := -Wall -pedantic -Wno-unknown-warning-option -Wno-gnu-zero-variadic-
 # Overridable CXXFLAGS
 CXXFLAGS     ?= -O3 -flto -DNDEBUG
 # Non-overridable CXXFLAGS
-REALCXXFLAGS := ${CXXFLAGS} ${WARNFLAGS} -std=c++20 -I include -fno-exceptions -fno-rtti
+# GCC 9 doesn't support `-std=c++20`, and all later GCCs treat it as equivalent to `-std=c++2a`.
+REALCXXFLAGS := ${CXXFLAGS} ${WARNFLAGS} -std=c++2a -I include -fno-exceptions -fno-rtti
 # Overridable LDFLAGS
 LDFLAGS      ?=
 # Non-overridable LDFLAGS

--- a/include/gfx/rgba.hpp
+++ b/include/gfx/rgba.hpp
@@ -40,6 +40,7 @@ struct Rgba {
 	}
 
 	bool operator==(Rgba const &rhs) const { return toCSS() == rhs.toCSS(); }
+	bool operator!=(Rgba const &rhs) const { return !operator==(rhs); }
 
 	// CGB colors are RGB555, so we use bit 15 to signify that the color is transparent instead
 	// Since the rest of the bits don't matter then, we return 0x8000 exactly.

--- a/include/itertools.hpp
+++ b/include/itertools.hpp
@@ -97,6 +97,7 @@ class EnumSeq {
 		EnumT operator*() const { return _value; }
 
 		bool operator==(Iterator const &rhs) const { return _value == rhs._value; }
+		bool operator!=(Iterator const &rhs) const { return !operator==(rhs); }
 	};
 
 public:
@@ -131,6 +132,7 @@ public:
 	bool operator==(ZipIterator const &rhs) const {
 		return std::get<0>(_iters) == std::get<0>(rhs._iters);
 	}
+	bool operator!=(ZipIterator const &rhs) const { return !operator==(rhs); }
 };
 
 // Only needed inside `zip` below.

--- a/include/link/section.hpp
+++ b/include/link/section.hpp
@@ -70,6 +70,7 @@ private:
 			SectionT &operator*() const { return *_piece; }
 
 			bool operator==(Iterator const &rhs) const { return _piece == rhs._piece; }
+			bool operator!=(Iterator const &rhs) const { return !operator==(rhs); }
 		};
 
 	public:

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -50,14 +50,14 @@ char const *printChar(int c);
 
 struct Uppercase {
 	// FNV-1a hash of an uppercased string
-	constexpr size_t operator()(std::string const &str) const {
+	size_t operator()(std::string const &str) const {
 		return std::accumulate(RANGE(str), size_t(0x811C9DC5), [](size_t hash, char c) {
 			return (hash ^ toUpper(c)) * 16777619;
 		});
 	}
 
 	// Compare two strings without case-sensitivity (by converting to uppercase)
-	constexpr bool operator()(std::string const &str1, std::string const &str2) const {
+	bool operator()(std::string const &str1, std::string const &str2) const {
 		return std::equal(RANGE(str1), RANGE(str2), [](char c1, char c2) {
 			return toUpper(c1) == toUpper(c2);
 		});

--- a/src/asm/fixpoint.cpp
+++ b/src/asm/fixpoint.cpp
@@ -5,10 +5,10 @@
 #include "asm/fixpoint.hpp"
 
 #include <math.h>
-#include <numbers>
 #include <stdint.h>
 
-static constexpr double tau = std::numbers::pi * 2;
+// Ideally we'd use `std::numbers::pi`, but GCC 9 doesn't support it.
+static constexpr double tau = 3.141592653589793238462643383279502884L * 2;
 
 static double fix2double(int32_t i, int32_t q) {
 	return i / pow(2.0, q);

--- a/src/gfx/pal_packing.cpp
+++ b/src/gfx/pal_packing.cpp
@@ -100,6 +100,7 @@ private:
 		AssignedSetsIter() = default;
 
 		bool operator==(AssignedSetsIter const &rhs) const { return _iter == rhs._iter; }
+		bool operator!=(AssignedSetsIter const &rhs) const { return !operator==(rhs); }
 
 		AssignedSetsIter &operator++() {
 			++_iter;

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -263,6 +263,7 @@ struct Image {
 			}
 
 			bool operator==(Iterator const &rhs) const { return coords() == rhs.coords(); }
+			bool operator!=(Iterator const &rhs) const { return !operator==(rhs); }
 		};
 
 	public:


### PR DESCRIPTION
As part of our efforts to support “old-ass” systems... this turns out to be a small enough patch that it may be worth keeping around, and it's testable in CI.

GCC 8 isn't packaged by Ubuntu, and it'd require more invasive patches (`std::string.starts_with` is not supported, mostly) so we probably don't want to upstream that. (But compat patches shouldn't be too difficult to write.)