### PR TITLE
Set the minimum Mac OS X API version to 10.0 for the static macOS build

### DIFF
--- a/cmake/macos-static.cmake
+++ b/cmake/macos-static.cmake
@@ -6,10 +6,10 @@
 # triggers some poorly-tested code paths within Apple's linker, which then crashes.
 # This can be worked around by using LLVM's LLD linker and passing `-fuse-ld=lld` when linking.
 
-# The `-mmacosx-version-min=10.4` flag ensures that the binary only uses APIs available on Mac OS X 10.4 Tiger.
+# The `-mmacosx-version-min=10.0` flag ensures that the binary only uses APIs available on Mac OS X 10.0 Cheetah.
 # The `-arch` flags build a "fat binary" that works on both Apple architectures:
 # older Intel x64 Macs and newer ARM "Apple Silicon" ones.
-set(secret_sauce -mmacosx-version-min=10.4 "SHELL:-arch x86_64" "SHELL:-arch arm64") # Avoid `-arch` being dedup'd.
+set(secret_sauce -mmacosx-version-min=10.0 "SHELL:-arch x86_64" "SHELL:-arch arm64") # Avoid `-arch` being dedup'd.
 add_compile_options(${secret_sauce})
 add_link_options(${secret_sauce})
 set(PNG_HARDWARE_OPTIMIZATIONS OFF) # These do not play well with a dual-arch build.


### PR DESCRIPTION
The `macos-static` build succeeds, and when I download the `rgbds-canary-macos-static` artifact (at least to macOS 11.7.11 Big Sur on Intel x64) it runs correctly.

This PR isn't concerned with whether we can *build* RGBDS on Mac OS X 10.0, just whether our release binary would run on it. It was released in 2001, the same year as Windows XP, so it may also be worth checking if our binaries run on that.