### PR TITLE
Format `getopt` errors more like others (sentence case, quoted options)

### DIFF
--- a/src/extern/getopt.cpp
+++ b/src/extern/getopt.cpp
@@ -5,6 +5,7 @@
 #include "extern/getopt.hpp"
 
 #include <limits.h>
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,12 +19,15 @@ int musl_optind = 1, musl_optopt;
 
 static int musl_optpos;
 
-static void musl_getopt_msg(char const *msg, char const *param) {
+[[gnu::format(printf, 1, 2)]]
+static void musl_getopt_error(char const *fmt, ...) {
 	style_Set(stderr, STYLE_RED, true);
 	fputs("error: ", stderr);
 	style_Reset(stderr);
-	fputs(msg, stderr);
-	fputs(param, stderr);
+	va_list args;
+	va_start(args, fmt);
+	vfprintf(stderr, fmt, args);
+	va_end(args);
 	putc('\n', stderr);
 }
 
@@ -92,7 +96,7 @@ static int musl_getopt(int argc, char *argv[], char const *optstring) {
 	if (d != c || c == ':') {
 		musl_optopt = c;
 		if (optstring[0] != ':') {
-			musl_getopt_msg("unrecognized option: ", optchar);
+			musl_getopt_error("Unrecognized option '-%s'", optchar);
 		}
 		return '?';
 	}
@@ -107,7 +111,7 @@ static int musl_getopt(int argc, char *argv[], char const *optstring) {
 			if (optstring[0] == ':') {
 				return ':';
 			}
-			musl_getopt_msg("option requires an argument: ", optchar);
+			musl_getopt_error("Missing argument for option '-%s'", optchar);
 			return '?';
 		}
 	}
@@ -179,7 +183,7 @@ static int
 				if (colon) {
 					return '?';
 				}
-				musl_getopt_msg("option does not take an argument: ", longopts[i].name);
+				musl_getopt_error("Option '--%s' does not take an argument", longopts[i].name);
 				return '?';
 			}
 			musl_optarg = opt + 1;
@@ -190,7 +194,7 @@ static int
 				if (colon) {
 					return ':';
 				}
-				musl_getopt_msg("option requires an argument: ", longopts[i].name);
+				musl_getopt_error("Missing argument for option '--%s'", longopts[i].name);
 				return '?';
 			}
 			++musl_optind;
@@ -204,9 +208,11 @@ static int
 	if (argv[musl_optind][1] == '-') {
 		musl_optopt = 0;
 		if (!colon) {
-			musl_getopt_msg(
-			    cnt ? "option is ambiguous: " : "unrecognized option: ", argv[musl_optind] + 2
-			);
+			if (cnt) {
+				musl_getopt_error("Ambiguous option '--%s'", argv[musl_optind] + 2);
+			} else {
+				musl_getopt_error("Unrecognized option '--%s'", argv[musl_optind] + 2);
+			}
 		}
 		++musl_optind;
 		return '?';


### PR DESCRIPTION
For example, "`error: unrecognized option: A`" is now "`error: Unrecognized option '-A'`".