### PR TITLE
Optimize `skipToLeadingKeyword` for the common `ViewedContent` case

### DIFF
--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -2082,6 +2082,52 @@ finish: // Can't `break` out of a nested `for`-`switch`
 	return Token(T_(YYEOF));
 }
 
+template<bool Quick, typename PeekFnT, typename ShiftFnT, typename NextLineFnT>
+static Token skipToLeadingKeyword(PeekFnT peekFn, ShiftFnT shiftFn, NextLineFnT nextLineFn) {
+	for (;;) {
+		int c = peekFn();
+		if (lexerState->atLineStart) {
+			lexerState->atLineStart = false;
+			while (isBlankSpace(c)) {
+				shiftFn();
+				c = peekFn();
+			}
+			if (c == EOF) {
+				return Token(T_(YYEOF));
+			} else if (isLetter(c)) {
+				std::string keyword(1, c);
+				shiftFn();
+				for (c = peekFn(); continuesIdentifier(c); c = peekFn()) {
+					keyword += c;
+					shiftFn();
+				}
+				if (auto search = keywords.find(keyword); search != keywords.end()) {
+					// There has been one more call to `peekFn` than to `shiftFn`.
+					// If they are optimized "quick" functions for `ViewedContent`,
+					// instead of `peek` and `shiftChar`, they have not updated
+					// `lexerState->expansionScanDistance`, so it must be incremented
+					// if it was previously zero.
+					if (Quick && lexerState->expansionScanDistance == 0) {
+						++lexerState->expansionScanDistance;
+					}
+					return Token(search->second);
+				}
+			}
+		}
+		shiftFn();
+		if (c == EOF) {
+			return Token(T_(YYEOF));
+		} else if (isNewline(c)) {
+			// Like `handleCRLF` but calling generic `shiftFn`
+			if (c == '\r' && peekFn() == '\n') {
+				shiftFn();
+			}
+			nextLineFn();
+			lexerState->atLineStart = true;
+		}
+	}
+}
+
 // This function is called when capturing `REPT`/`FOR` loops and `MACRO` bodies,
 // and when skipping unexecuted `IF`/`ELIF`/`ELSE` blocks and `REPT`/`FOR` loops.
 // It expects that these constructs' `ENDC`/`ENDR`/`ENDM` closing tokens are only
@@ -2098,28 +2144,27 @@ finish: // Can't `break` out of a nested `for`-`switch`
 static Token skipToLeadingKeyword() {
 	assume(!lexerState->enableExpansions);
 
-	for (;;) {
-		if (lexerState->atLineStart) {
-			lexerState->atLineStart = false;
-			if (int c = skipChars(isBlankSpace); c == EOF) {
-				return Token(T_(YYEOF));
-			} else if (isLetter(c)) {
-				std::string keyword(1, c);
-				for (c = nextChar(); continuesIdentifier(c); c = nextChar()) {
-					keyword += c;
-				}
-				if (auto search = keywords.find(keyword); search != keywords.end()) {
-					return Token(search->second);
-				}
-			}
+	if (std::holds_alternative<ViewedContent>(lexerState->content)
+	    && lexerState->expansionStack.empty()) {
+		// Optimize the common case (a fully-read assembly file without ongoing
+		// expansions) to avoid the bookkeeping of `peek` and `shiftChar`.
+		auto &view = std::get<ViewedContent>(lexerState->content);
+		char const *ptr = view.span.ptr.get();
+		auto quickPeek = [&]() { return view.offset < view.span.size ? ptr[view.offset] : EOF; };
+		auto quickNextLine = []() { ++lexerState->lineNo; };
+		if (lexerState->capturing) {
+			assume(lexerState->captureBuf == nullptr);
+			auto quickCaptureShiftChar = [&]() {
+				++view.offset;
+				++lexerState->captureSize;
+			};
+			return skipToLeadingKeyword<true>(quickPeek, quickCaptureShiftChar, quickNextLine);
+		} else {
+			auto quickShiftChar = [&]() { ++view.offset; };
+			return skipToLeadingKeyword<true>(quickPeek, quickShiftChar, quickNextLine);
 		}
-		if (int c = bumpChar(); c == EOF) {
-			return Token(T_(YYEOF));
-		} else if (isNewline(c)) {
-			handleCRLF(c);
-			nextLine();
-			lexerState->atLineStart = true;
-		}
+	} else {
+		return skipToLeadingKeyword<false>(peek, shiftChar, nextLine);
 	}
 }
 

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -2082,8 +2082,10 @@ finish: // Can't `break` out of a nested `for`-`switch`
 	return Token(T_(YYEOF));
 }
 
-template<bool Quick, typename PeekFnT, typename ShiftFnT, typename NextLineFnT>
-static Token skipToLeadingKeyword(PeekFnT peekFn, ShiftFnT shiftFn, NextLineFnT nextLineFn) {
+template<bool IsOptimized>
+static Token skipToLeadingKeyword(
+    InvocableR<int> auto peekFn, Procedure<> auto shiftFn, Procedure<> auto nextLineFn
+) {
 	for (;;) {
 		int c = peekFn();
 		if (lexerState->atLineStart) {
@@ -2103,11 +2105,11 @@ static Token skipToLeadingKeyword(PeekFnT peekFn, ShiftFnT shiftFn, NextLineFnT 
 				}
 				if (auto search = keywords.find(keyword); search != keywords.end()) {
 					// There has been one more call to `peekFn` than to `shiftFn`.
-					// If they are optimized "quick" functions for `ViewedContent`,
+					// If they are optimized functions for unexpanded `ViewedContent`,
 					// instead of `peek` and `shiftChar`, they have not updated
 					// `lexerState->expansionScanDistance`, so it must be incremented
 					// if it was previously zero.
-					if (Quick && lexerState->expansionScanDistance == 0) {
+					if (IsOptimized && lexerState->expansionScanDistance == 0) {
 						++lexerState->expansionScanDistance;
 					}
 					return Token(search->second);

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -2082,9 +2082,11 @@ finish: // Can't `break` out of a nested `for`-`switch`
 	return Token(T_(YYEOF));
 }
 
-template<bool IsOptimized>
 static Token skipToLeadingKeyword(
-    InvocableR<int> auto peekFn, Procedure<> auto shiftFn, Procedure<> auto nextLineFn
+    InvocableR<int> auto peekFn,
+    Procedure<> auto shiftFn,
+    Procedure<> auto nextLineFn,
+    Procedure<> auto finalizeFn
 ) {
 	for (;;) {
 		int c = peekFn();
@@ -2104,14 +2106,7 @@ static Token skipToLeadingKeyword(
 					shiftFn();
 				}
 				if (auto search = keywords.find(keyword); search != keywords.end()) {
-					// There has been one more call to `peekFn` than to `shiftFn`.
-					// If they are optimized functions for unexpanded `ViewedContent`,
-					// instead of `peek` and `shiftChar`, they have not updated
-					// `lexerState->expansionScanDistance`, so it must be incremented
-					// if it was previously zero.
-					if (IsOptimized && lexerState->expansionScanDistance == 0) {
-						++lexerState->expansionScanDistance;
-					}
+					finalizeFn();
 					return Token(search->second);
 				}
 			}
@@ -2154,19 +2149,31 @@ static Token skipToLeadingKeyword() {
 		char const *ptr = view.span.ptr.get();
 		auto quickPeek = [&]() { return view.offset < view.span.size ? ptr[view.offset] : EOF; };
 		auto quickNextLine = []() { ++lexerState->lineNo; };
+		auto quickFinalize = []() {
+			// When `skipToLeadingKeyword` returns a token, there has been one more
+			// call to `quickPeek` than to `quickNextLine`. Unlike `peek` and `shiftChar`,
+			// the optimized functions do not update `lexerState->expansionScanDistance`,
+			// so it must be incrementedif it was previously zero.
+			if (lexerState->expansionScanDistance == 0) {
+				++lexerState->expansionScanDistance;
+			}
+		};
 		if (lexerState->capturing) {
 			assume(lexerState->captureBuf == nullptr);
 			auto quickCaptureShiftChar = [&]() {
 				++view.offset;
 				++lexerState->captureSize;
 			};
-			return skipToLeadingKeyword<true>(quickPeek, quickCaptureShiftChar, quickNextLine);
+			return skipToLeadingKeyword(
+			    quickPeek, quickCaptureShiftChar, quickNextLine, quickFinalize
+			);
 		} else {
 			auto quickShiftChar = [&]() { ++view.offset; };
-			return skipToLeadingKeyword<true>(quickPeek, quickShiftChar, quickNextLine);
+			return skipToLeadingKeyword(quickPeek, quickShiftChar, quickNextLine, quickFinalize);
 		}
 	} else {
-		return skipToLeadingKeyword<false>(peek, shiftChar, nextLine);
+		auto finalize = []() {};
+		return skipToLeadingKeyword(peek, shiftChar, nextLine, finalize);
 	}
 }
 


### PR DESCRIPTION
I recently profiled RGBASM on a large assembly file as previously done in https://github.com/gbdev/rgbds/pull/1954#issuecomment-4264075794. Unlike https://github.com/gbdev/rgbds/issues/653#issuecomment-756358547 (which was in 2021, so I guess profiling v0.4.2), `SKIP_TO_ELIF` takes up significant time now. (So does `yy::parser::stack<>::push`, but that's just because we switched to bison's C++ parser.)

Skipping to `ELIF`/`ELSE`/`ENDC` uses `skipToLeadingKeyword` (as does skipping to `ENDR` after a `BREAK`, and capturing `REPT`/`FOR` and `MACRO` bodies). This function does a lot of `peek()` and `shiftChar()` calls, but that's often more overhead than we really need. If we know the whole assembly file has been read into memory (i.e. it has `ViewedContent`) and there are no ongoing expansions, then we can just traverse it like an ordinary string, because expansions are disabled during `skipToLeadingKeyword`.

Profiling results:

- The previous profiling run measured 37.8% of `yylex()`'s time spent in `yylex_NORMAL()`, and 56.6% spent in `yylex_SKIP_TO_ELIF()` (with just 5.6% elsewhere).
- The new run with this PR measured 66.8% of `yylex()`'s time spent in `yylex_NORMAL()`, and 25.3% spent in `yylex_SKIP_TO_ELIF()` (with just 7.9% elsewhere).
- The "Instruction Fetch" cost of `main()` decreased from 375 billion to 262 billion, so 70% of the previous total.

Comparing `time` runs' `user` seconds after `make -j`, taking the average of 5 without the min or max:

- Old (`master`): [24.638, 24.829, 26.105, 27.586, 28.605] → average 26.17 s
- New (`quick-skip-leading-keyword`): [17.734, 18.757, 19.807, 20.171, 20.636] → average 19.58 s
- The new run took 75% of the old run, so agrees with the cachegrind cost measurement.
