### PR TITLE
Link zlib and libpng statically by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,10 @@ FetchContent_MakeAvailable(ZLIB)
 if(NOT DEFINED ZLIB_INCLUDE_DIRS)
   set(ZLIB_INCLUDE_DIRS "${zlib_BINARY_DIR};${zlib_SOURCE_DIR}") # libpng's `genout` script relies on this variable to be set.
 endif()
+# Statically building zlib (from source) generates a target named differently.
+if(NOT TARGET ZLIB::ZLIB AND TARGET zlibstatic)
+  add_library(ZLIB::ZLIB ALIAS zlibstatic)
+endif()
 
 if(NOT DEFINED PNG_TESTS) # Unless overridden (e.g. in the cache), we don't care about libpng's tests.
   set(PNG_TESTS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ endif()
 include(FetchContent)
 include(cmake/deps.cmake)
 
+# Be sure to make zlib available before libpng, otherwise libpng
+# will attempt to `find_package(ZLIB)` without going through `FetchContent`.
 if(NOT DEFINED ZLIB_BUILD_TESTING) # Unless overridden (e.g. in the cache), we don't care about zlib's tests.
   set(ZLIB_BUILD_TESTING OFF)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,15 @@ include(CMakeDependentOption)
 option(SANITIZERS "Build with sanitizers enabled" OFF)
 cmake_dependent_option(MORE_WARNINGS "Turn on more warnings" OFF "NOT MSVC" OFF)
 
+if(NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY) # Allow this to be overridden from the CLI easily.
+  # We link against the Microsoft C++ runtime libs statically, except the debug-mode one.
+  # This is because Microsoft's license terms (through some indirection) allow us to redistribute
+  # the runtime lib code *except* the debug-mode libs'.
+  # Since we want to remain able to not think too hard about debug executables, we link against
+  # the debug libs dynamically, shifting the burden of obtaining them onto the recipient.
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:DebugDLL>")
+endif()
+
 if(SANITIZERS)
   if(MSVC)
     message(STATUS "ASan enabled")

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -8,10 +8,10 @@ FetchContent_Declare(PNG
                      EXCLUDE_FROM_ALL # We only install the runtime dependencies, and do so separately.
                      FIND_PACKAGE_ARGS 1.5.4)
 
-set(PNG_TESTS OFF CACHE INTERNAL "") # We do not care for these two (and they can even cause compile errors!)
-set(PNG_TOOLS OFF CACHE INTERNAL "")
-set(PNG_SHARED ON CACHE INTERNAL "") # Upstream seems to favour the dynamic lib over the static one?
-set(PNG_STATIC OFF CACHE INTERNAL "")
+set(PNG_TESTS OFF CACHE INTERNAL "") # We do not need libpng's tests or tools
+set(PNG_TOOLS OFF CACHE INTERNAL "") # (and they can even cause compile errors!)
+set(PNG_SHARED OFF CACHE INTERNAL "")
+set(PNG_STATIC ON CACHE INTERNAL "")
 
 FetchContent_Declare(ZLIB
                      URL https://www.zlib.net/zlib-1.3.2.tar.xz
@@ -21,5 +21,5 @@ FetchContent_Declare(ZLIB
 # We thus enforce 1.0.4, but note that the libpng source code mentions that "it may work with versions as old as zlib 0.95".
                      FIND_PACKAGE_ARGS 1.0.4)
 
-set(ZLIB_BUILD_SHARED ON CACHE INTERNAL "")
-set(ZLIB_BUILD_STATIC OFF CACHE INTERNAL "")
+set(ZLIB_BUILD_SHARED OFF CACHE INTERNAL "")
+set(ZLIB_BUILD_STATIC ON CACHE INTERNAL "")


### PR DESCRIPTION
Only when we are building them ourselves, that is.

Fixes #1907

On that topic, @SelvinPL suggested we consider linking the compiler runtime (UCRT, etc.) statically also. I checked licensing, and [Visual Studio's license terms](https://visualstudio.microsoft.com/license-terms/vs2026-ga-community/) state (through some indirection) that we're OK to redistribute [the runtime files](https://learn.microsoft.com/en-gb/visualstudio/releases/2026/redistribution#visual-c-runtime-files) **except** debug-mode ones.

Since we publish our CI binaries (we sometimes share them in public venues for debugging help, and I don't want to start treating our CI pages as something sensitive), we should link dynamically against the debug DLL and statically against the usual runtime.

Thanks to @CasualPokePlayer for additional help figuring out the MSVC runtime questions! :)