### PR TITLE
Use C++20 concepts to require constraints on template parameters

### DIFF
--- a/include/backtrace.hpp
+++ b/include/backtrace.hpp
@@ -7,9 +7,9 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <type_traits> // is_invocable_r_v
 #include <vector>
 
+#include "helpers.hpp" // InvocableR
 #include "style.hpp"
 
 #define TRACE_SEPARATOR  "<-"
@@ -26,10 +26,12 @@ extern Tracing tracing;
 
 bool trace_ParseTraceDepth(char const *arg);
 
-template<typename NodeT, typename NameFnT, typename LineNoFnT>
-    requires std::is_invocable_r_v<char const *, NameFnT, NodeT const &>
-             && std::is_invocable_r_v<uint32_t, LineNoFnT, NodeT const &>
-void trace_PrintBacktrace(std::vector<NodeT> const &stack, NameFnT getName, LineNoFnT getLineNo) {
+template<typename NodeT>
+void trace_PrintBacktrace(
+    std::vector<NodeT> const &stack,
+    InvocableR<char const *, NodeT const &> auto getName,
+    InvocableR<uint32_t, NodeT const &> auto getLineNo
+) {
 	size_t n = stack.size();
 	if (n == 0) {
 		return; // LCOV_EXCL_LINE

--- a/include/backtrace.hpp
+++ b/include/backtrace.hpp
@@ -3,11 +3,11 @@
 #ifndef RGBDS_BACKTRACE_HPP
 #define RGBDS_BACKTRACE_HPP
 
-#include <concepts> // same_as
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <type_traits> // is_invocable_r_v
 #include <vector>
 
 #include "style.hpp"
@@ -27,10 +27,8 @@ extern Tracing tracing;
 bool trace_ParseTraceDepth(char const *arg);
 
 template<typename NodeT, typename NameFnT, typename LineNoFnT>
-    requires requires(NodeT const &item, NameFnT getName, LineNoFnT getLineNo) {
-	    { getName(item) } -> std::same_as<char const *>;
-	    { getLineNo(item) } -> std::same_as<uint32_t>;
-    }
+    requires std::is_invocable_r_v<char const *, NameFnT, NodeT const &>
+             && std::is_invocable_r_v<uint32_t, LineNoFnT, NodeT const &>
 void trace_PrintBacktrace(std::vector<NodeT> const &stack, NameFnT getName, LineNoFnT getLineNo) {
 	size_t n = stack.size();
 	if (n == 0) {

--- a/include/backtrace.hpp
+++ b/include/backtrace.hpp
@@ -3,6 +3,7 @@
 #ifndef RGBDS_BACKTRACE_HPP
 #define RGBDS_BACKTRACE_HPP
 
+#include <concepts> // same_as
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -26,6 +27,10 @@ extern Tracing tracing;
 bool trace_ParseTraceDepth(char const *arg);
 
 template<typename NodeT, typename NameFnT, typename LineNoFnT>
+    requires requires(NodeT const &item, NameFnT getName, LineNoFnT getLineNo) {
+	    { getName(item) } -> std::same_as<char const *>;
+	    { getLineNo(item) } -> std::same_as<uint32_t>;
+    }
 void trace_PrintBacktrace(std::vector<NodeT> const &stack, NameFnT getName, LineNoFnT getLineNo) {
 	size_t n = stack.size();
 	if (n == 0) {

--- a/include/diagnostics.hpp
+++ b/include/diagnostics.hpp
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
-#include <type_traits> // is_enum_v
 #include <utility>
 #include <vector>
 
@@ -31,8 +30,7 @@ struct WarningState {
 
 std::pair<WarningState, std::optional<uint32_t>> getInitialWarningState(std::string &flag);
 
-template<typename LevelEnumT>
-    requires std::is_enum_v<LevelEnumT>
+template<Enum LevelEnumT>
 struct WarningFlag {
 	char const *name;
 	LevelEnumT level;
@@ -40,16 +38,14 @@ struct WarningFlag {
 
 enum WarningBehavior { DISABLED, ENABLED, ERROR };
 
-template<typename WarningEnumT>
-    requires std::is_enum_v<WarningEnumT>
+template<Enum WarningEnumT>
 struct ParamWarning {
 	WarningEnumT firstID;
 	WarningEnumT lastID;
 	uint8_t defaultLevel;
 };
 
-template<typename WarningEnumT>
-    requires std::is_enum_v<WarningEnumT>
+template<Enum WarningEnumT>
 struct DiagnosticsState {
 	WarningState flagStates[WarningEnumT::NB_WARNINGS];
 	WarningState metaStates[WarningEnumT::NB_WARNINGS];
@@ -57,8 +53,7 @@ struct DiagnosticsState {
 	bool warningsAreErrors = false;
 };
 
-template<typename LevelEnumT, typename WarningEnumT>
-    requires std::is_enum_v<LevelEnumT> && std::is_enum_v<WarningEnumT>
+template<Enum LevelEnumT, Enum WarningEnumT>
 struct Diagnostics {
 	std::vector<WarningFlag<LevelEnumT>> metaWarnings;
 	std::vector<WarningFlag<LevelEnumT>> warningFlags;
@@ -76,8 +71,7 @@ struct Diagnostics {
 	void processWarningFlag(char const *flag);
 };
 
-template<typename LevelEnumT, typename WarningEnumT>
-    requires std::is_enum_v<LevelEnumT> && std::is_enum_v<WarningEnumT>
+template<Enum LevelEnumT, Enum WarningEnumT>
 WarningBehavior Diagnostics<LevelEnumT, WarningEnumT>::getWarningBehavior(WarningEnumT id) const {
 	// Check if warnings are globally disabled
 	if (!state.warningsEnabled) {
@@ -126,8 +120,7 @@ WarningBehavior Diagnostics<LevelEnumT, WarningEnumT>::getWarningBehavior(Warnin
 	return WarningBehavior::DISABLED;
 }
 
-template<typename LevelEnumT, typename WarningEnumT>
-    requires std::is_enum_v<LevelEnumT> && std::is_enum_v<WarningEnumT>
+template<Enum LevelEnumT, Enum WarningEnumT>
 void Diagnostics<LevelEnumT, WarningEnumT>::processWarningFlag(char const *flag) {
 	std::string rootFlag = flag;
 

--- a/include/diagnostics.hpp
+++ b/include/diagnostics.hpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <type_traits> // is_enum_v
 #include <utility>
 #include <vector>
 
@@ -31,6 +32,7 @@ struct WarningState {
 std::pair<WarningState, std::optional<uint32_t>> getInitialWarningState(std::string &flag);
 
 template<typename LevelEnumT>
+    requires std::is_enum_v<LevelEnumT>
 struct WarningFlag {
 	char const *name;
 	LevelEnumT level;
@@ -39,6 +41,7 @@ struct WarningFlag {
 enum WarningBehavior { DISABLED, ENABLED, ERROR };
 
 template<typename WarningEnumT>
+    requires std::is_enum_v<WarningEnumT>
 struct ParamWarning {
 	WarningEnumT firstID;
 	WarningEnumT lastID;
@@ -46,6 +49,7 @@ struct ParamWarning {
 };
 
 template<typename WarningEnumT>
+    requires std::is_enum_v<WarningEnumT>
 struct DiagnosticsState {
 	WarningState flagStates[WarningEnumT::NB_WARNINGS];
 	WarningState metaStates[WarningEnumT::NB_WARNINGS];
@@ -54,6 +58,7 @@ struct DiagnosticsState {
 };
 
 template<typename LevelEnumT, typename WarningEnumT>
+    requires std::is_enum_v<LevelEnumT> && std::is_enum_v<WarningEnumT>
 struct Diagnostics {
 	std::vector<WarningFlag<LevelEnumT>> metaWarnings;
 	std::vector<WarningFlag<LevelEnumT>> warningFlags;
@@ -72,6 +77,7 @@ struct Diagnostics {
 };
 
 template<typename LevelEnumT, typename WarningEnumT>
+    requires std::is_enum_v<LevelEnumT> && std::is_enum_v<WarningEnumT>
 WarningBehavior Diagnostics<LevelEnumT, WarningEnumT>::getWarningBehavior(WarningEnumT id) const {
 	// Check if warnings are globally disabled
 	if (!state.warningsEnabled) {
@@ -121,6 +127,7 @@ WarningBehavior Diagnostics<LevelEnumT, WarningEnumT>::getWarningBehavior(Warnin
 }
 
 template<typename LevelEnumT, typename WarningEnumT>
+    requires std::is_enum_v<LevelEnumT> && std::is_enum_v<WarningEnumT>
 void Diagnostics<LevelEnumT, WarningEnumT>::processWarningFlag(char const *flag) {
 	std::string rootFlag = flag;
 

--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -3,7 +3,7 @@
 #ifndef RGBDS_HELPERS_HPP
 #define RGBDS_HELPERS_HPP
 
-#include <type_traits> // is_void_v, invoke_result_t
+#include <type_traits>
 
 // Ideally we'd use `std::unreachable`, but it has insufficient compiler support
 #ifdef __GNUC__ // GCC or compatible
@@ -108,9 +108,20 @@ static constexpr int literal_strlen(char const (&)[SizeOfString]) {
 	return SizeOfString - 1; // Don't count the ending '\0'
 }
 
+// Concept for template parameters that must be an `enum` type
+template<typename EnumT>
+concept Enum = std::is_enum_v<EnumT>;
+
+// Concept for template parameters that must be a function returning `void`
+template<typename ProcedureFnT, typename... Args>
+concept Procedure = std::is_void_v<std::invoke_result_t<ProcedureFnT, Args...>>;
+
+// Concept for template parameters that must be a function returning a particular type
+template<typename FnT, typename ReturnT, typename... Args>
+concept InvocableR = std::is_invocable_r_v<ReturnT, FnT, Args...>;
+
 // For ad-hoc RAII in place of a `defer` statement or cross-platform `__attribute__((cleanup))`
-template<typename DeferredFnT>
-    requires(std::is_void_v<std::invoke_result_t<DeferredFnT>>)
+template<Procedure DeferredFnT>
 struct Defer {
 	DeferredFnT deferred;
 	Defer(DeferredFnT func) : deferred(func) {}

--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -120,6 +120,10 @@ concept Procedure = std::is_void_v<std::invoke_result_t<ProcedureFnT, Args...>>;
 template<typename FnT, typename ReturnT, typename... Args>
 concept InvocableR = std::is_invocable_r_v<ReturnT, FnT, Args...>;
 
+// Concept for template parameters that must match a particular type modulo cv-qualifiers
+template<typename T, typename UnqualifiedT>
+concept QualifiedEquivalent = std::is_same_v<std::remove_cvref_t<T>, UnqualifiedT>;
+
 // For ad-hoc RAII in place of a `defer` statement or cross-platform `__attribute__((cleanup))`
 template<Procedure DeferredFnT>
 struct Defer {

--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -3,6 +3,8 @@
 #ifndef RGBDS_HELPERS_HPP
 #define RGBDS_HELPERS_HPP
 
+#include <type_traits> // is_void_v, invoke_result_t
+
 // Ideally we'd use `std::unreachable`, but it has insufficient compiler support
 #ifdef __GNUC__ // GCC or compatible
 	#ifdef NDEBUG
@@ -101,12 +103,14 @@ static inline int clz(unsigned int x) {
 
 // MSVC does not inline `strlen()` or `.length()` of a constant string
 template<int SizeOfString>
+    requires(SizeOfString > 0)
 static constexpr int literal_strlen(char const (&)[SizeOfString]) {
 	return SizeOfString - 1; // Don't count the ending '\0'
 }
 
 // For ad-hoc RAII in place of a `defer` statement or cross-platform `__attribute__((cleanup))`
 template<typename DeferredFnT>
+    requires(std::is_void_v<std::invoke_result_t<DeferredFnT>>)
 struct Defer {
 	DeferredFnT deferred;
 	Defer(DeferredFnT func) : deferred(func) {}

--- a/include/itertools.hpp
+++ b/include/itertools.hpp
@@ -12,6 +12,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include "helpers.hpp" // Enum
+
 // A wrapper around iterables to reverse their iteration order; used in `for`-each loops.
 template<typename IterableT>
 struct ReversedIterable {
@@ -78,7 +80,7 @@ public:
 };
 
 // An iterable of `enum` values in the half-open range [start, stop).
-template<typename EnumT>
+template<Enum EnumT>
 class EnumSeq {
 	EnumT _start;
 	EnumT _stop;
@@ -169,7 +171,7 @@ template<typename IterableT>
 using ZipHolder = std::conditional_t<
     std::is_lvalue_reference_v<IterableT>,
     IterableT,
-    std::remove_cv_t<std::remove_reference_t<IterableT>>>;
+    std::remove_cvref_t<IterableT>>;
 
 // Iterates over N containers at once, yielding tuples of N items at a time.
 // Does the same number of iterations as the first container's iterator!

--- a/include/link/section.hpp
+++ b/include/link/section.hpp
@@ -6,9 +6,9 @@
 #include <memory>
 #include <stdint.h>
 #include <string>
-#include <type_traits> // is_same_t, remove_cvref_t
 #include <vector>
 
+#include "helpers.hpp" // QualifiedEquivalent
 #include "linkdefs.hpp"
 
 struct FileStackNode;
@@ -53,8 +53,7 @@ struct Section {
 
 private:
 	// Template class for both const and non-const iterators over the "pieces" of this section
-	template<typename SectionT>
-	    requires(std::is_same_v<std::remove_cvref_t<SectionT>, Section>)
+	template<QualifiedEquivalent<Section> SectionT>
 	class PiecesIterable {
 		SectionT *_firstPiece;
 

--- a/include/link/section.hpp
+++ b/include/link/section.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <stdint.h>
 #include <string>
+#include <type_traits> // is_same_t, remove_cvref_t
 #include <vector>
 
 #include "linkdefs.hpp"
@@ -53,6 +54,7 @@ struct Section {
 private:
 	// Template class for both const and non-const iterators over the "pieces" of this section
 	template<typename SectionT>
+	    requires(std::is_same_v<std::remove_cvref_t<SectionT>, Section>)
 	class PiecesIterable {
 		SectionT *_firstPiece;
 

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -39,7 +39,10 @@ bool startsIdentifier(int c);
 bool continuesIdentifier(int c);
 
 template<uint32_t Base>
-    requires(Base > 0 && Base <= 36)
+inline constexpr bool BaseV = Base > 0 && Base <= 36;
+
+template<uint32_t Base>
+    requires BaseV<Base>
 bool isDigit(int c) {
 	if constexpr (Base <= 10) {
 		return c >= '0' && c < static_cast<int>('0' + Base);
@@ -50,7 +53,7 @@ bool isDigit(int c) {
 }
 
 template<uint32_t Base>
-    requires(Base > 0 && Base <= 36)
+    requires BaseV<Base>
 uint8_t parseDigit(int c) {
 	assume(isDigit<Base>(c));
 	if constexpr (Base <= 10) {

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -39,8 +39,8 @@ bool startsIdentifier(int c);
 bool continuesIdentifier(int c);
 
 template<uint32_t Base>
+    requires(Base > 0 && Base <= 36)
 bool isDigit(int c) {
-	static_assert(Base <= 36, "Base must be 36 or less to allow digits 0-9A-Z");
 	if constexpr (Base <= 10) {
 		return c >= '0' && c < static_cast<int>('0' + Base);
 	} else {
@@ -50,8 +50,8 @@ bool isDigit(int c) {
 }
 
 template<uint32_t Base>
+    requires(Base > 0 && Base <= 36)
 uint8_t parseDigit(int c) {
-	static_assert(Base <= 36, "Base must be 36 or less to allow digits 0-9A-Z");
 	assume(isDigit<Base>(c));
 	if constexpr (Base <= 10) {
 		return c - '0';

--- a/src/asm/charmap.cpp
+++ b/src/asm/charmap.cpp
@@ -3,6 +3,7 @@
 #include "asm/charmap.hpp"
 
 #include <algorithm>
+#include <concepts> // same_as
 #include <map>
 #include <optional>
 #include <stack>
@@ -66,6 +67,9 @@ struct Charmap {
 
 // Traverse the trie depth-first to derive the character mappings in definition order
 template<typename CallbackFnT>
+    requires requires(CallbackFnT callback, size_t nodeIdx, std::string const &mapping) {
+	    { callback(nodeIdx, mapping) } -> std::same_as<bool>;
+    }
 bool forEachChar(Charmap const &charmap, CallbackFnT callback) {
 	// clang-format off: nested initializers
 	for (std::stack<std::pair<size_t, std::string>> prefixes({{0, ""}}); !prefixes.empty();) {

--- a/src/asm/charmap.cpp
+++ b/src/asm/charmap.cpp
@@ -66,18 +66,16 @@ struct Charmap {
 };
 
 // Traverse the trie depth-first to derive the character mappings in definition order
-template<typename CallbackFnT>
-    requires requires(CallbackFnT callback, size_t nodeIdx, std::string const &mapping) {
-	    { callback(nodeIdx, mapping) } -> std::same_as<bool>;
-    }
-bool forEachChar(Charmap const &charmap, CallbackFnT callback) {
+template<typename PredicateFnT>
+    requires std::predicate<PredicateFnT, size_t, std::string const &>
+bool forEachChar(Charmap const &charmap, PredicateFnT predicate) {
 	// clang-format off: nested initializers
 	for (std::stack<std::pair<size_t, std::string>> prefixes({{0, ""}}); !prefixes.empty();) {
 		// clang-format on
 		auto [nodeIdx, mapping] = std::move(prefixes.top());
 		prefixes.pop();
 		CharmapNode const &node = charmap.nodes[nodeIdx];
-		if (node.isTerminal() && !callback(nodeIdx, mapping)) {
+		if (node.isTerminal() && !predicate(nodeIdx, mapping)) {
 			return false;
 		}
 		for (auto const &[c, nextIdx] : node.children) {

--- a/src/asm/charmap.cpp
+++ b/src/asm/charmap.cpp
@@ -3,7 +3,7 @@
 #include "asm/charmap.hpp"
 
 #include <algorithm>
-#include <concepts> // same_as
+#include <concepts> // predicate
 #include <map>
 #include <optional>
 #include <stack>
@@ -66,16 +66,16 @@ struct Charmap {
 };
 
 // Traverse the trie depth-first to derive the character mappings in definition order
-template<typename PredicateFnT>
-    requires std::predicate<PredicateFnT, size_t, std::string const &>
-bool forEachChar(Charmap const &charmap, PredicateFnT predicate) {
+bool forEachChar(
+    Charmap const &charmap, std::predicate<size_t, std::string const &> auto callback
+) {
 	// clang-format off: nested initializers
 	for (std::stack<std::pair<size_t, std::string>> prefixes({{0, ""}}); !prefixes.empty();) {
 		// clang-format on
 		auto [nodeIdx, mapping] = std::move(prefixes.top());
 		prefixes.pop();
 		CharmapNode const &node = charmap.nodes[nodeIdx];
-		if (node.isTerminal() && !predicate(nodeIdx, mapping)) {
+		if (node.isTerminal() && !callback(nodeIdx, mapping)) {
 			return false;
 		}
 		for (auto const &[c, nextIdx] : node.children) {

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -4,7 +4,7 @@
 #include <sys/stat.h>
 
 #include <algorithm>
-#include <concepts> // same_as
+#include <concepts> // predicate
 #include <errno.h>
 #include <fcntl.h>
 #include <fstream>
@@ -821,9 +821,7 @@ static int nextChar() {
 }
 
 template<typename PredicateFnT>
-    requires requires(PredicateFnT predicate, int c) {
-	    { predicate(c) } -> std::same_as<bool>;
-    }
+    requires std::predicate<PredicateFnT, int>
 static int skipChars(PredicateFnT predicate) {
 	int c = peek();
 	while (predicate(c)) {

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -21,7 +21,6 @@
 #include <string>
 #include <string_view>
 #include <tuple>
-#include <type_traits> // is_invocable_r_v
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -529,7 +528,7 @@ static void shiftChar();
 static int bumpChar();
 static int nextChar();
 template<uint32_t Base>
-    requires(Base > 0 && Base <= 36)
+    requires BaseV<Base>
 static uint32_t readNumber(int initial, char const *prefix);
 
 static uint32_t readBracketedMacroArgNum() {
@@ -821,9 +820,7 @@ static int nextChar() {
 	return peek();
 }
 
-template<typename PredicateFnT>
-    requires std::predicate<PredicateFnT, int>
-static int skipChars(PredicateFnT predicate) {
+static int skipChars(std::predicate<int> auto predicate) {
 	int c = peek();
 	while (predicate(c)) {
 		c = nextChar();
@@ -1103,7 +1100,7 @@ void lexer_SetGfxDigits(char const digits[4]) {
 }
 
 template<uint32_t Base>
-    requires(Base > 0 && Base <= 36)
+    requires BaseV<Base>
 static uint32_t readNumber(int initial, char const *prefix) {
 	auto isSomeDigit = [](int c) {
 		if constexpr (Base == 2) {
@@ -2288,9 +2285,7 @@ yy::parser::symbol_type yylex() {
 	}
 }
 
-template<typename CallbackFnT>
-    requires std::is_invocable_r_v<int, CallbackFnT, int>
-static Capture makeCapture(char const *name, CallbackFnT callback) {
+static Capture makeCapture(char const *name, InvocableR<int, int> auto callback) {
 	// Due to parser internals, it reads the EOL after the expression before calling this.
 	// Thus, we don't need to keep one in the buffer afterwards.
 	// The following assumption checks that.

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <concepts> // same_as
 #include <errno.h>
 #include <fcntl.h>
 #include <fstream>
@@ -527,6 +528,7 @@ static void shiftChar();
 static int bumpChar();
 static int nextChar();
 template<uint32_t Base>
+    requires(Base > 0 && Base <= 36)
 static uint32_t readNumber(int initial, char const *prefix);
 
 static uint32_t readBracketedMacroArgNum() {
@@ -819,6 +821,9 @@ static int nextChar() {
 }
 
 template<typename PredicateFnT>
+    requires requires(PredicateFnT predicate, int c) {
+	    { predicate(c) } -> std::same_as<bool>;
+    }
 static int skipChars(PredicateFnT predicate) {
 	int c = peek();
 	while (predicate(c)) {
@@ -1099,6 +1104,7 @@ void lexer_SetGfxDigits(char const digits[4]) {
 }
 
 template<uint32_t Base>
+    requires(Base > 0 && Base <= 36)
 static uint32_t readNumber(int initial, char const *prefix) {
 	auto isSomeDigit = [](int c) {
 		if constexpr (Base == 2) {
@@ -2284,6 +2290,9 @@ yy::parser::symbol_type yylex() {
 }
 
 template<typename CallbackFnT>
+    requires requires(CallbackFnT callback, int tokenType) {
+	    { callback(tokenType) } -> std::same_as<int>;
+    }
 static Capture makeCapture(char const *name, CallbackFnT callback) {
 	// Due to parser internals, it reads the EOL after the expression before calling this.
 	// Thus, we don't need to keep one in the buffer afterwards.

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <type_traits> // is_invocable_r_v
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -2288,9 +2289,7 @@ yy::parser::symbol_type yylex() {
 }
 
 template<typename CallbackFnT>
-    requires requires(CallbackFnT callback, int tokenType) {
-	    { callback(tokenType) } -> std::same_as<int>;
-    }
+    requires std::is_invocable_r_v<int, CallbackFnT, int>
 static Capture makeCapture(char const *name, CallbackFnT callback) {
 	// Due to parser internals, it reads the EOL after the expression before calling this.
 	// Thus, we don't need to keep one in the buffer afterwards.

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -32,6 +32,7 @@
 
 %code {
 	#include <algorithm>
+	#include <concepts> // invocable
 	#include <inttypes.h>
 	#include <optional>
 	#include <stdio.h>
@@ -58,15 +59,8 @@
 	yy::parser::symbol_type yylex(); // Provided by lexer.cpp
 
 	template<typename NumCallbackFnT, typename StrCallbackFnT>
-	    requires requires(
-	        NumCallbackFnT numCallback,
-	        StrCallbackFnT strCallback,
-	        Expression const &expr,
-	        std::string const &str
-	    ) {
-		    numCallback(expr);
-		    strCallback(str);
-	    }
+	    requires std::invocable<NumCallbackFnT, Expression const &>
+	             && std::invocable<StrCallbackFnT, std::string const &>
 	static auto handleSymbolByType(
 	    std::string const &symName, NumCallbackFnT numCallback, StrCallbackFnT strCallback
 	) {

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -58,11 +58,10 @@
 
 	yy::parser::symbol_type yylex(); // Provided by lexer.cpp
 
-	template<typename NumCallbackFnT, typename StrCallbackFnT>
-	    requires std::invocable<NumCallbackFnT, Expression const &>
-	             && std::invocable<StrCallbackFnT, std::string const &>
 	static auto handleSymbolByType(
-	    std::string const &symName, NumCallbackFnT numCallback, StrCallbackFnT strCallback
+	    std::string const &symName,
+	    std::invocable<Expression const &> auto numCallback,
+	    std::invocable<std::string const &> auto strCallback
 	) {
 		if (Symbol *sym = sym_FindScopedSymbol(symName); sym && sym->type == SYM_EQUS) {
 			return strCallback(*sym->getEqus());

--- a/src/asm/parser.y
+++ b/src/asm/parser.y
@@ -58,6 +58,15 @@
 	yy::parser::symbol_type yylex(); // Provided by lexer.cpp
 
 	template<typename NumCallbackFnT, typename StrCallbackFnT>
+	    requires requires(
+	        NumCallbackFnT numCallback,
+	        StrCallbackFnT strCallback,
+	        Expression const &expr,
+	        std::string const &str
+	    ) {
+		    numCallback(expr);
+		    strCallback(str);
+	    }
 	static auto handleSymbolByType(
 	    std::string const &symName, NumCallbackFnT numCallback, StrCallbackFnT strCallback
 	) {

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <charconv>
+#include <concepts> // unsigned_integral
 #include <errno.h>
 #include <fstream>
 #include <inttypes.h>
@@ -15,7 +16,6 @@
 #include <string.h>
 #include <string>
 #include <string_view>
-#include <type_traits> // is_unsigned_v
 #include <utility>
 #include <vector>
 
@@ -203,8 +203,7 @@ static void warnExtraColors(
 }
 
 // Parses the initial part of a string_view, advancing the "read index" as it does
-template<typename UintT>
-    requires std::is_unsigned_v<UintT>
+template<std::unsigned_integral UintT>
 static std::optional<UintT> parseDec(std::string const &str, size_t &n) {
 	UintT value = 0;
 	auto result = std::from_chars(str.data() + n, str.data() + str.length(), value);

--- a/src/gfx/pal_spec.cpp
+++ b/src/gfx/pal_spec.cpp
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <string>
 #include <string_view>
+#include <type_traits> // is_unsigned_v
 #include <utility>
 #include <vector>
 
@@ -202,7 +203,8 @@ static void warnExtraColors(
 }
 
 // Parses the initial part of a string_view, advancing the "read index" as it does
-template<typename UintT> // Should be uint*_t
+template<typename UintT>
+    requires std::is_unsigned_v<UintT>
 static std::optional<UintT> parseDec(std::string const &str, size_t &n) {
 	UintT value = 0;
 	auto result = std::from_chars(str.data() + n, str.data() + str.length(), value);

--- a/src/link/lexer.cpp
+++ b/src/link/lexer.cpp
@@ -95,6 +95,7 @@ static std::string readKeyword(int initial) {
 }
 
 template<uint32_t Base>
+    requires(Base > 0 && Base <= 36)
 static yy::parser::symbol_type readNumber(int initial, char const *prefix, char const *name) {
 	LexerStackEntry &context = lexerStack.back();
 	uint32_t number;

--- a/src/link/lexer.cpp
+++ b/src/link/lexer.cpp
@@ -95,7 +95,7 @@ static std::string readKeyword(int initial) {
 }
 
 template<uint32_t Base>
-    requires(Base > 0 && Base <= 36)
+    requires BaseV<Base>
 static yy::parser::symbol_type readNumber(int initial, char const *prefix, char const *name) {
 	LexerStackEntry &context = lexerStack.back();
 	uint32_t number;

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <tuple>
-#include <type_traits> // is_void_v, invoke_result_t
 #include <variant>
 #include <vector>
 
@@ -311,9 +310,9 @@ static bool compareSymbols(SortedSymbol const &sym1, SortedSymbol const &sym2) {
 	       < std::tie(sym2.addr, sym2_local, sym2.parentAddr, sym2_name);
 }
 
-template<typename CallbackFnT>
-    requires std::is_void_v<std::invoke_result_t<CallbackFnT, Section const &>>
-static void forEachSortedSection(SortedSections const &bankSections, CallbackFnT callback) {
+static void forEachSortedSection(
+    SortedSections const &bankSections, Procedure<Section const &> auto callback
+) {
 	for (Section const *sect : bankSections.zeroLenSections) {
 		for (Section const &piece : sect->pieces()) {
 			callback(piece);
@@ -413,9 +412,7 @@ static void writeSectionName(std::string const &name, FILE *file) {
 	}
 }
 
-template<typename CallbackFnT>
-    requires std::is_void_v<std::invoke_result_t<CallbackFnT, Section const &>>
-uint16_t forEachSection(SortedSections const &sectList, CallbackFnT callback) {
+uint16_t forEachSection(SortedSections const &sectList, Procedure<Section const &> auto callback) {
 	uint16_t used = 0;
 	auto section = sectList.sections.begin();
 	auto zeroLenSection = sectList.zeroLenSections.begin();

--- a/src/link/output.cpp
+++ b/src/link/output.cpp
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <tuple>
+#include <type_traits> // is_void_v, invoke_result_t
 #include <variant>
 #include <vector>
 
@@ -311,6 +312,7 @@ static bool compareSymbols(SortedSymbol const &sym1, SortedSymbol const &sym2) {
 }
 
 template<typename CallbackFnT>
+    requires std::is_void_v<std::invoke_result_t<CallbackFnT, Section const &>>
 static void forEachSortedSection(SortedSections const &bankSections, CallbackFnT callback) {
 	for (Section const *sect : bankSections.zeroLenSections) {
 		for (Section const &piece : sect->pieces()) {
@@ -412,6 +414,7 @@ static void writeSectionName(std::string const &name, FILE *file) {
 }
 
 template<typename CallbackFnT>
+    requires std::is_void_v<std::invoke_result_t<CallbackFnT, Section const &>>
 uint16_t forEachSection(SortedSections const &sectList, CallbackFnT callback) {
 	uint16_t used = 0;
 	auto section = sectList.sections.begin();


### PR DESCRIPTION
Fixes #1972

C++20 added `<concepts>` with some concepts like `std::invocable`, `std::predicate`, and `std::unsigned_integral`. Previously C++11 had added `<type_traits>` with some Boolean traits like `std::is_invocable` and `std::is_unsigned`. The concepts are terser and more convenient to use, when they exist, but some things expressible as `requires` traits [do not (yet)](https://stackoverflow.com/questions/77172259/why-does-c-have-no-stdinvocable-r-concept) have standard concepts, so I defined a few more in `helpers.hpp`.

- ❌ `template<typename T> void func(T arg) {}` (unconstrained "dynamic typing")
- ❌ `template<typename T> requires Constraint<T> void func(T arg) {}` (very verbose)
- ❌ `template<Constraint T> void func(T arg) {}` (okay for structs, but...)
- ✅ `void func(Constraint auto arg) {}` (...functions can be abbreviated in C++20)

I have not yet added concepts to `include/itertools.hpp` or `src/gfx/pal_packing.cpp` because that would require `<ranges>`. [Compiler support](https://en.cppreference.com/cpp/compiler_support/20#:~:text=The%20One%20Ranges%20Proposal%C2%A0%20%28FTM%29) is hopefully sufficient, but that can be another PR.