### PR TITLE
Do not support GCC 9

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -20,7 +20,7 @@ case "${OS%%-*}" in
 				pkgs="$pkgs libz-mingw-w64-dev g++-mingw-w64-x86-64-win32"
 				TOOLSET=
 			;;
-			g++-9 | lcov)
+			g++-10 | lcov)
 				pkgs="$pkgs libpng-dev pkgconf $TOOLSET"
 				TOOLSET=
 			;;

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,9 +40,9 @@ jobs:
         exclude: # Don't use `g++` on macOS; it's just an alias to `clang++`.
           - { os: macos-15-intel, cxx: g++ }
           - { os: macos-26, cxx: g++ }
-        include: # Use `g++-9`, the earliest GCC version we support, on the earliest Ubuntu runner.
-          - { os: ubuntu-22.04, cxx: g++-9, buildsys: make }
-          - { os: ubuntu-22.04, cxx: g++-9, buildsys: cmake }
+        include: # Use `g++-10`, the earliest GCC version we support, on the earliest Ubuntu runner.
+          - { os: ubuntu-22.04, cxx: g++-10, buildsys: make }
+          - { os: ubuntu-22.04, cxx: g++-10, buildsys: cmake }
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ WARNFLAGS := -Wall -pedantic -Wno-unknown-warning-option -Wno-gnu-zero-variadic-
 # Overridable CXXFLAGS
 CXXFLAGS     ?= -O3 -flto -DNDEBUG
 # Non-overridable CXXFLAGS
-# GCC 9 doesn't support `-std=c++20`, and all later GCCs treat it as equivalent to `-std=c++2a`.
-REALCXXFLAGS := ${CXXFLAGS} ${WARNFLAGS} -std=c++2a -I include -fno-exceptions -fno-rtti
+REALCXXFLAGS := ${CXXFLAGS} ${WARNFLAGS} -std=c++20 -I include -fno-exceptions -fno-rtti
 # Overridable LDFLAGS
 LDFLAGS      ?=
 # Non-overridable LDFLAGS
@@ -257,7 +256,7 @@ tidy: src/asm/parser.hpp src/link/script.hpp
 iwyu:
 	$Qenv ${MAKE} \
 		CXX="include-what-you-use" \
-		REALCXXFLAGS="-std=c++2a -I include"
+		REALCXXFLAGS="-std=c++20 -I include"
 
 # Target used in development to conveniently invoke RGBDS binaries with Wine.
 wine-shim:

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,4 +1,4 @@
--std=c++2a
+-std=c++20
 -I
 include
 -fno-exceptions

--- a/include/gfx/rgba.hpp
+++ b/include/gfx/rgba.hpp
@@ -40,7 +40,6 @@ struct Rgba {
 	}
 
 	bool operator==(Rgba const &rhs) const { return toCSS() == rhs.toCSS(); }
-	bool operator!=(Rgba const &rhs) const { return !operator==(rhs); }
 
 	// CGB colors are RGB555, so we use bit 15 to signify that the color is transparent instead
 	// Since the rest of the bits don't matter then, we return 0x8000 exactly.

--- a/include/itertools.hpp
+++ b/include/itertools.hpp
@@ -97,7 +97,6 @@ class EnumSeq {
 		EnumT operator*() const { return _value; }
 
 		bool operator==(Iterator const &rhs) const { return _value == rhs._value; }
-		bool operator!=(Iterator const &rhs) const { return !operator==(rhs); }
 	};
 
 public:
@@ -132,7 +131,6 @@ public:
 	bool operator==(ZipIterator const &rhs) const {
 		return std::get<0>(_iters) == std::get<0>(rhs._iters);
 	}
-	bool operator!=(ZipIterator const &rhs) const { return !operator==(rhs); }
 };
 
 // Only needed inside `zip` below.

--- a/include/link/section.hpp
+++ b/include/link/section.hpp
@@ -70,7 +70,6 @@ private:
 			SectionT &operator*() const { return *_piece; }
 
 			bool operator==(Iterator const &rhs) const { return _piece == rhs._piece; }
-			bool operator!=(Iterator const &rhs) const { return !operator==(rhs); }
 		};
 
 	public:

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -74,14 +74,14 @@ char const *printChar(int c);
 
 struct Uppercase {
 	// FNV-1a hash of an uppercased string
-	size_t operator()(std::string const &str) const {
+	constexpr size_t operator()(std::string const &str) const {
 		return std::accumulate(RANGE(str), size_t(0x811C9DC5), [](size_t hash, char c) {
 			return (hash ^ toUpper(c)) * 16777619;
 		});
 	}
 
 	// Compare two strings without case-sensitivity (by converting to uppercase)
-	bool operator()(std::string const &str1, std::string const &str2) const {
+	constexpr bool operator()(std::string const &str1, std::string const &str2) const {
 		return std::equal(RANGE(str1), RANGE(str2), [](char c1, char c2) {
 			return toUpper(c1) == toUpper(c2);
 		});

--- a/src/asm/fixpoint.cpp
+++ b/src/asm/fixpoint.cpp
@@ -5,10 +5,10 @@
 #include "asm/fixpoint.hpp"
 
 #include <math.h>
+#include <numbers>
 #include <stdint.h>
 
-// Ideally we'd use `std::numbers::pi`, but GCC 9 doesn't support it.
-static constexpr double tau = 3.141592653589793238462643383279502884L * 2;
+static constexpr double tau = std::numbers::pi * 2;
 
 static double fix2double(int32_t i, int32_t q) {
 	return i / pow(2.0, q);

--- a/src/gfx/pal_packing.cpp
+++ b/src/gfx/pal_packing.cpp
@@ -100,7 +100,6 @@ private:
 		AssignedSetsIter() = default;
 
 		bool operator==(AssignedSetsIter const &rhs) const { return _iter == rhs._iter; }
-		bool operator!=(AssignedSetsIter const &rhs) const { return !operator==(rhs); }
 
 		AssignedSetsIter &operator++() {
 			++_iter;

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -263,7 +263,6 @@ struct Image {
 			}
 
 			bool operator==(Iterator const &rhs) const { return coords() == rhs.coords(); }
-			bool operator!=(Iterator const &rhs) const { return !operator==(rhs); }
 		};
 
 	public:


### PR DESCRIPTION
This will let us use C++20 features that GCC 9's experimental C++20 support did not yet cover, such as "concepts".

This reverts some commits:
- 6bcd79b997f321678c763b5b8bfec6284202b0c3
- d5ce5329ea3ac8255d1cc1fa30c260bc0d534b77
- 728d14879bfcc49e22f0d2a82664541968def1e9

GCC 9.1 was released in May 2019, and was last updated as GCC 9.5 in May 2022. Meanwhile GCC 10.1 was released in May 2020, introducing non-experimental C++20 support. We stopped supporting GCC 9 in #1660, so RGBDS 0.9.2 and up have required GCC 10+. We restored support for GCC 9 in #1961, while experimenting with some retro hardware and VMs. But building with GCC 9 is not actually essential to supporting old platforms -- even for Mac OS X 10.4 Tiger from 2005, [Tigerbrew](https://github.com/mistydemeo/tigerbrew) supposedly lets you install GCC 14 (and although we've had issues with doing so, it could theoretically be [built from source](https://briancallahan.net/blog/20250329.html)) -- so I think it's worth being able to use full C++20 features.