### PR TITLE
Avoid using `<functional>`; prefer using templates

### DIFF
--- a/include/asm/warning.hpp
+++ b/include/asm/warning.hpp
@@ -3,9 +3,11 @@
 #ifndef RGBDS_ASM_WARNING_HPP
 #define RGBDS_ASM_WARNING_HPP
 
-#include <functional>
+#include <stdio.h>
 
 #include "diagnostics.hpp"
+#include "helpers.hpp" // Procedure
+#include "style.hpp"
 
 enum WarningLevel {
 	LEVEL_DEFAULT,    // Warnings that are enabled by default
@@ -68,10 +70,6 @@ void warning(WarningID id, char const *fmt, ...);
 [[gnu::format(printf, 1, 2), noreturn]]
 void fatal(char const *fmt, ...);
 
-// Used for fatal errors that handle their own backtrace output.
-[[noreturn]]
-void fatalNoTrace(std::function<void()> callback);
-
 // Used for errors that make it impossible to assemble correctly, but don't
 // affect the following code. The code will fail to assemble but the user will
 // get a list of all errors at the end, making it easier to fix all of them at
@@ -79,10 +77,31 @@ void fatalNoTrace(std::function<void()> callback);
 [[gnu::format(printf, 1, 2)]]
 void error(char const *fmt, ...);
 
+// Only visible so `errorNoTrace` can call it; should not be otherwise used.
+void incrementErrors();
+
+// Used for fatal errors that handle their own backtrace output.
+[[noreturn]]
+void fatalNoTrace(Procedure<> auto callback) {
+	style_Set(stderr, STYLE_RED, true);
+	fputs("FATAL: ", stderr);
+	style_Reset(stderr);
+	callback();
+
+	exit(1);
+}
+
 // Used for errors that handle their own backtrace output. The code will fail
 // to assemble but the user will get a list of all errors at the end, making it
 // easier to fix all of them at once.
-void errorNoTrace(std::function<void()> callback);
+void errorNoTrace(Procedure<> auto callback) {
+	style_Set(stderr, STYLE_RED, true);
+	fputs("error: ", stderr);
+	style_Reset(stderr);
+	callback();
+
+	incrementErrors();
+}
 
 void requireZeroErrors();
 

--- a/src/asm/warning.cpp
+++ b/src/asm/warning.cpp
@@ -2,7 +2,6 @@
 
 #include "asm/warning.hpp"
 
-#include <functional>
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -83,7 +82,7 @@ static void printDiag(
 	fstk_TraceCurrent();
 }
 
-static void incrementErrors() {
+void incrementErrors() {
 	// This intentionally makes 0 act as "unlimited"
 	warnings.incrementErrors();
 	if (warnings.nbErrors == options.maxErrors) {
@@ -111,15 +110,6 @@ void error(char const *fmt, ...) {
 	incrementErrors();
 }
 
-void errorNoTrace(std::function<void()> callback) {
-	style_Set(stderr, STYLE_RED, true);
-	fputs("error: ", stderr);
-	style_Reset(stderr);
-	callback();
-
-	incrementErrors();
-}
-
 [[noreturn]]
 void fatal(char const *fmt, ...) {
 	va_list args;
@@ -127,16 +117,6 @@ void fatal(char const *fmt, ...) {
 	va_start(args, fmt);
 	printDiag(fmt, args, "FATAL", STYLE_RED, nullptr, nullptr);
 	va_end(args);
-
-	exit(1);
-}
-
-[[noreturn]]
-void fatalNoTrace(std::function<void()> callback) {
-	style_Set(stderr, STYLE_RED, true);
-	fputs("FATAL: ", stderr);
-	style_Reset(stderr);
-	callback();
 
 	exit(1);
 }


### PR DESCRIPTION
RGBASM's warning/error functions started using `<functional>` in 8c50839109369a6d71e03720bfe889b735297359 for `error` (which later got renamed to `errorNoTrace`) to take a `std::function<void()> callback` argument, and more recently d56dbbb4bfa3a4ab6a083b2987a37fc2505dd908 (#1964) used it again for `fatalNoTrace`. However, using `std::function`, or even including `<functional>` at all, may be inefficient, particularly with how it increases binary sizes. So this PR is an attempt to optimize RGBASM by using templates instead. Now `errorNoTrace` and `fatalNoTrace` each take a `Procedure<> auto callback` argument (with `Procedure<>` being our custom `concept` for a function that takes no arguments and returns `void`), which should get inlined into each usage. We'll need to measure how the binary size and runtime are affected, and consider the effect on code quality (now `warning.hpp` includes other headers, and has to spuriously make `incrementErrors` public), before merging.