### PR TITLE
More optimizations related to lexing keywords

### DIFF
--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -101,6 +101,10 @@ static inline int clz(unsigned int x) {
 #define RANGE(s)  std::begin(s), std::end(s)
 #define RRANGE(s) std::rbegin(s), std::rend(s)
 
+// Macros to print-format a `std::string_view` (like <inttype.h> macros)
+#define PRI_SV         ".*s"
+#define PRI_SV_ARG(sv) static_cast<int>((sv).length()), (sv).data()
+
 // MSVC does not inline `strlen()` or `.length()` of a constant string
 template<int SizeOfString>
     requires(SizeOfString > 0)

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -8,7 +8,7 @@
 #include <optional>
 #include <stddef.h>
 #include <stdint.h>
-#include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include "helpers.hpp"
@@ -76,23 +76,25 @@ std::optional<uint64_t> parseWholeNumber(char const *str, NumberBase base = BASE
 char const *printChar(int c);
 
 struct Uppercase {
+	using is_transparent = void;
+
 	// FNV-1a hash of an uppercased string
-	constexpr size_t operator()(std::string const &str) const {
+	constexpr size_t operator()(std::string_view str) const {
 		return std::accumulate(RANGE(str), size_t(0x811C9DC5), [](size_t hash, char c) {
 			return (hash ^ toUpper(c)) * 16777619;
 		});
 	}
 
 	// Compare two strings without case-sensitivity (by converting to uppercase)
-	constexpr bool operator()(std::string const &str1, std::string const &str2) const {
+	constexpr bool operator()(std::string_view str1, std::string_view str2) const {
 		return std::equal(RANGE(str1), RANGE(str2), [](char c1, char c2) {
 			return toUpper(c1) == toUpper(c2);
 		});
 	}
 };
 
-// An unordered map from case-insensitive `std::string` keys to `ItemT` items
+// An unordered map from case-insensitive `std::string_view` keys to `ItemT` items
 template<typename ItemT>
-using UpperMap = std::unordered_map<std::string, ItemT, Uppercase, Uppercase>;
+using UpperMap = std::unordered_map<std::string_view, ItemT, Uppercase, Uppercase>;
 
 #endif // RGBDS_UTIL_HPP

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -2058,44 +2058,50 @@ finish: // Can't `break` out of a nested `for`-`switch`
 	return Token(T_(YYEOF));
 }
 
-static Token skipToLeadingKeyword(
-    InvocableR<int> auto peekFn,
-    Procedure<> auto shiftFn,
-    Procedure<> auto nextLineFn,
-    Procedure<> auto finalizeFn
-) {
+static Token skipToLeadingKeywordFast(Procedure<> auto shiftFast) {
+	// This is essentially `skipToLeadingKeyword` with `peek` and `shiftChar` replaced,
+	// as well as anything that calls them like `nextChar` or `handleCRLF`.
+	char const *ptr = lexerState->content.ptr.get();
+	auto peekFast = [&]() {
+		return lexerState->offset < lexerState->content.size ? ptr[lexerState->offset] : EOF;
+	};
 	for (;;) {
-		int c = peekFn();
+		int c = peekFast();
 		if (lexerState->atLineStart) {
 			lexerState->atLineStart = false;
 			while (isBlankSpace(c)) {
-				shiftFn();
-				c = peekFn();
+				shiftFast();
+				c = peekFast();
 			}
 			if (c == EOF) {
 				return Token(T_(YYEOF));
 			} else if (isLetter(c)) {
-				std::string builder(1, c);
-				shiftFn();
-				for (c = peekFn(); continuesIdentifier(c); c = peekFn()) {
-					builder += c;
-					shiftFn();
+				size_t start = lexerState->offset;
+				shiftFast();
+				for (c = peekFast(); continuesIdentifier(c); c = peekFast()) {
+					shiftFast();
 				}
-				if (auto search = keywords.find(builder); search != keywords.end()) {
-					finalizeFn();
+				std::string_view leading{ptr + start, ptr + lexerState->offset};
+				if (auto search = keywords.find(leading); search != keywords.end()) {
+					// When this branch returns a token, there has been one more call to `peekFast`
+					// than to `shiftFast`. Unlike `peek` and `shiftChar`, the optimized functions
+					// do not update `lexerState->expansionScanDistance`, so it must be incremented
+					// if it was previously zero.
+					if (lexerState->expansionScanDistance == 0) {
+						++lexerState->expansionScanDistance;
+					}
 					return Token(search->second);
 				}
 			}
 		}
-		shiftFn();
+		shiftFast();
 		if (c == EOF) {
 			return Token(T_(YYEOF));
 		} else if (isNewline(c)) {
-			// Like `handleCRLF` but calling generic `shiftFn`
-			if (c == '\r' && peekFn() == '\n') {
-				shiftFn();
+			if (c == '\r' && peekFast() == '\n') {
+				shiftFast();
 			}
-			nextLineFn();
+			++lexerState->lineNo;
 			lexerState->atLineStart = true;
 		}
 	}
@@ -2120,36 +2126,42 @@ static Token skipToLeadingKeyword() {
 	if (lexerState->expansionStack.empty()) {
 		// Optimize the common case (no ongoing expansions) to avoid
 		// the bookkeeping of `peek` and `shiftChar`.
-		char const *ptr = lexerState->content.ptr.get();
-		auto quickPeek = [&]() {
-			return lexerState->offset < lexerState->content.size ? ptr[lexerState->offset] : EOF;
-		};
-		auto quickNextLine = []() { ++lexerState->lineNo; };
-		auto quickFinalize = []() {
-			// When `skipToLeadingKeyword` returns a token, there has been one more
-			// call to `quickPeek` than to `quickNextLine`. Unlike `peek` and `shiftChar`,
-			// the optimized functions do not update `lexerState->expansionScanDistance`,
-			// so it must be incrementedif it was previously zero.
-			if (lexerState->expansionScanDistance == 0) {
-				++lexerState->expansionScanDistance;
-			}
-		};
 		if (lexerState->capturing) {
 			assume(lexerState->captureBuf == nullptr);
-			auto quickCaptureShiftChar = [&]() {
+			return skipToLeadingKeywordFast([&]() {
 				++lexerState->offset;
 				++lexerState->captureSize;
-			};
-			return skipToLeadingKeyword(
-			    quickPeek, quickCaptureShiftChar, quickNextLine, quickFinalize
-			);
+			});
 		} else {
-			auto quickShiftChar = [&]() { ++lexerState->offset; };
-			return skipToLeadingKeyword(quickPeek, quickShiftChar, quickNextLine, quickFinalize);
+			return skipToLeadingKeywordFast([&]() { ++lexerState->offset; });
 		}
-	} else {
-		auto finalize = []() {};
-		return skipToLeadingKeyword(peek, shiftChar, nextLine, finalize);
+	}
+
+	for (;;) {
+		int c = peek();
+		if (lexerState->atLineStart) {
+			lexerState->atLineStart = false;
+			c = skipChars(isBlankSpace);
+			if (c == EOF) {
+				return Token(T_(YYEOF));
+			} else if (isLetter(c)) {
+				std::string builder(1, c);
+				for (c = nextChar(); continuesIdentifier(c); c = nextChar()) {
+					builder += c;
+				}
+				if (auto search = keywords.find(builder); search != keywords.end()) {
+					return Token(search->second);
+				}
+			}
+		}
+		shiftChar();
+		if (c == EOF) {
+			return Token(T_(YYEOF));
+		} else if (isNewline(c)) {
+			handleCRLF(c);
+			nextLine();
+			lexerState->atLineStart = true;
+		}
 	}
 }
 

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -2058,6 +2058,22 @@ finish: // Can't `break` out of a nested `for`-`switch`
 	return Token(T_(YYEOF));
 }
 
+// This map lists all RGBASM keywords which `skipToLeadingKeyword` needs to recognize.
+// It is a subset of `keywords`.
+static UpperMap<int> const leadingKeywords{
+    // There is no need to recognize "MACRO", since macros cannot be nested
+    {"ENDM", T_(POP_ENDM)},
+
+    {"REPT", T_(POP_REPT)},
+    {"FOR",  T_(POP_FOR) },
+    {"ENDR", T_(POP_ENDR)},
+
+    {"IF",   T_(POP_IF)  },
+    {"ELSE", T_(POP_ELSE)},
+    {"ELIF", T_(POP_ELIF)},
+    {"ENDC", T_(POP_ENDC)},
+};
+
 static Token skipToLeadingKeywordFast(Procedure<> auto shiftFast) {
 	// This is essentially `skipToLeadingKeyword` with `peek` and `shiftChar` replaced,
 	// as well as anything that calls them like `nextChar` or `handleCRLF`.
@@ -2082,7 +2098,7 @@ static Token skipToLeadingKeywordFast(Procedure<> auto shiftFast) {
 					shiftFast();
 				}
 				std::string_view leading{ptr + start, ptr + lexerState->offset};
-				if (auto search = keywords.find(leading); search != keywords.end()) {
+				if (auto search = leadingKeywords.find(leading); search != leadingKeywords.end()) {
 					// When this branch returns a token, there has been one more call to `peekFast`
 					// than to `shiftFast`. Unlike `peek` and `shiftChar`, the optimized functions
 					// do not update `lexerState->expansionScanDistance`, so it must be incremented
@@ -2112,9 +2128,6 @@ static Token skipToLeadingKeywordFast(Procedure<> auto shiftFast) {
 // It expects that these constructs' `ENDC`/`ENDR`/`ENDM` closing tokens are only
 // valid at the start of their lines, which enables ignoring everything except
 // the leading keyword in lines that have one (as well as line continuations).
-//
-// The only keywords it needs to recognize are case-insensitive `IF`, `ELIF`,
-// `ELSE`, `ENDC`, `REPT`, `FOR`, `ENDR`, and `ENDM` (not `MACRO`).
 //
 // Note that when these constructs are *evaluated*, they can perform expansions
 // (for macro args, interpolations, and macro invocations) which may produce
@@ -2149,7 +2162,7 @@ static Token skipToLeadingKeyword() {
 				for (c = nextChar(); continuesIdentifier(c); c = nextChar()) {
 					builder += c;
 				}
-				if (auto search = keywords.find(builder); search != keywords.end()) {
+				if (auto search = leadingKeywords.find(builder); search != leadingKeywords.end()) {
 					return Token(search->second);
 				}
 			}

--- a/src/link/main.cpp
+++ b/src/link/main.cpp
@@ -176,6 +176,7 @@ static void parseScrambleSpec(char *spec) {
 			fatal("Unknown region name \"%s\" in spec for option '-S'", regionName);
 		}
 
+		uint16_t *scrambleLimit = search->second.first;
 		uint16_t limit = search->second.second;
 		if (regionSize) {
 			char const *ptr = regionSize + skipBlankSpace(regionSize);
@@ -183,24 +184,29 @@ static void parseScrambleSpec(char *spec) {
 				fatal("Invalid region size limit \"%s\" for option '-S'", regionSize);
 			} else if (*value > limit) {
 				fatal(
-				    "%s region size for option '-S' must be between 0 and %" PRIu16,
-				    search->first.c_str(),
+				    "%" PRI_SV " region size for option '-S' must be between 0 and %" PRIu16,
+				    PRI_SV_ARG(search->first),
 				    limit
 				);
 			} else {
 				limit = *value;
 			}
-		} else if (search->second.first != &options.scrambleWRAMX) {
+		} else if (scrambleLimit != &options.scrambleWRAMX) {
 			// Only WRAMX limit can be implied, since ROMX and SRAM size may vary.
-			fatal("Missing %s region size limit for option '-S'", search->first.c_str());
+			fatal(
+			    "Missing %" PRI_SV " region size limit for option '-S'", PRI_SV_ARG(search->first)
+			);
 		}
 
-		if (*search->second.first != limit && *search->second.first != 0) {
-			warnx("Overriding %s region size limit for option '-S'", search->first.c_str());
+		if (*scrambleLimit != limit && *search->second.first != 0) {
+			warnx(
+			    "Overriding %" PRI_SV " region size limit for option '-S'",
+			    PRI_SV_ARG(search->first)
+			);
 		}
 
 		// Update the scrambling region size limit.
-		*search->second.first = limit;
+		*scrambleLimit = limit;
 	}
 }
 


### PR DESCRIPTION
Fixes #1982

The issue mentioned more possible optimizations, but I decided against them.

- Perfect hash functions aren't worth the trouble of setting them up, especially with the case-sensitivity requirement.
- A trie didn't actually run faster than `std::unordered_map`.
- Using a `std::string_view` when possible is one of these commits (though three out of four places that identifiers are built up weren't able to do so).
- Using a smaller leading-only map is another of these commits.

Lines of code went up because I refactored `skipToLeadingKeyword` *again* to make `skipToLeadingKeywordFast` be its own mostly-similar function instead of `template`izing the whole thing.

My usual `hyperfine` performance measurement went down from `17.815 s ± 0.305 s` to `17.018 s ± 0.264 s`.

pokecrystal build time remains at around `4.90–4.93 s`.