### PR TITLE
Reorganize struct fields and shrink enums to reduce padding

### DIFF
--- a/include/asm/actions.hpp
+++ b/include/asm/actions.hpp
@@ -17,8 +17,8 @@
 #include "asm/rpn.hpp"    // Expression
 
 struct AlignmentSpec {
-	uint8_t alignment;
 	uint16_t alignOfs;
+	uint8_t alignment;
 };
 
 void act_If(int32_t condition);

--- a/include/asm/format.hpp
+++ b/include/asm/format.hpp
@@ -8,16 +8,16 @@
 #include <string>
 
 class FormatSpec {
+	size_t width;
+	size_t fracWidth;
+	size_t precision;
 	int sign;
+	int type;
 	bool exact;
 	bool alignLeft;
 	bool padZero;
-	size_t width;
 	bool hasFrac;
-	size_t fracWidth;
 	bool hasPrec;
-	size_t precision;
-	int type;
 	bool parsed;
 
 public:

--- a/include/asm/fstack.hpp
+++ b/include/asm/fstack.hpp
@@ -19,13 +19,11 @@
 #include "asm/lexer.hpp"
 
 struct FileStackNode {
-	FileStackNodeType type;
 	std::variant<
 	    std::vector<uint32_t>, // NODE_REPT
 	    std::string            // NODE_FILE, NODE_MACRO
 	    >
 	    data;
-	bool isQuiet; // Whether to omit this node from error reporting
 
 	std::shared_ptr<FileStackNode> parent; // Pointer to parent node, for error reporting
 	// Line at which the parent context was exited
@@ -34,6 +32,10 @@ struct FileStackNode {
 
 	// Set only if referenced: ID within the object file, `UINT32_MAX` if not output yet
 	uint32_t ID = UINT32_MAX;
+
+	FileStackNodeType type;
+
+	bool isQuiet; // Whether to omit this node from error reporting
 
 	// REPT iteration counts since last named node, in reverse depth order
 	std::vector<uint32_t> &iters() { return std::get<std::vector<uint32_t>>(data); }
@@ -47,7 +49,7 @@ struct FileStackNode {
 	    std::variant<std::vector<uint32_t>, std::string> data_,
 	    bool isQuiet_
 	)
-	    : type(type_), data(data_), isQuiet(isQuiet_) {}
+	    : data(data_), type(type_), isQuiet(isQuiet_) {}
 
 	void printBacktrace(uint32_t curLineNo) const;
 };

--- a/include/asm/lexer.hpp
+++ b/include/asm/lexer.hpp
@@ -13,7 +13,7 @@
 
 #include "asm/intern.hpp"
 
-enum LexerMode {
+enum LexerMode : uint8_t {
 	LEXER_NORMAL,
 	LEXER_RAW,
 	LEXER_SKIP_TO_ELIF,
@@ -44,25 +44,27 @@ struct IfStackEntry {
 struct LexerState {
 	std::string path;
 
-	LexerMode mode;
-	bool atLineStart;
-	uint32_t lineNo;
-	int lastToken;
-	int nextToken;
-
 	std::deque<IfStackEntry> ifStack; // Front is the innermost `IF` block
 
-	bool capturing;     // Whether the text being lexed should be captured
-	size_t captureSize; // Amount of text captured
+	size_t captureSize;                            // Amount of text captured
 	std::shared_ptr<std::vector<char>> captureBuf; // Buffer to send the captured text to if set
 
-	bool enableExpansions;
-	bool enableStringExpansions;
 	size_t expansionScanDistance;         // Max distance already scanned for expansions
 	std::deque<Expansion> expansionStack; // Front is the innermost current expansion
 
 	ContentSpan content; // Span of chars
 	size_t offset = 0;   // Cursor into `content.ptr`
+
+	uint32_t lineNo;
+	int lastToken;
+	int nextToken;
+
+	LexerMode mode;
+
+	bool atLineStart;
+	bool capturing; // Whether the text being lexed should be captured
+	bool enableExpansions;
+	bool enableStringExpansions;
 
 	~LexerState();
 
@@ -97,8 +99,8 @@ uint32_t lexer_GetLineNo();
 void lexer_TraceStringExpansions();
 
 struct Capture {
-	uint32_t lineNo;
 	ContentSpan span;
+	uint32_t lineNo;
 };
 
 Capture lexer_CaptureRept();

--- a/include/asm/macro.hpp
+++ b/include/asm/macro.hpp
@@ -9,8 +9,8 @@
 #include <vector>
 
 struct MacroArgs {
-	uint32_t shift;
 	std::vector<std::shared_ptr<std::string>> args;
+	uint32_t shift;
 
 	uint32_t nbArgs() const { return args.size() - shift; }
 	std::shared_ptr<std::string> getArg(int32_t i) const;

--- a/include/asm/output.hpp
+++ b/include/asm/output.hpp
@@ -14,7 +14,14 @@ struct Expression;
 struct FileStackNode;
 struct Symbol;
 
-enum StateFeature { STATE_EQU, STATE_VAR, STATE_EQUS, STATE_CHAR, STATE_MACRO, NB_STATE_FEATURES };
+enum StateFeature : uint8_t {
+	STATE_EQU,
+	STATE_VAR,
+	STATE_EQUS,
+	STATE_CHAR,
+	STATE_MACRO,
+	NB_STATE_FEATURES
+};
 
 void out_RegisterNode(std::shared_ptr<FileStackNode> node);
 void out_RegisterSymbol(Symbol &sym);

--- a/include/asm/rpn.hpp
+++ b/include/asm/rpn.hpp
@@ -15,8 +15,8 @@
 struct Symbol;
 
 struct RPNValue {
-	RPNCommand command;                                                // The RPN_* command ID
 	std::variant<std::monostate, uint8_t, uint32_t, InternedStr> data; // Data after the ID, if any
+	RPNCommand command;                                                // The RPN_* command ID
 
 	RPNValue(RPNCommand cmd);
 	RPNValue(RPNCommand cmd, uint8_t val);

--- a/include/asm/section.hpp
+++ b/include/asm/section.hpp
@@ -20,27 +20,27 @@ struct Section;
 
 struct Patch {
 	std::shared_ptr<FileStackNode> src;
+	Section *pcSection;
+	std::vector<uint8_t> rpn;
 	uint32_t lineNo;
 	uint32_t offset;
-	Section *pcSection;
 	uint32_t pcOffset;
 	uint8_t type;
-	std::vector<uint8_t> rpn;
 };
 
 struct Section {
 	std::string name;
-	SectionType type;
-	SectionModifier modifier;
 	std::shared_ptr<FileStackNode> src; // Where the section was defined
-	uint32_t fileLine;                  // Line where the section was defined
+	std::deque<Patch> patches;
+	std::vector<uint8_t> data;
+	uint32_t fileLine; // Line where the section was defined
 	uint32_t size;
 	uint32_t org;
 	uint32_t bank;
-	uint8_t align; // Exactly as specified in `ALIGN[]`
 	uint16_t alignOfs;
-	std::deque<Patch> patches;
-	std::vector<uint8_t> data;
+	SectionType type;
+	SectionModifier modifier;
+	uint8_t align; // Exactly as specified in `ALIGN[]`
 
 	uint32_t getID() const; // ID of the section in the object file (`UINT32_MAX` if none)
 	bool isSizeKnown() const;
@@ -48,8 +48,8 @@ struct Section {
 
 struct SectionSpec {
 	uint32_t bank;
-	uint8_t alignment;
 	uint16_t alignOfs;
+	uint8_t alignment;
 };
 
 size_t sect_CountSections();

--- a/include/asm/symbol.hpp
+++ b/include/asm/symbol.hpp
@@ -14,7 +14,7 @@
 #include "asm/lexer.hpp"
 #include "asm/section.hpp"
 
-enum SymbolType {
+enum SymbolType : uint8_t {
 	SYM_LABEL,
 	SYM_EQU,
 	SYM_VAR,
@@ -27,15 +27,6 @@ struct Symbol;                    // Forward declaration for `sym_IsPC`
 bool sym_IsPC(Symbol const *sym); // Forward declaration for `getSection`
 
 struct Symbol {
-	InternedStr name;
-	SymbolType type;
-	bool isBuiltin;
-	bool isExported; // Not relevant for SYM_MACRO or SYM_EQUS
-	bool isQuiet;    // Only relevant for SYM_MACRO
-	Section *section;
-	std::shared_ptr<FileStackNode> src; // Where the symbol was defined
-	uint32_t fileLine;                  // Line where the symbol was defined
-
 	std::variant<
 	    int32_t,                           // If isNumeric()
 	    int32_t (*)(),                     // If isNumeric() via a callback
@@ -45,8 +36,19 @@ struct Symbol {
 	    >
 	    data;
 
+	Section *section;
+	std::shared_ptr<FileStackNode> src; // Where the symbol was defined
+	InternedStr name;
+	uint32_t fileLine; // Line where the symbol was defined
+
 	uint32_t ID;       // ID of the symbol in the object file (`UINT32_MAX` if none)
 	uint32_t defIndex; // Ordering of the symbol in the state file
+
+	SymbolType type;
+
+	bool isBuiltin;
+	bool isExported; // Not relevant for SYM_MACRO or SYM_EQUS
+	bool isQuiet;    // Only relevant for SYM_MACRO
 
 	bool isDefined() const { return type != SYM_REF; }
 	bool isNumeric() const { return type == SYM_LABEL || type == SYM_EQU || type == SYM_VAR; }

--- a/include/asm/warning.hpp
+++ b/include/asm/warning.hpp
@@ -4,17 +4,18 @@
 #define RGBDS_ASM_WARNING_HPP
 
 #include <functional>
+#include <stdint.h>
 
 #include "diagnostics.hpp"
 
-enum WarningLevel {
+enum WarningLevel : uint8_t {
 	LEVEL_DEFAULT,    // Warnings that are enabled by default
 	LEVEL_ALL,        // Warnings that probably indicate an error
 	LEVEL_EXTRA,      // Warnings that are less likely to indicate an error
 	LEVEL_EVERYTHING, // Literally every warning
 };
 
-enum WarningID {
+enum WarningID : uint8_t {
 	WARNING_ASSERT,               // Assertions
 	WARNING_BACKWARDS_FOR,        // `FOR` loop with backwards range
 	WARNING_BUILTIN_ARG,          // Invalid args to builtins

--- a/include/diagnostics.hpp
+++ b/include/diagnostics.hpp
@@ -19,7 +19,7 @@
 [[gnu::format(printf, 1, 2)]]
 void warnx(char const *fmt, ...);
 
-enum WarningAbled { WARNING_DEFAULT, WARNING_ENABLED, WARNING_DISABLED };
+enum WarningAbled : uint8_t { WARNING_DEFAULT, WARNING_ENABLED, WARNING_DISABLED };
 
 struct WarningState {
 	WarningAbled state;
@@ -36,7 +36,7 @@ struct WarningFlag {
 	LevelEnumT level;
 };
 
-enum WarningBehavior { DISABLED, ENABLED, ERROR };
+enum WarningBehavior : uint8_t { DISABLED, ENABLED, ERROR };
 
 template<Enum WarningEnumT>
 struct ParamWarning {

--- a/include/fix/main.hpp
+++ b/include/fix/main.hpp
@@ -18,7 +18,7 @@ static constexpr uint8_t FIX_GLOBAL_SUM   = 1 << 3;
 static constexpr uint8_t TRASH_GLOBAL_SUM = 1 << 2;
 // clang-format on
 
-enum Model { DMG, BOTH, CGB };
+enum Model : uint8_t { DMG, BOTH, CGB };
 
 struct Options {
 	uint8_t fixSpec = 0;                // -f, -v

--- a/include/fix/mbc.hpp
+++ b/include/fix/mbc.hpp
@@ -9,7 +9,7 @@
 constexpr uint16_t UNSPECIFIED = 0x200;
 static_assert(UNSPECIFIED > 0xFF, "UNSPECIFIED should not be in byte range!");
 
-enum MbcType {
+enum MbcType : uint16_t {
 	ROM = 0x00,
 	ROM_RAM = 0x08,
 	ROM_RAM_BATTERY = 0x09,

--- a/include/fix/warning.hpp
+++ b/include/fix/warning.hpp
@@ -7,13 +7,13 @@
 
 #include "diagnostics.hpp"
 
-enum WarningLevel {
+enum WarningLevel : uint8_t {
 	LEVEL_DEFAULT,    // Warnings that are enabled by default
 	LEVEL_ALL,        // Warnings that probably indicate an error
 	LEVEL_EVERYTHING, // Literally every warning
 };
 
-enum WarningID {
+enum WarningID : uint8_t {
 	WARNING_MBC,        // Issues with MBC specs
 	WARNING_OBSOLETE,   // Obsolete/deprecated things
 	WARNING_OVERWRITE,  // Overwriting non-zero bytes

--- a/include/gfx/warning.hpp
+++ b/include/gfx/warning.hpp
@@ -3,15 +3,17 @@
 #ifndef RGBDS_GFX_WARNING_HPP
 #define RGBDS_GFX_WARNING_HPP
 
+#include <stdint.h>
+
 #include "diagnostics.hpp"
 
-enum WarningLevel {
+enum WarningLevel : uint8_t {
 	LEVEL_DEFAULT,    // Warnings that are enabled by default
 	LEVEL_ALL,        // Warnings that probably indicate an error
 	LEVEL_EVERYTHING, // Literally every warning
 };
 
-enum WarningID {
+enum WarningID : uint8_t {
 	WARNING_EMBEDDED,      // Using an embedded PNG palette without '-c embedded'
 	WARNING_OBSOLETE,      // Obsolete/deprecated things
 	WARNING_TRIM_NONEMPTY, // '-x' trims nonempty tiles

--- a/include/link/fstack.hpp
+++ b/include/link/fstack.hpp
@@ -12,18 +12,20 @@
 #include "linkdefs.hpp"
 
 struct FileStackNode {
-	FileStackNodeType type;
 	std::variant<
 	    std::monostate,        // Default constructed; `.type` and `.data` must be set manually
 	    std::vector<uint32_t>, // NODE_REPT
 	    std::string            // NODE_FILE, NODE_MACRO
 	    >
 	    data;
-	bool isQuiet; // Whether to omit this node from error reporting
 
 	FileStackNode *parent;
 	// Line at which the parent context was exited; meaningless for the root level
 	uint32_t lineNo;
+
+	FileStackNodeType type;
+
+	bool isQuiet; // Whether to omit this node from error reporting
 
 	// REPT iteration counts since last named node, in reverse depth order
 	std::vector<uint32_t> &iters() { return std::get<std::vector<uint32_t>>(data); }

--- a/include/link/section.hpp
+++ b/include/link/section.hpp
@@ -17,39 +17,40 @@ struct Symbol;
 
 struct Patch {
 	FileStackNode const *src;
+	Section const *pcSection;
+	std::vector<uint8_t> rpnExpression;
 	uint32_t lineNo;
 	uint32_t offset;
-	Section const *pcSection;
 	uint32_t pcSectionID;
 	uint32_t pcOffset;
 	PatchType type;
-	std::vector<uint8_t> rpnExpression;
 };
 
 struct Section {
-	// Info contained in the object files
-	std::string name;
-	uint16_t size;
-	uint16_t offset;
-	SectionType type;
-	SectionModifier modifier;
-	bool isAddressFixed;
-	// This `struct`'s address in ROM.
-	// Importantly for fragments, this does not include `offset`!
-	uint16_t org;
-	bool isBankFixed;
-	uint32_t bank;
-	bool isAlignFixed;
-	uint16_t alignMask;
-	uint16_t alignOfs;
-	FileStackNode const *src;
-	int32_t lineNo;
-	std::vector<uint8_t> data; // Array of size `size`, or 0 if `type` does not have data
-	std::vector<Patch> patches;
 	// Extra info computed during linking
 	std::vector<Symbol> *fileSymbols;
 	std::vector<Symbol *> symbols;
 	std::unique_ptr<Section> nextPiece; // The next fragment or union "piece" of this section
+
+	// Info contained in the object files
+	std::string name;
+	std::vector<uint8_t> data; // Array of size `size`, or 0 if `type` does not have data
+	std::vector<Patch> patches;
+	FileStackNode const *src;
+	int32_t lineNo;
+	uint32_t bank;
+	uint16_t size;
+	uint16_t offset;
+	// This `struct`'s address in ROM.
+	// Importantly for fragments, this does not include `offset`!
+	uint16_t org;
+	uint16_t alignMask;
+	uint16_t alignOfs;
+	SectionType type;
+	SectionModifier modifier;
+	bool isAddressFixed;
+	bool isBankFixed;
+	bool isAlignFixed;
 
 private:
 	// Template class for both const and non-const iterators over the "pieces" of this section

--- a/include/link/symbol.hpp
+++ b/include/link/symbol.hpp
@@ -15,23 +15,22 @@ struct FileStackNode;
 struct Section;
 
 struct Label {
+	Section *section; // Extra info computed during linking
 	int32_t sectionID;
 	int32_t offset;
-	// Extra info computed during linking
-	Section *section;
 };
 
 struct Symbol {
 	// Info contained in the object files
-	std::string name;
-	ExportLevel type;
-	FileStackNode const *src;
-	int32_t lineNo;
 	std::variant<
 	    int32_t, // Constants just have a numeric value
 	    Label    // Label values refer to an offset within a specific section
 	    >
 	    data;
+	std::string name;
+	FileStackNode const *src;
+	int32_t lineNo;
+	ExportLevel type;
 
 	void linkToSection(Section &section);
 	void fixSectionOffset();

--- a/include/link/warning.hpp
+++ b/include/link/warning.hpp
@@ -15,13 +15,13 @@
 #define fatalTwoAt(where1, where2, ...) \
 	fatalTwo(*(where1).src, (where1).lineNo, *(where2).src, (where2).lineNo, __VA_ARGS__)
 
-enum WarningLevel {
+enum WarningLevel : uint8_t {
 	LEVEL_DEFAULT,    // Warnings that are enabled by default
 	LEVEL_ALL,        // Warnings that probably indicate an error
 	LEVEL_EVERYTHING, // Literally every warning
 };
 
-enum WarningID {
+enum WarningID : uint8_t {
 	WARNING_ASSERT,       // Assertions
 	WARNING_DIV,          // Undefined division behavior
 	WARNING_OBSOLETE,     // Obsolete/deprecated things

--- a/include/linkdefs.hpp
+++ b/include/linkdefs.hpp
@@ -13,7 +13,7 @@
 
 enum AssertionType { ASSERT_WARN, ASSERT_ERROR, ASSERT_FATAL };
 
-enum RPNCommand {
+enum RPNCommand : uint8_t {
 	RPN_ADD = 0x00,
 	RPN_SUB = 0x01,
 	RPN_MUL = 0x02,
@@ -63,7 +63,7 @@ enum RPNCommand {
 	RPN_SYM = 0x81
 };
 
-enum SectionType {
+enum SectionType : uint8_t {
 	SECTTYPE_WRAM0,
 	SECTTYPE_VRAM,
 	SECTTYPE_ROMX,
@@ -82,7 +82,7 @@ static constexpr uint8_t SECTTYPE_TYPE_MASK = 0b111;
 static constexpr uint8_t SECTTYPE_UNION_BIT = 7;
 static constexpr uint8_t SECTTYPE_FRAGMENT_BIT = 6;
 
-enum FileStackNodeType {
+enum FileStackNodeType : uint8_t {
 	NODE_REPT,
 	NODE_FILE,
 	NODE_MACRO,
@@ -93,10 +93,10 @@ static constexpr uint8_t FSTACKNODE_QUIET_BIT = 7;
 // Nont-`const` members may be patched in RGBLINK depending on CLI flags
 extern struct SectionTypeInfo {
 	std::string const name;
-	uint16_t const startAddr;
-	uint16_t size;
 	uint32_t const firstBank;
 	uint32_t lastBank;
+	uint16_t const startAddr;
+	uint16_t size;
 } sectionTypeInfo[SECTTYPE_INVALID];
 
 // Tells whether a section has data in its object file definition,
@@ -116,13 +116,13 @@ static inline uint32_t sectTypeBanks(SectionType type) {
 	return sectionTypeInfo[type].lastBank - sectionTypeInfo[type].firstBank + 1;
 }
 
-enum SectionModifier { SECTION_NORMAL, SECTION_UNION, SECTION_FRAGMENT };
+enum SectionModifier : uint8_t { SECTION_NORMAL, SECTION_UNION, SECTION_FRAGMENT };
 
 extern char const * const sectionModNames[];
 
-enum ExportLevel { SYMTYPE_LOCAL, SYMTYPE_IMPORT, SYMTYPE_EXPORT, SYMTYPE_INVALID };
+enum ExportLevel : uint8_t { SYMTYPE_LOCAL, SYMTYPE_IMPORT, SYMTYPE_EXPORT, SYMTYPE_INVALID };
 
-enum PatchType {
+enum PatchType : uint8_t {
 	PATCHTYPE_BYTE,
 	PATCHTYPE_WORD,
 	PATCHTYPE_LONG,

--- a/include/style.hpp
+++ b/include/style.hpp
@@ -3,6 +3,7 @@
 #ifndef RGBDS_STYLE_HPP
 #define RGBDS_STYLE_HPP
 
+#include <stdint.h>
 #include <stdio.h>
 
 #if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)
@@ -11,7 +12,7 @@
 	#define STYLE_ANSI 1
 #endif
 
-enum StyleColor {
+enum StyleColor : uint8_t {
 #if STYLE_ANSI
 	// Values analogous to ANSI foreground and background SGR colors
 	STYLE_BLACK,

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -13,7 +13,7 @@
 
 #include "helpers.hpp"
 
-enum NumberBase {
+enum NumberBase : uint8_t {
 	BASE_AUTO = 0,
 	BASE_2 = 2,
 	BASE_8 = 8,

--- a/include/verbosity.hpp
+++ b/include/verbosity.hpp
@@ -4,6 +4,7 @@
 #define RGBDS_VERBOSITY_HPP
 
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 
 // This macro does not evaluate its arguments unless the condition is true.
@@ -14,7 +15,7 @@
 		} \
 	} while (0)
 
-enum Verbosity {
+enum Verbosity : uint8_t {
 	VERB_NONE,   // 0. Default, no extra output
 	VERB_CONFIG, // 1. Basic configuration, after parsing CLI options
 	VERB_NOTICE, // 2. Before significant actions

--- a/src/asm/fstack.cpp
+++ b/src/asm/fstack.cpp
@@ -44,11 +44,11 @@ struct Context {
 	// parent's, and likewise "back-propagates" a unique ID if requested), hence using `shared_ptr`.
 	std::shared_ptr<std::string> uniqueIDStr = nullptr;
 	std::shared_ptr<MacroArgs> macroArgs = nullptr; // Macro args are *saved* here
+	InternedStr forName{};
 	uint32_t nbReptIters = 0;
-	bool isForLoop = false;
 	int32_t forValue = 0;
 	int32_t forStep = 0;
-	InternedStr forName{};
+	bool isForLoop = false;
 };
 
 static std::stack<Context> contextStack;

--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -47,29 +47,29 @@
 #define T_(name) static_cast<int>(yy::parser::token::name)
 
 struct Token {
-	int type;
 	std::variant<std::monostate, InternedStr, uint32_t, std::string> value;
+	int type;
 
-	Token() : type(T_(NUMBER)), value(std::monostate{}) {
+	Token() : value(std::monostate{}), type(T_(NUMBER)) {
 		assume(
 		    type != T_(NUMBER) && type != T_(STRING) && type != T_(CHARACTER) && type != T_(SYMBOL)
 		    && type != T_(LABEL) && type != T_(LOCAL) && type != T_(ANON) && type != T_(QMACRO)
 		);
 	}
-	Token(int type_) : type(type_), value(std::monostate{}) {
+	Token(int type_) : value(std::monostate{}), type(type_) {
 		assume(
 		    type != T_(NUMBER) && type != T_(STRING) && type != T_(CHARACTER) && type != T_(SYMBOL)
 		    && type != T_(LABEL) && type != T_(LOCAL) && type != T_(ANON) && type != T_(QMACRO)
 		);
 	}
-	Token(int type_, uint32_t value_) : type(type_), value(value_) { assume(type == T_(NUMBER)); }
-	Token(int type_, std::string const &value_) : type(type_), value(std::move(value_)) {
+	Token(int type_, uint32_t value_) : value(value_), type(type_) { assume(type == T_(NUMBER)); }
+	Token(int type_, std::string const &value_) : value(std::move(value_)), type(type_) {
 		assume(type == T_(STRING) || type == T_(CHARACTER));
 	}
-	Token(int type_, std::string &&value_) : type(type_), value(std::move(value_)) {
+	Token(int type_, std::string &&value_) : value(std::move(value_)), type(type_) {
 		assume(type == T_(STRING) || type == T_(CHARACTER));
 	}
-	Token(int type_, InternedStr value_) : type(type_), value(value_) {
+	Token(int type_, InternedStr value_) : value(value_), type(type_) {
 		assume(
 		    type == T_(SYMBOL) || type == T_(LABEL) || type == T_(LOCAL) || type == T_(ANON)
 		    || type == T_(QMACRO)
@@ -2364,7 +2364,8 @@ static Capture makeCapture(char const *name, InvocableR<int, int> auto callback)
 	lexerState->captureSize = 0;
 
 	Capture capture = {
-	    .lineNo = lexer_GetLineNo(), .span = {.ptr = nullptr, .size = 0}
+	    .span = {.ptr = nullptr, .size = 0},
+          .lineNo = lexer_GetLineNo()
 	};
 	if (lexerState->expansionStack.empty()) {
 		capture.span.ptr = std::shared_ptr<char[]>(

--- a/src/asm/rpn.cpp
+++ b/src/asm/rpn.cpp
@@ -534,7 +534,7 @@ void Expression::encode(std::vector<uint8_t> &buffer) const {
 	}
 }
 
-RPNValue::RPNValue(RPNCommand cmd) : command(cmd), data(std::monostate{}) {
+RPNValue::RPNValue(RPNCommand cmd) : data(std::monostate{}), command(cmd) {
 	assume(
 	    cmd != RPN_SIZEOF_SECTTYPE && cmd != RPN_STARTOF_SECTTYPE && cmd != RPN_BIT_INDEX
 	    && cmd != RPN_CONST && cmd != RPN_SYM && cmd != RPN_BANK_SYM && cmd != RPN_BANK_SECT
@@ -542,15 +542,15 @@ RPNValue::RPNValue(RPNCommand cmd) : command(cmd), data(std::monostate{}) {
 	);
 }
 
-RPNValue::RPNValue(RPNCommand cmd, uint8_t val) : command(cmd), data(val) {
+RPNValue::RPNValue(RPNCommand cmd, uint8_t val) : data(val), command(cmd) {
 	assume(cmd == RPN_SIZEOF_SECTTYPE || cmd == RPN_STARTOF_SECTTYPE || cmd == RPN_BIT_INDEX);
 }
 
-RPNValue::RPNValue(RPNCommand cmd, uint32_t val) : command(cmd), data(val) {
+RPNValue::RPNValue(RPNCommand cmd, uint32_t val) : data(val), command(cmd) {
 	assume(cmd == RPN_CONST);
 }
 
-RPNValue::RPNValue(RPNCommand cmd, InternedStr name) : command(cmd), data(name) {
+RPNValue::RPNValue(RPNCommand cmd, InternedStr name) : data(name), command(cmd) {
 	assume(
 	    cmd == RPN_SYM || cmd == RPN_BANK_SYM || cmd == RPN_BANK_SECT || cmd == RPN_SIZEOF_SECT
 	    || cmd == RPN_STARTOF_SECT

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -81,11 +81,11 @@ void cli_ParseArgs(
     Usage usage
 ) {
 	struct AtFileStackEntry {
-		int parentInd;            // Saved offset into parent argv
 		std::vector<char *> argv; // This context's arg pointer vec
+		int parentInd;            // Saved offset into parent argv
 
 		AtFileStackEntry(int parentInd_, std::vector<char *> argv_)
-		    : parentInd(parentInd_), argv(argv_) {}
+		    : argv(argv_), parentInd(parentInd_) {}
 	};
 	std::vector<AtFileStackEntry> atFileStack;
 

--- a/src/gfx/process.cpp
+++ b/src/gfx/process.cpp
@@ -84,7 +84,7 @@ struct Image {
 	Rgba &pixel(uint32_t x, uint32_t y) { return png.pixels[y * png.width + x]; }
 	Rgba const &pixel(uint32_t x, uint32_t y) const { return png.pixels[y * png.width + x]; }
 
-	enum GrayscaleResult {
+	enum GrayscaleResult : uint8_t {
 		GRAY_OK,
 		GRAY_TOO_MANY,
 		GRAY_NONGRAY,
@@ -218,13 +218,13 @@ struct Image {
 
 	class TilesVisitor {
 		Image const &_image;
-		bool const _columnMajor;
 		uint32_t const _width, _height;
+		bool const _columnMajor;
 		uint32_t const _limit = _columnMajor ? _height : _width;
 
 	public:
 		TilesVisitor(Image const &image, bool columnMajor, uint32_t width, uint32_t height)
-		    : _image(image), _columnMajor(columnMajor), _width(width), _height(height) {}
+		    : _image(image), _width(width), _height(height), _columnMajor(columnMajor) {}
 
 		class Tile {
 			Image const &_image;
@@ -562,7 +562,7 @@ public:
 	std::array<uint8_t, 16> const &data() const { return _data; }
 	uint16_t hash() const { return _hash; }
 
-	enum MatchType {
+	enum MatchType : uint8_t {
 		NOPE,
 		EXACT,
 		HFLIP,

--- a/src/link/assign.cpp
+++ b/src/link/assign.cpp
@@ -24,8 +24,8 @@
 #include "link/warning.hpp"
 
 struct MemoryLocation {
-	uint16_t address;
 	uint32_t bank;
+	uint16_t address;
 };
 
 struct FreeSpace {
@@ -246,9 +246,9 @@ static void placeSection(Section &section) {
 		// Unless the SECTION's address was fixed, the starting address
 		// is fine for any alignment, as checked in sect_DoSanityChecks.
 		MemoryLocation location = {
+		    .bank = section.isBankFixed ? section.bank : sectionTypeInfo[section.type].firstBank,
 		    .address =
 		        section.isAddressFixed ? section.org : sectionTypeInfo[section.type].startAddr,
-		    .bank = section.isBankFixed ? section.bank : sectionTypeInfo[section.type].firstBank,
 		};
 		assignSection(section, location);
 		return;

--- a/src/link/object.cpp
+++ b/src/link/object.cpp
@@ -197,10 +197,9 @@ static void readSymbol(
 			symbol.data = value;
 		} else {
 			symbol.data = Label{
+			    .section = nullptr, // Set the `.section` later based on the `.sectionID`
 			    .sectionID = sectionID,
 			    .offset = value,
-			    // Set the `.section` later based on the `.sectionID`
-			    .section = nullptr,
 			};
 		}
 	} else {
@@ -461,11 +460,11 @@ void obj_ReadFile(std::string const &filePath, size_t fileID) {
 		// Since SDCC does not provide line info, everything will be reported as coming from the
 		// object file. It's better than nothing.
 		nodes[fileID].push_back({
-		    .type = NODE_FILE,
 		    .data = std::variant<std::monostate, std::vector<uint32_t>, std::string>(fileName),
-		    .isQuiet = false,
 		    .parent = nullptr,
 		    .lineNo = 0,
+		    .type = NODE_FILE,
+		    .isQuiet = false,
 		});
 
 		std::vector<Symbol> &fileSymbols = symbolLists.emplace_front();

--- a/src/link/sdas_obj.cpp
+++ b/src/link/sdas_obj.cpp
@@ -106,7 +106,7 @@ static uint8_t readByte(Location const &where, char const *str, NumberBase base)
 	return num;
 }
 
-enum AreaFlags {
+enum AreaFlags : uint8_t {
 	AREA_TYPE = 2, // 0: Concatenate, 1: overlay
 	AREA_ISABS,    // 0: Relative (???) address, 1: absolute address
 	AREA_PAGING,   // Unsupported
@@ -114,7 +114,7 @@ enum AreaFlags {
 	AREA_ALL_FLAGS = 1 << AREA_TYPE | 1 << AREA_ISABS | 1 << AREA_PAGING,
 };
 
-enum RelocFlags {
+enum RelocFlags : uint16_t {
 	RELOC_SIZE,      // 0: 16-bit, 1: 8-bit
 	RELOC_ISSYM,     // 0: Area, 1: Symbol
 	RELOC_ISPCREL,   // 0: Normal, 1: PC-relative
@@ -395,7 +395,7 @@ void sdobj_ReadFile(FileStackNode const &src, FILE *file, std::vector<Symbol> &f
 					value -= section->org;
 				}
 				// No need to set the `sectionID`, since we set the pointer
-				symbol.data = Label{.sectionID = 0, .offset = value, .section = section};
+				symbol.data = Label{.section = section, .sectionID = 0, .offset = value};
 			} else {
 				// Symbols without sections are just constants
 				symbol.data = value;

--- a/src/linkdefs.cpp
+++ b/src/linkdefs.cpp
@@ -12,59 +12,59 @@ using namespace std::literals;
 SectionTypeInfo sectionTypeInfo[SECTTYPE_INVALID] = {
     {
         .name = "WRAM0"s,
-        .startAddr = 0xC000,
-        .size = 0x2000, // Patched to 0x1000 if !isWRAM0Mode
         .firstBank = 0,
         .lastBank = 0,
+        .startAddr = 0xC000,
+        .size = 0x2000, // Patched to 0x1000 if !isWRAM0Mode
     },
     {
         .name = "VRAM"s,
-        .startAddr = 0x8000,
-        .size = 0x2000,
         .firstBank = 0,
         .lastBank = 1, // Patched to 0 if isDmgMode
+        .startAddr = 0x8000,
+        .size = 0x2000,
     },
     {
         .name = "ROMX"s,
-        .startAddr = 0x4000,
-        .size = 0x4000,
         .firstBank = 1,
         .lastBank = 65535,
+        .startAddr = 0x4000,
+        .size = 0x4000,
     },
     {
         .name = "ROM0"s,
-        .startAddr = 0x0000,
-        .size = 0x8000, // Patched to 0x4000 if !is32kMode
         .firstBank = 0,
         .lastBank = 0,
+        .startAddr = 0x0000,
+        .size = 0x8000, // Patched to 0x4000 if !is32kMode
     },
     {
         .name = "HRAM"s,
-        .startAddr = 0xFF80,
-        .size = 0x007F,
         .firstBank = 0,
         .lastBank = 0,
+        .startAddr = 0xFF80,
+        .size = 0x007F,
     },
     {
         .name = "WRAMX"s,
-        .startAddr = 0xD000,
-        .size = 0x1000,
         .firstBank = 1,
         .lastBank = 7,
+        .startAddr = 0xD000,
+        .size = 0x1000,
     },
     {
         .name = "SRAM"s,
-        .startAddr = 0xA000,
-        .size = 0x2000,
         .firstBank = 0,
         .lastBank = 255,
+        .startAddr = 0xA000,
+        .size = 0x2000,
     },
     {
         .name = "OAM"s,
-        .startAddr = 0xFE00,
-        .size = 0x00A0,
         .firstBank = 0,
         .lastBank = 0,
+        .startAddr = 0xFE00,
+        .size = 0x00A0,
     },
 };
 // clang-format on

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -5,6 +5,7 @@
 
 #include "style.hpp"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h> // getenv
 #include <string.h>
@@ -18,7 +19,7 @@
 // clang-format on
 #endif
 
-enum Tribool { TRI_NO, TRI_YES, TRI_MAYBE };
+enum Tribool : uint8_t { TRI_NO, TRI_YES, TRI_MAYBE };
 
 #if !STYLE_ANSI
 static HANDLE const outHandle = GetStdHandle(STD_OUTPUT_HANDLE);


### PR DESCRIPTION
These were detected with GCC's `-Wpadded`. I didn't bother reorganizing every struct, e.g. not the `Options` ones.

- Maximum resident set size (when building pokecrystal's main.asm) went down from 31.7 MB to 30.3 MB (−4%)
- Maximum resident set size (when building polishedcrystal's main.asm) went down from 54.2 MB to 51.1 MB (−6%)
- Time to build pokecrystal stayed at 4.93 s
