### PR TITLE
Tell Dependabot to ignore minor and patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,9 @@ updates:
     groups:
       actions:
         patterns: [ "*" ]
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels: [ builds ] # Since those are CI-related updates...


### PR DESCRIPTION
We specify major-only versions, e.g. `actions/checkout@v7`, which automatically uses the latest minor+patch of that release.

Fixes #2000