### PR TITLE
Use `CONFIGURE_DEPENDS` with `GLOB` to re-compute when `external/*.cfg` files change

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,7 @@ add_test(NAME fetch-nonfree-deps
 set_tests_properties(fetch-nonfree-deps PROPERTIES FIXTURES_SETUP "nonfree-repos"
                                                    LABELS "external;nonfree")
 
-file(GLOB ext_projects "external/*.cfg") # This will not be re-computed if a new project is added! You must manually reconfigure.
+file(GLOB ext_projects CONFIGURE_DEPENDS "external/*.cfg")
 foreach(cfg_file IN LISTS ext_projects)
   cmake_path(GET cfg_file STEM LAST_ONLY project) # Extract the project's name from the config file's name.
 


### PR DESCRIPTION
From https://cmake.org/cmake/help/latest/command/file.html#filesystem:

> *Added in version 3.12:* If the `CONFIGURE_DEPENDS` flag is specified, CMake will add logic to the main build system check target to rerun the flagged `GLOB` commands at build time. If any of the outputs change, CMake will regenerate the build system.
> 
> **Note:** We do not recommend using `GLOB` to collect a list of source files from your source tree. If no CMakeLists.txt file changes when a source is added or removed then the generated build system cannot know when to ask CMake to regenerate. The `CONFIGURE_DEPENDS` flag may not work reliably on all generators, or if a new generator is added in the future that cannot support it, projects using it will be stuck. Even if `CONFIGURE_DEPENDS` works reliably, there is still a cost to perform the check on every rebuild.

We require minimum CMake 3.24, so I expect this would be reliable. As far as I can tell it's a note against using `GLOB` here in the first place, but since we're already doing that and it works fine for the platforms and generators we need, `CONFIGURE_DEPENDS` might be fine too.