### PR TITLE
Disallow minus sign before symbol name in bracketed macro arguments

### DIFF
--- a/src/asm/lexer.cpp
+++ b/src/asm/lexer.cpp
@@ -535,13 +535,16 @@ static uint32_t readBracketedMacroArgNum() {
 	int c = peek();
 	bool empty = false;
 	bool symbolError = false;
-	bool negative = c == '-';
 
-	if (negative) {
-		c = nextChar();
-	}
-
-	if (isDigit<10>(c)) {
+	if (c == '-' || isDigit<10>(c)) {
+		bool negative = c == '-';
+		if (negative) {
+			c = nextChar();
+			if (!isDigit<10>(c)) {
+				error("No digit after minus sign in bracketed macro argument");
+				return 0;
+			}
+		}
 		uint32_t n = readNumber<10>(bumpChar(), nullptr);
 		if (n > INT32_MAX) {
 			error("Number in bracketed macro argument is too large");

--- a/test/asm/macro-arg-negative-symbol.asm
+++ b/test/asm/macro-arg-negative-symbol.asm
@@ -1,0 +1,5 @@
+MACRO test
+	println \<2>, " vs ", \<-2>
+	println \<_NARG>, " vs ", \<-_NARG>
+ENDM
+	test "hello", "goodbye"

--- a/test/asm/macro-arg-negative-symbol.err
+++ b/test/asm/macro-arg-negative-symbol.err
@@ -1,0 +1,5 @@
+error: No digit after minus sign in bracketed macro argument
+    at macro-arg-negative-symbol.asm::test(3) <- macro-arg-negative-symbol.asm(5)
+error: syntax error, unexpected end of line
+    at macro-arg-negative-symbol.asm::test(3) <- macro-arg-negative-symbol.asm(5)
+Assembly aborted with 2 errors

--- a/test/asm/macro-arg-negative-symbol.out
+++ b/test/asm/macro-arg-negative-symbol.out
@@ -1,0 +1,2 @@
+goodbye vs hello
+goodbye vs 


### PR DESCRIPTION
This was being silently allowed but without actually negating the symbol's value