### PR TITLE
Fix condition for invalid bank range check

### DIFF
--- a/src/link/section.cpp
+++ b/src/link/section.cpp
@@ -204,12 +204,14 @@ static void doSanityChecks(Section &section) {
 		return;
 	}
 
+	bool bankModeError = false;
 	if (options.is32kMode && section.type == SECTTYPE_ROMX) {
 		if (section.isBankFixed && section.bank != 1) {
 			error(
 			    "Section \"%s\" has type `ROMX`, which must be in bank 1 (if any) with option '-t'",
 			    section.name.c_str()
 			);
+			bankModeError = true;
 		} else {
 			section.type = SECTTYPE_ROM0;
 		}
@@ -221,15 +223,18 @@ static void doSanityChecks(Section &section) {
 			    "'-d'",
 			    section.name.c_str()
 			);
+			bankModeError = true;
 		} else {
 			section.type = SECTTYPE_WRAM0;
 		}
 	}
-	if (options.isDmgMode && section.type == SECTTYPE_VRAM && section.bank == 1) {
+	if (options.isDmgMode && section.type == SECTTYPE_VRAM && section.isBankFixed
+	    && section.bank != 0) {
 		error(
 		    "Section \"%s\" has type `VRAM`, which must be in bank 0 with option '-d'",
 		    section.name.c_str()
 		);
+		bankModeError = true;
 	}
 
 	// Check if alignment is reasonable, this is important to avoid UB
@@ -251,7 +256,8 @@ static void doSanityChecks(Section &section) {
 	uint32_t minbank = sectionTypeInfo[section.type].firstBank,
 	         maxbank = sectionTypeInfo[section.type].lastBank;
 
-	if (section.isBankFixed && section.bank < minbank && section.bank > maxbank) {
+	if (!bankModeError && section.isBankFixed
+	    && (section.bank < minbank || section.bank > maxbank)) {
 		error(
 		    minbank == maxbank
 		        ? "Cannot place section \"%s\" in bank %" PRIu32 ", it must be %" PRIu32


### PR DESCRIPTION
We were checking `section.bank < minbank && section.bank > maxbank`, which of course should be `&&` not `||`.

I added the `bankModeError` boolean because triggering this message would be redundant with our pre-existing ones for DMG/32K modes. (See `test/link/invalid-ram-types` and `test/link/vram-fixed-dmg-mode`.)

I didn't add a new test case because I don't think this can actually be triggered with a valid object file. RGBASM will error out itself if you do e.g. `VRAM, BANK[3]` or `WRAMX, BANK[9]`. We would have to craft an object file just to test this failsafe of RGBLINK -- and although that *is* probably a good idea, there are many such failsafes worth testing, and it falls under #1927.