### PR TITLE
Run external tests for FreeBSD

### DIFF
--- a/.github/scripts/freebsd-env.sh
+++ b/.github/scripts/freebsd-env.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+local_bin_dir="$PWD/.local/bin"
+
+mkdir -p "$local_bin_dir"
+
+# Alias `make` to `gmake` and `python` to `python3` for use by external tests.
+ln -s "$(which gmake)" "$local_bin_dir/make"
+ln -s "$(which python3)" "$local_bin_dir/python"
+
+export PATH="$local_bin_dir:$PATH"

--- a/.github/scripts/install-deps.sh
+++ b/.github/scripts/install-deps.sh
@@ -58,7 +58,8 @@ case "${OS%%-*}" in
 		printf 'PATH=%s\n' "$PATH" >>"$GITHUB_ENV" # Make it available to later CI steps too.
 		;;
 	freebsd)
-		pkg install -y bash bison cmake git png
+		# GNU `gmake` and `gcc` are dependencies for most repos built by our external tests.
+		pkg install -y bash bison cmake git png gmake lang/gcc python3 py312-pillow
 		;;
 	windows)
 		# GitHub Actions' hosted runners ship CMake 3.x, but versions prior to 4.0.0 ignore `CPACK_PACKAGE_FILE_NAME`.

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -395,12 +395,14 @@ jobs:
             GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
           release: "15.1"
           usesh: true
+          copyback: false
           prepare: |
             .github/scripts/install-deps.sh freebsd
           run: | # Leak detection is not supported on FreeBSD, so disable it.
             cmake -B build --preset develop
             cmake --build build --verbose -- -k -j "$(getconf _NPROCESSORS_ONLN)"
-            ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build --schedule-random --label-exclude external
+            . .github/scripts/freebsd-env.sh
+            ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build --schedule-random
             cmake --install build --verbose
             type rgbasm rgblink rgbfix rgbgfx
             man -w 1 rgbasm rgblink rgbfix rgbgfx


### PR DESCRIPTION
Fixes #2030

I added [`copyback: false`](https://github.com/vmactions/freebsd-vm/#2-share-code) to the `vmactions/freebsd-vm` config because otherwise the `.local/bin` symlinks break it:

```
skipping symlink with 0-length value: "/home/runner/work/rgbds/rgbds/.local/bin/python"
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1887) [generator=3.2.7]
```

Of course, we could delete the symlinks afterwards, but we don't need any files to be copied out of the FreeBSD VM into the `ubuntu-latest` container anyway; running the VM is the very last step in the `freebsd` job.
