### PR TITLE
Use Ninja as the generator for CMake on FreeBSD

### DIFF
--- a/.github/scripts/install-deps.sh
+++ b/.github/scripts/install-deps.sh
@@ -59,7 +59,7 @@ case "${OS%%-*}" in
 		;;
 	freebsd)
 		# GNU `gmake` and `gcc` are dependencies for most repos built by our external tests.
-		pkg install -y bash bison cmake git png gmake lang/gcc python3 py312-pillow
+		pkg install -y bash bison cmake ninja git png gmake lang/gcc python3 py312-pillow
 		;;
 	windows)
 		# GitHub Actions' hosted runners ship CMake 3.x, but versions prior to 4.0.0 ignore `CPACK_PACKAGE_FILE_NAME`.

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -399,8 +399,8 @@ jobs:
           prepare: |
             .github/scripts/install-deps.sh freebsd
           run: | # Leak detection is not supported on FreeBSD, so disable it.
-            cmake -B build --preset develop
-            cmake --build build --verbose -- -k -j "$(getconf _NPROCESSORS_ONLN)"
+            cmake -B build -G Ninja --preset develop
+            cmake --build build -- -k 0
             . .github/scripts/freebsd-env.sh
             ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build --schedule-random
             cmake --install build --verbose


### PR DESCRIPTION
Ninja provides synchronous output by default, and only shows full command lines when they fail, which is convenient for reading GitHub Actions logs.