### PR TITLE
Fix CI testing of installing RGBDS on Cygwin

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -339,7 +339,7 @@ jobs:
     timeout-minutes: 30
     defaults:
       run:
-        shell: C:\cygwin\bin\env.exe CYGWIN_NOWINPATH=1 CHERE_INVOKING=1 C:\cygwin\bin\bash.exe -o igncr '{0}'
+        shell: C:\cygwin\bin\env.exe CYGWIN_NOWINPATH=1 CHERE_INVOKING=1 C:\cygwin\bin\bash.exe -eo igncr '{0}'
     steps:
       - name: Save Windows git location for the PATH
         shell: pwsh
@@ -368,8 +368,8 @@ jobs:
           make -k -j "$(getconf _NPROCESSORS_ONLN)" Q=
       - name: Install using Make
         if: matrix.arch == 'x86'
-        run: |
-          make install Q=
+        run: | # `/usr/local/bin` is not in the PATH but `/usr/bin` is, so we install to `/usr`.
+          make install PREFIX=/usr Q=
           type rgbasm rgblink rgbfix rgbgfx
           man -w 1 rgbasm rgblink rgbfix rgbgfx
       - name: Build using CMake
@@ -379,8 +379,8 @@ jobs:
           cmake --build build -- -k 0
       - name: Install using CMake
         if: matrix.arch == 'x86_64'
-        run: |
-          cmake --install build --verbose
+        run: | # `/usr/local/bin` is not in the PATH but `/usr/bin` is, so we install to `/usr`.
+          cmake --install build --prefix /usr --verbose
           type rgbasm rgblink rgbfix rgbgfx
           man -w 1 rgbasm rgblink rgbfix rgbgfx
       - name: Compute test dependency cache params


### PR DESCRIPTION
We need to pass `-e` to Cygwin `bash` explicitly, since specifying it as the non-default `shell:` no longer [automatically adds `-e` behavior](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#exit-codes-and-error-action-preference) to `run` blocks.

We also need to install to `/usr/bin` (which `cygwin-install-action` [automatically adds to the `PATH`](https://github.com/cygwin/cygwin-install-action#add-to-path)), not `/usr/local/bin` (which is not in the default `PATH`). This tests our `PREFIX`/`--prefix` handling.

(I believe that instead of using `make PREFIX`/`cmake --prefix`, we could use a *login* shell -- like https://github.com/cygwin/cygwin-install-action/issues/29 does with `bin\bash.exe -leo pipefail -o igncr '{0}'` -- which would parse the Cygwin-default `.bash_profile`/`.bashrc` files and thereby add `/usr/local/bin` to the `PATH`. But I think the current solution is more reliable, and gets to test more of our supported behavior.)