### PR TITLE
Add a project-specific AI policy on top of the gbdev-wide one

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -262,6 +262,19 @@ docker build . --tag ghcr.io/gbdev/rgbds:master
 docker push ghcr.io/gbdev/rgbds:master
 ```
 
+## AI coding assistants
+
+You may find AI helpful in finding bugs, reviewing code, generating test cases,
+and so on.
+Contrary to the [gbdev-wide AI policy](https://gbdev.io/aipolicy.html), we do
+*not* discourage AI usage for contributing *to RGBDS*.
+However, you must still disclose which AI-based tool and model you used, as per
+the [gbdev-wide attribution guidelines](https://gbdev.io/aipolicy.html#attribution).
+
+RGBDS has had a good track record so far of AI assisting its contributors and
+maintainers to find and fix bugs that would otherwise be unlikely to solve.
+Your contribution is appreciated whether or not AI was used in its creation.
+
 ## Publishing a new release
 
 Please refer to [`RELEASE.md`](/RELEASE.md).


### PR DESCRIPTION
GBDev has published our [org-wide AI policy](https://gbdev.io/aipolicy.html)! There's a lot that I appreciate in it. Guidelines that "anything you submit is your responsibility" and "you must have sufficiently evaluated and properly understood the work you intend to submit" may seem obvious -- one doesn't abdicate responsibility or care when using tools like clang-format or ASan, and LLM-based AI is no different -- but in practice that does need clarifying. And the attribution guidelines on how to use `Assisted-by` tags are also helpful.

There's just one change I'd like to make for RGBDS: remove the statement that "LLM-assisted contributions are discouraged". In practice, this has no actual policy effect on what contributors or maintainers are supposed to do; I read it as just staking out the community's emotional position. However, I don't actually want potential RGBDS contributors to feel emotionally discouraged from sharing their work if AI was involved. I want to make it clear that if AI can assist people to do work they otherwise couldn't, then that still helps RGBDS and is appreciated.

We've had a good track record so far, as people have used AI tools to fix bugs (#1912, #1883), find edge-case bugs that I had been overlooking (#2015, 08e83601f5c14981a7f0cea32b682bb4aff79f4e, be4c1161bda39fbd564ad0b2a1eb9673c8b5451c), improve files that hadn't gotten much attention beforehand (#1897), or review our own human-written work for mistakes (#1809). This is not unusual or remarkable; AI has been increasingly helpful and common in professional software development in the past year or two, and RGBDS is a software project.

Of course, not every gbdev project has the same nature. Pan Docs and the GB asm tutorial are primarily written works, and AI *prose* is still awkward-sounding and more prone to mistakes (there's no `./run-tests.sh` for verifying whether claims in English are accurate). And unlike RGBDS, they've had some fully AI-generated PRs, with mistakes that clearly no human cared to review, that didn't even get any follow-up comments or edits from the human behind the AI tool, apparently made automatically in response to a monetary "bounty" on some problem to solve. Obviously RGBDS is not encouraging *that*. (And if a human wrote some untested messy PR all on their own, just because there were some incentive to getting it merged, we would not appreciate that either.)

It's my hope that we continue to get useful PRs from sincere contributors, no matter what tools they're using.