### PR TITLE
Specify `COLUMNS` in test scripts for consistent output

### DIFF
--- a/test/asm/test.sh
+++ b/test/asm/test.sh
@@ -2,6 +2,10 @@
 
 export LC_ALL=C
 
+# Screen width for help/usage text (for reproducible test results)
+export COLUMNS=79
+shopt -u checkwinsize # Prevent subsequent commands from resetting `COLUMNS`
+
 # Game Boy release date, 1989-04-21T12:34:56Z (for reproducible test results)
 export SOURCE_DATE_EPOCH=609165296
 

--- a/test/fix/test.sh
+++ b/test/fix/test.sh
@@ -2,6 +2,10 @@
 
 export LC_ALL=C
 
+# Screen width for help/usage text (for reproducible test results)
+export COLUMNS=79
+shopt -u checkwinsize # Prevent subsequent commands from resetting `COLUMNS`
+
 tmpdir="$(mktemp -d)"
 # shellcheck disable=SC2064 # (Immediate expansion is the desired behavior.)
 trap "cd; rm -rf ${tmpdir@Q}" EXIT

--- a/test/gfx/test.sh
+++ b/test/gfx/test.sh
@@ -3,6 +3,12 @@
 [[ -e ./rgbgfx_test ]] || make -C ../.. test/gfx/rgbgfx_test Q= ${CXX:+"CXX=$CXX"} || exit
 [[ -e ./randtilegen ]] || make -C ../.. test/gfx/randtilegen Q= ${CXX:+"CXX=$CXX"} || exit
 
+export LC_ALL=C
+
+# Screen width for help/usage text (for reproducible test results)
+export COLUMNS=79
+shopt -u checkwinsize # Prevent subsequent commands from resetting `COLUMNS`
+
 errtmp="$(mktemp)"
 
 # shellcheck disable=SC2064 # (Immediate expansion is the desired behavior.)

--- a/test/link/test.sh
+++ b/test/link/test.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
-export LC_ALL=C
 set -o pipefail
+
+export LC_ALL=C
+
+# Screen width for help/usage text (for reproducible test results)
+export COLUMNS=79
+shopt -u checkwinsize # Prevent subsequent commands from resetting `COLUMNS`
 
 otemp="$(mktemp)"
 gbtemp="$(mktemp)"


### PR DESCRIPTION
Fixes #2041